### PR TITLE
Expose ParentInstance in TaskOrchestrationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## v0.4.1-beta
 
 Initial public release
+
+## Unreleased changes
+
+### Breaking changes
+
+- Added new abstract property `TaskOrchestrationContext.ParentInstance`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ﻿# Changelog
 
-## v0.4.1-beta
-
-Initial public release
-
-## Unreleased changes
+## v0.5.0-beta
 
 ### Breaking changes
 
 - Added new abstract property `TaskOrchestrationContext.ParentInstance`.
+
+## v0.4.1-beta
+
+Initial public release

--- a/src/DurableTask/OrchestrationRunner.cs
+++ b/src/DurableTask/OrchestrationRunner.cs
@@ -109,7 +109,7 @@ public static class OrchestrationRunner
 
         TaskName orchestratorName = new(runtimeState.Name, runtimeState.Version);
 
-        TaskOrchestrationShim orchestrator = new(workerContext, orchestratorName, implementation);
+        TaskOrchestrationShim orchestrator = new(new(workerContext, runtimeState), orchestratorName, implementation);
         TaskOrchestrationExecutor executor = new(runtimeState, orchestrator, BehaviorOnContinueAsNew.Carryover);
         OrchestratorExecutionResult result = executor.Execute();
 

--- a/src/DurableTask/TaskOrchestrationContext.cs
+++ b/src/DurableTask/TaskOrchestrationContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DurableTask.Core;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DurableTask;
@@ -23,6 +24,11 @@ public abstract class TaskOrchestrationContext
     /// Gets the unique ID of the current orchestration instance.
     /// </summary>
     public abstract string InstanceId { get; }
+
+    /// <summary>
+    /// Gets the parent instance. Null if no parent orchestration.
+    /// </summary>
+    public abstract ParentInstance? Parent { get; }
 
     /// <summary>
     /// Gets the current orchestration time in UTC.

--- a/src/DurableTask/TaskOrchestrationContext.cs
+++ b/src/DurableTask/TaskOrchestrationContext.cs
@@ -26,7 +26,7 @@ public abstract class TaskOrchestrationContext
     public abstract string InstanceId { get; }
 
     /// <summary>
-    /// Gets the parent instance or <c>null</c> if no parent orchestration.
+    /// Gets the parent instance or <c>null</c> if there is no parent orchestration.
     /// </summary>
     public abstract ParentInstance? Parent { get; }
 

--- a/src/DurableTask/TaskOrchestrationContext.cs
+++ b/src/DurableTask/TaskOrchestrationContext.cs
@@ -26,7 +26,7 @@ public abstract class TaskOrchestrationContext
     public abstract string InstanceId { get; }
 
     /// <summary>
-    /// Gets the parent instance. Null if no parent orchestration.
+    /// Gets the parent instance or <c>null</c> if no parent orchestration.
     /// </summary>
     public abstract ParentInstance? Parent { get; }
 

--- a/src/DurableTask/WorkerContext.cs
+++ b/src/DurableTask/WorkerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using DurableTask.Core;
 using Microsoft.DurableTask.Options;
 using Microsoft.Extensions.Logging;
 
@@ -12,3 +13,5 @@ record WorkerContext(
     ILogger Logger,
     IServiceProvider Services,
     TimerOptions TimerOptions);
+
+record struct OrchestrationInvocationContext(WorkerContext WorkerContext, OrchestrationRuntimeState RuntimeState);


### PR DESCRIPTION
This adds `ParentInstance` property `TaskOrchestrationContext`.

**WARNING**: this is a breaking change - adding a new `abstract` property will break any projects which also try to implement this class. @cgillum - what is the process for breaking changes like this?

resolves #23