### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -201,3 +201,6 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License. 
 csharp_style_namespace_declarations = file_scoped:silent
+
+# https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelinesPreview
+guidelines = 120

--- a/src/DurableTask/Converters/JsonDataConverter.cs
+++ b/src/DurableTask/Converters/JsonDataConverter.cs
@@ -7,9 +7,9 @@ using System.Text.Json;
 namespace Microsoft.DurableTask.Converters;
 
 /// <summary>
-/// An implementation of <see cref="IDataConverter"/> that uses System.Text.Json APIs for data serialization.
+/// An implementation of <see cref="DataConverter"/> that uses System.Text.Json APIs for data serialization.
 /// </summary>
-public class JsonDataConverter : IDataConverter
+public class JsonDataConverter : DataConverter
 {
     // WARNING: Changing default serialization options could potentially be breaking for in-flight orchestrations.
     static readonly JsonSerializerOptions DefaultOptions = new()
@@ -36,12 +36,12 @@ public class JsonDataConverter : IDataConverter
         }
     }
 
-    public virtual string? Serialize(object? value)
+    public override string? Serialize(object? value)
     {
         return value != null ? JsonSerializer.Serialize(value, this.options) : null;
     }
 
-    public virtual object? Deserialize(string? data, Type targetType)
+    public override object? Deserialize(string? data, Type targetType)
     {
         return data != null ? JsonSerializer.Deserialize(data, targetType, this.options) : null;
     }

--- a/src/DurableTask/DataConverter.cs
+++ b/src/DurableTask/DataConverter.cs
@@ -7,15 +7,15 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.DurableTask;
 
 /// <summary>
-/// Interface for serializing and deserializing data that gets passed to and from orchestrators and activities.
+/// Abstraction for serializing and deserializing data that gets passed to and from orchestrators and activities.
 /// </summary>
 /// <remarks>
-/// Implementations of this interface are free to use any serialization method. The default implementation
+/// Implementations of this abstract class are free to use any serialization method. The default implementation
 /// uses the JSON serializer from the System.Text.Json namespace. Currently only strings are supported as
-/// the serialized representation of data. Byte array payloads and streams are not supported by this interface.
+/// the serialized representation of data. Byte array payloads and streams are not supported by this abstraction.
 /// Note that these methods all accept null values, in which case the return value should also be null.
 /// </remarks>
-public interface IDataConverter
+public abstract class DataConverter
 {
     /// <summary>
     /// Serializes <paramref name="value"/> into a text string.
@@ -25,7 +25,7 @@ public interface IDataConverter
     /// Returns a serialized <c>string</c> representation of <paramref name="value"/> or <c>null</c> if the input is null.
     /// </returns>
     [return: NotNullIfNotNull("value")]
-    string? Serialize(object? value);
+    public abstract string? Serialize(object? value);
 
     /// <summary>
     /// Deserializes <paramref name="data"/> into an object of type <paramref name="targetType"/>.
@@ -35,7 +35,7 @@ public interface IDataConverter
     /// Returns a deserialized object or <c>null</c> if the input is null.
     /// </returns>
     [return: NotNullIfNotNull("data")]
-    object? Deserialize(string? data, Type targetType);
+    public abstract object? Deserialize(string? data, Type targetType);
 
     /// <summary>
     /// Deserializes <paramref name="data"/> into an object of type <typeparamref name="T"/>.
@@ -45,5 +45,5 @@ public interface IDataConverter
     /// Returns a deserialized object or <c>null</c> if the input is null.
     /// </returns>
     [return: NotNullIfNotNull("data")]
-    T? Deserialize<T>(string? data) => (T?)(this.Deserialize(data, typeof(T)) ?? default);
+    public virtual T? Deserialize<T>(string? data) => (T?)(this.Deserialize(data, typeof(T)) ?? default);
 }

--- a/src/DurableTask/DurableTaskAttribute.cs
+++ b/src/DurableTask/DurableTaskAttribute.cs
@@ -10,9 +10,8 @@ namespace Microsoft.DurableTask;
 /// </summary>
 /// <remarks>
 /// This attribute is meant to be used on class definitions that derive from
-/// <see cref="TaskOrchestratorBase{TInput, TOutput}"/> or
-/// <see cref="TaskActivityBase{TInput, TOutput}"/>. It is used specifically
-/// by build-time source generators to generate type-safe methods for invoking
+/// <see cref="TaskOrchestratorBase{TInput, TOutput}"/> or <see cref="TaskActivityBase{TInput, TOutput}"/>.
+/// It is used specifically by build-time source generators to generate type-safe methods for invoking
 /// orchestratos or activities.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]

--- a/src/DurableTask/Grpc/DurableTaskGrpcClient.cs
+++ b/src/DurableTask/Grpc/DurableTaskGrpcClient.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DurableTask.Grpc;
 public class DurableTaskGrpcClient : DurableTaskClient
 {
     readonly IServiceProvider services;
-    readonly IDataConverter dataConverter;
+    readonly DataConverter dataConverter;
     readonly ILogger logger;
     readonly IConfiguration? configuration;
     readonly GrpcChannel sidecarGrpcChannel;
@@ -32,7 +32,7 @@ public class DurableTaskGrpcClient : DurableTaskClient
     DurableTaskGrpcClient(Builder builder)
     {
         this.services = builder.services ?? SdkUtils.EmptyServiceProvider;
-        this.dataConverter = builder.dataConverter ?? this.services.GetService<IDataConverter>() ?? SdkUtils.DefaultDataConverter;
+        this.dataConverter = builder.dataConverter ?? this.services.GetService<DataConverter>() ?? SdkUtils.DefaultDataConverter;
         this.logger = SdkUtils.GetLogger(builder.loggerFactory ?? this.services.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance);
         this.configuration = builder.configuration ?? this.services.GetService<IConfiguration>();
 
@@ -237,7 +237,7 @@ public class DurableTaskGrpcClient : DurableTaskClient
     {
         internal IServiceProvider? services;
         internal ILoggerFactory? loggerFactory;
-        internal IDataConverter? dataConverter;
+        internal DataConverter? dataConverter;
         internal IConfiguration? configuration;
         internal GrpcChannel? channel;
         internal string? address;
@@ -277,7 +277,7 @@ public class DurableTaskGrpcClient : DurableTaskClient
             return this;
         }
 
-        public Builder UseDataConverter(IDataConverter dataConverter)
+        public Builder UseDataConverter(DataConverter dataConverter)
         {
             this.dataConverter = dataConverter ?? throw new ArgumentNullException(nameof(dataConverter));
             return this;

--- a/src/DurableTask/Grpc/DurableTaskGrpcWorker.cs
+++ b/src/DurableTask/Grpc/DurableTaskGrpcWorker.cs
@@ -31,7 +31,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
     static readonly Google.Protobuf.WellKnownTypes.Empty EmptyMessage = new();
 
     readonly IServiceProvider services;
-    readonly IDataConverter dataConverter;
+    readonly DataConverter dataConverter;
     readonly ILogger logger;
     readonly IConfiguration? configuration;
     readonly GrpcChannel sidecarGrpcChannel;
@@ -48,7 +48,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
     DurableTaskGrpcWorker(Builder builder)
     {
         this.services = builder.services ?? SdkUtils.EmptyServiceProvider;
-        this.dataConverter = builder.dataConverter ?? this.services.GetService<IDataConverter>() ?? SdkUtils.DefaultDataConverter;
+        this.dataConverter = builder.dataConverter ?? this.services.GetService<DataConverter>() ?? SdkUtils.DefaultDataConverter;
         this.logger = SdkUtils.GetLogger(builder.loggerFactory ?? this.services.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance);
         this.configuration = builder.configuration ?? this.services.GetService<IConfiguration>();
 
@@ -147,7 +147,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
         // Cancelling the shutdownTcs causes the background processing to shutdown gracefully.
         this.shutdownTcs?.Cancel();
 
-        // Wait for the listen loop to copmlete
+        // Wait for the listen loop to complete
         await (this.listenLoop?.WaitAsync(cancellationToken) ?? Task.CompletedTask);
 
         // TODO: Wait for any outstanding tasks to complete
@@ -468,7 +468,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
     {
         internal DefaultTaskBuilder taskProvider = new();
         internal ILoggerFactory? loggerFactory;
-        internal IDataConverter? dataConverter;
+        internal DataConverter? dataConverter;
         internal IServiceProvider? services;
         internal IConfiguration? configuration;
         internal string? address;
@@ -509,7 +509,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
             return this;
         }
 
-        public Builder UseDataConverter(IDataConverter dataConverter)
+        public Builder UseDataConverter(DataConverter dataConverter)
         {
             this.dataConverter = dataConverter ?? throw new ArgumentNullException(nameof(dataConverter));
             return this;

--- a/src/DurableTask/Microsoft.DurableTask.csproj
+++ b/src/DurableTask/Microsoft.DurableTask.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>embedded</DebugType>
@@ -32,13 +32,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.38.0" />
+    <PackageReference Include="Grpc.Core" Version="2.38.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask/OrchestrationMetadata.cs
+++ b/src/DurableTask/OrchestrationMetadata.cs
@@ -13,12 +13,12 @@ namespace Microsoft.DurableTask;
 /// </summary>
 public sealed class OrchestrationMetadata
 {
-    readonly IDataConverter dataConverter;
+    readonly DataConverter dataConverter;
     readonly bool requestedInputsAndOutputs;
 
     internal OrchestrationMetadata(
         P.GetInstanceResponse response,
-        IDataConverter dataConverter,
+        DataConverter dataConverter,
         bool requestedInputsAndOutputs)
     {
         this.Name = response.OrchestrationState.Name;
@@ -168,7 +168,7 @@ public sealed class OrchestrationMetadata
         const int MaxLength = 50;
         if (payload.Length > MaxLength)
         {
-            return string.Concat(payload.AsSpan(0, MaxLength), "...");
+            return string.Concat(payload[..MaxLength], "...");
         }
 
         return payload;

--- a/src/DurableTask/OrchestrationRunner.cs
+++ b/src/DurableTask/OrchestrationRunner.cs
@@ -72,7 +72,7 @@ public static class OrchestrationRunner
         List<HistoryEvent> pastEvents = request.PastEvents.Select(ProtoUtils.ConvertHistoryEvent).ToList();
         IEnumerable<HistoryEvent> newEvents = request.NewEvents.Select(ProtoUtils.ConvertHistoryEvent);
 
-        IDataConverter dataConverter = services?.GetService<IDataConverter>() ?? SdkUtils.DefaultDataConverter;
+        DataConverter dataConverter = services?.GetService<DataConverter>() ?? SdkUtils.DefaultDataConverter;
         ILoggerFactory loggerFactory = services?.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
         ILogger logger = SdkUtils.GetLogger(loggerFactory);
 

--- a/src/DurableTask/TaskActivityShim.cs
+++ b/src/DurableTask/TaskActivityShim.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DurableTask;
 class TaskActivityShim<TInput, TOutput> : TaskActivityShim
 {
     public TaskActivityShim(
-        IDataConverter dataConverter,
+        DataConverter dataConverter,
         TaskName name,
         Func<TaskActivityContext, TInput?, Task<TOutput?>> implementation)
         : base(dataConverter, name, new LambdaActivity(implementation))
@@ -36,11 +36,11 @@ class TaskActivityShim<TInput, TOutput> : TaskActivityShim
 class TaskActivityShim : TaskActivity
 {
     readonly ITaskActivity implementation;
-    readonly IDataConverter dataConverter;
+    readonly DataConverter dataConverter;
     readonly TaskName name;
 
     public TaskActivityShim(
-        IDataConverter dataConverter,
+        DataConverter dataConverter,
         TaskName name,
         ITaskActivity implementation)
     {

--- a/src/DurableTask/WorkerContext.cs
+++ b/src/DurableTask/WorkerContext.cs
@@ -7,6 +7,6 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.DurableTask;
 
 record WorkerContext(
-    IDataConverter DataConverter,
+    DataConverter DataConverter,
     ILogger Logger,
     IServiceProvider Services);

--- a/src/DurableTask/_CSharpLangCompat.cs
+++ b/src/DurableTask/_CSharpLangCompat.cs
@@ -1,0 +1,309 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#if NETSTANDARD2_0
+
+// This file defines several classes and methods that exist in .NET Core but not in .NET Standard 2.0.
+// They are defined here to enable certain C# features that otherwise require higher framework versions.
+// Redefining types in this way is a standard practice for libary authors that are forced to target .NET Standard 2.0.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+// These extension methods are defined in the global namespace so that they're available everywhere.
+static class KeyValuePairExtensions
+{
+    // Based on https://source.dot.net/#System.Private.CoreLib/KeyValuePair.cs,aa57b8e336bf7f59
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+    {
+        key = pair.Key;
+        value = pair.Value;
+    }
+}
+
+static class StringExtensions
+{
+    public static bool StartsWith(this string s, char value)
+    {
+        return s.Length > 0 && s[0] == value;
+    }
+
+    public static bool EndsWith(this string s, char value)
+    {
+        return s.Length > 0 && s[s.Length - 1] == value;
+    }
+}
+
+static class TaskExtensions
+{
+    public static Task WaitAsync(this Task task, CancellationToken cancellationToken)
+    {
+        // NOTE: This is NOT the same implementation as what's done in .NET 6. This
+        //       implementation was chosen to avoid copying tons of code for something
+        //       that's fairly trivial to implement manually (but not as efficiently).
+        return Task.WhenAny(task, Task.Delay(Timeout.Infinite, cancellationToken));
+    }
+}
+
+// The types below exist in specific namespaces as required by the C# compiler.
+namespace System
+{
+    /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+    /// <remarks>
+    /// Index is used by the C# compiler to support the new index syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+    /// int lastElement = someArray[^1]; // lastElement = 5
+    /// </code>
+    /// </remarks>
+    readonly struct Index : IEquatable<Index>
+    {
+        readonly int value;
+
+        /// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+        /// <param name="value">The index value. it has to be zero or positive number.</param>
+        /// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+        /// <remarks>
+        /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            this.value = fromEnd ? ~value : value;
+        }
+
+        // The following private constructors mainly created for perf reason to avoid the checks
+        Index(int value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>Create an Index pointing at first element.</summary>
+        public static Index Start => new Index(0);
+
+        /// <summary>Create an Index pointing at beyond last element.</summary>
+        public static Index End => new Index(~0);
+
+        /// <summary>Create an Index from the start at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the start.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromStart(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(value);
+        }
+
+        /// <summary>Create an Index from the end at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the end.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromEnd(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(~value);
+        }
+
+        /// <summary>Returns the index value.</summary>
+        public int Value
+        {
+            get
+            {
+                if (this.value < 0)
+                {
+                    return ~this.value;
+                }
+                else
+                {
+                    return this.value;
+                }
+            }
+        }
+
+        /// <summary>Indicates whether the index is from the start or the end.</summary>
+        public bool IsFromEnd => this.value < 0;
+
+        /// <summary>Calculate the offset from the start using the giving collection length.</summary>
+        /// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value.</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+        /// we don't validate either the returned offset is greater than the input length.
+        /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+        /// then used to index a collection will get out of range exception which will be same affect as the validation.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetOffset(int length)
+        {
+            int offset = this.value;
+            if (this.IsFromEnd)
+            {
+                // offset = length - (~value)
+                // offset = length + (~(~value) + 1)
+                // offset = length + value + 1
+
+                offset += length + 1;
+            }
+
+            return offset;
+        }
+
+        /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object.</param>
+        public override bool Equals(object? value) => value is Index && this.value == ((Index)value).value;
+
+        /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(Index other) => this.value == other.value;
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode() => this.value;
+
+        /// <summary>Converts integer number to an Index.</summary>
+        public static implicit operator Index(int value) => FromStart(value);
+
+        /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return this.IsFromEnd ? "^" + ((uint)this.Value).ToString() : ((uint)this.Value).ToString();
+        }
+    }
+
+    /// <summary>Represent a range has start and end indexes.</summary>
+    /// <remarks>
+    /// Range is used by the C# compiler to support the range syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 };
+    /// int[] subArray1 = someArray[0..2]; // { 1, 2 }
+    /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
+    /// </code>
+    /// </remarks>
+    readonly struct Range : IEquatable<Range>
+    {
+        /// <summary>Represent the inclusive start index of the Range.</summary>
+        public Index Start { get; }
+
+        /// <summary>Represent the exclusive end index of the Range.</summary>
+        public Index End { get; }
+
+        /// <summary>Construct a Range object using the start and end indexes.</summary>
+        /// <param name="start">Represent the inclusive start index of the range.</param>
+        /// <param name="end">Represent the exclusive end index of the range.</param>
+        public Range(Index start, Index end)
+        {
+            this.Start = start;
+            this.End = end;
+        }
+
+        /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object.</param>
+        public override bool Equals(object? value) =>
+            value is Range r &&
+            r.Start.Equals(this.Start) &&
+            r.End.Equals(this.End);
+
+        /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(Range other) => other.Start.Equals(this.Start) && other.End.Equals(this.End);
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return (this.Start.GetHashCode() * 31) + this.End.GetHashCode();
+        }
+
+        /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return this.Start + ".." + this.End;
+        }
+
+        /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
+        public static Range StartAt(Index start) => new(start, Index.End);
+
+        /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
+        public static Range EndAt(Index end) => new(Index.Start, end);
+
+        /// <summary>Create a Range object starting from first element to the end.</summary>
+        public static Range All => new(Index.Start, Index.End);
+
+        /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
+        /// <param name="length">The length of the collection that the range will be used with. length has to be a positive value.</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter against negative values.
+        /// It is expected Range will be used with collections which always have non negative length/count.
+        /// We validate the range is inside the length scope though.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int Offset, int Length) GetOffsetAndLength(int length)
+        {
+            int start;
+            var startIndex = this.Start;
+            start = startIndex.IsFromEnd ? length - startIndex.Value : startIndex.Value;
+
+            int end;
+            Index endIndex = this.End;
+            end = endIndex.IsFromEnd ? length - endIndex.Value : endIndex.Value;
+
+            if ((uint)end > (uint)length || (uint)start > (uint)end)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            return (start, end - start);
+        }
+    }
+}
+
+// Copied from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L69
+namespace System.Diagnostics.CodeAnalysis
+{
+    sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => this.ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => this.ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// This dummy class is required to compile records when targeting .NET Standard
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    static class IsExternalInit { }
+}
+#endif


### PR DESCRIPTION
In order to support .NET Framework in the future, change this library to target .NET Standard 2.0 instead of .NET 6. One of the important changes required to get this working was to switch from using the "officially" supported gRPC client libraries to the "unofficial" libraries. In spite of my efforts, I couldn't get the "official" libraries to work on .NET Framework, likely because TLS is required, as mentioned here: https://docs.microsoft.com/en-us/aspnet/core/grpc/netstandard?view=aspnetcore-6.0#net-framework (and we don't want to require TLS since all our scenarios are currently localhost).

To avoid making too many code changes, various extension methods and replacement classes were added to a _CSharpLangCompat.cs file.

This PR also contains some pending API documentation updates.