### PR TITLE
Add vscode tasks.json with build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "type": "shell",
+        "command": "dotnet",
+        "args": [
+          "build",
+          "${workspaceRoot}/Microsoft.DurableTask.sln",
+          // Ask dotnet build to generate full paths for file names.
+          "/property:GenerateFullPaths=true",
+          // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+          "/consoleloggerparameters:NoSummary"
+        ],
+        "label": "build",
+        "group": "build",
+        "presentation": {
+          "reveal": "silent"
+        },
+        "problemMatcher": "$msCompile"
+      }
+    ]
+  }


### PR DESCRIPTION
Enables Ctrl+Shift+b in vscode (or whatever your shortcut is) to start a build.