### PR TITLE
Break long timers into smaller timers

### DIFF
--- a/src/DurableTask/Grpc/DurableTaskGrpcWorker.cs
+++ b/src/DurableTask/Grpc/DurableTaskGrpcWorker.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.History;
 using Grpc.Core;
+using Microsoft.DurableTask.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -54,7 +55,8 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
         this.workerContext = new WorkerContext(
             this.dataConverter,
             this.logger,
-            this.services);
+            this.services,
+            builder.timerOptions ?? TimerOptions.Default);
 
         this.orchestrators = builder.taskProvider.orchestratorsBuilder.ToImmutable();
         this.activities = builder.taskProvider.activitiesBuilder.ToImmutable();
@@ -472,6 +474,7 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
         internal DataConverter? dataConverter;
         internal IServiceProvider? services;
         internal IConfiguration? configuration;
+        internal TimerOptions? timerOptions;
         internal string? hostname;
         internal int? port;
         internal Channel? channel;
@@ -527,6 +530,12 @@ public class DurableTaskGrpcWorker : IHostedService, IAsyncDisposable
         public Builder UseConfiguration(IConfiguration configuration)
         {
             this.configuration = configuration;
+            return this;
+        }
+
+        public Builder UseTimerOptions(TimerOptions timerOptions)
+        {
+            this.timerOptions = timerOptions;
             return this;
         }
 

--- a/src/DurableTask/Options/TimerOptions.cs
+++ b/src/DurableTask/Options/TimerOptions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.DurableTask.Options;
+
+/// <summary>
+/// Configuration options that impact the behavior of Durable timers.
+/// </summary>
+public class TimerOptions
+{
+    internal static TimerOptions Default { get; set; } = new();
+
+    /// <summary>
+    /// Sets the maximum timer interval for the <see cref="TaskOrchestrationContext.CreateTimer"/> method.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default maximum timer interval is 3 days. If a <see cref="TaskOrchestrationContext.CreateTimer"/> call 
+    /// specifies a 7-day timer, it will be implemented using three separate timers: two for 3 days and one for 1 day.
+    /// </para><para>
+    /// Long timers are broken up into smaller timers to support certain types of backend storage providers which have 
+    /// limits on how long a durable timer entity can be created. For example, the Azure Storage state provider uses
+    /// scheduled queue messages to implement durable timers, but scheduled queue messages cannot exceed 7 days. In
+    /// order to support longer durable timers, a long timer is broken up into smaller timers internally. This division
+    /// into multiple timers is not visible to user code. However, it is visible in the generated orchestration history.
+    /// </para><para>
+    /// Be aware that changing this setting may be breaking for in-flight orchestrations. For example, if an existing
+    /// orchestration has created a timer that exceeds the maximum interval (e.g., a 7 day timer), and this value is 
+    /// subsequently changed to a higher value (e.g., from 3 days to 10 days) then the next reply of the existing 
+    /// orchestration will fail with a non-determinism error because the number of intermediate timers scheduled during 
+    /// the replay (e.g., one timer) will no longer match the number of timers that exist in the orchestration history 
+    /// (e.g., two timers).
+    /// </para><para>
+    /// To avoid accidentally breaking existing orchestrations, this value should only be changed for new applications
+    /// with no state or when an application is known to have no in-flight orchestration instances.
+    /// </para>
+    /// </remarks>
+    // WARNING: Changing this default value is a breaking change for in-flight orchestrations!
+    public TimeSpan MaximumTimerInterval { get; set; } = TimeSpan.FromDays(3);
+}

--- a/src/DurableTask/OrchestrationRunner.cs
+++ b/src/DurableTask/OrchestrationRunner.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using P = Microsoft.DurableTask.Protobuf;
+using Microsoft.DurableTask.Options;
 
 namespace Microsoft.DurableTask;
 
@@ -78,8 +79,13 @@ public static class OrchestrationRunner
         DataConverter dataConverter = services?.GetService<DataConverter>() ?? SdkUtils.DefaultDataConverter;
         ILoggerFactory loggerFactory = services?.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
         ILogger logger = SdkUtils.GetLogger(loggerFactory);
+        TimerOptions timerOptions = TimerOptions.Default; // TODO: Support loading timer options from configuration
 
-        WorkerContext workerContext = new(dataConverter, logger, services ?? SdkUtils.EmptyServiceProvider);
+        WorkerContext workerContext = new(
+            dataConverter,
+            logger,
+            services ?? SdkUtils.EmptyServiceProvider,
+            timerOptions);
 
         // Re-construct the orchestration state from the history.
         // New events must be added using the AddEvent method.

--- a/src/DurableTask/WorkerContext.cs
+++ b/src/DurableTask/WorkerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.DurableTask.Options;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DurableTask;
@@ -9,4 +10,5 @@ namespace Microsoft.DurableTask;
 record WorkerContext(
     DataConverter DataConverter,
     ILogger Logger,
-    IServiceProvider Services);
+    IServiceProvider Services,
+    TimerOptions TimerOptions);


### PR DESCRIPTION
This is to support long-timers when using the Azure Storage backend.