### PR TITLE
Suppress build warnings

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <!-- Common build settings -->
   <PropertyGroup>

--- a/src/DurableTask.Generators/Microsoft.DurableTask.Generators.csproj
+++ b/src/DurableTask.Generators/Microsoft.DurableTask.Generators.csproj
@@ -6,6 +6,7 @@
 
     <!-- Do not include the generator as a lib dependency -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   
     <!-- Package info -->
@@ -28,10 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask/Logs.cs
+++ b/src/DurableTask/Logs.cs
@@ -49,15 +49,21 @@ namespace Microsoft.DurableTask
         public static partial void WorkerBusy(this ILogger logger);
 
         [LoggerMessage(EventId = 40, Level = LogLevel.Information, Message = "Scheduling new {name} orchestration with instance ID '{instanceId}' and {sizeInBytes} bytes of input data.")]
+#pragma warning disable SYSLIB1015 // Argument is not referenced from the logging message
         public static partial void SchedulingOrchestration(this ILogger logger, string instanceId, string name, int sizeInBytes, DateTimeOffset startTime);
+#pragma warning restore SYSLIB1015 // Argument is not referenced from the logging message
 
         // NOTE: fetchInputsAndOutputs seems like something that could be left out of the text message and just included in the structured logs
         [LoggerMessage(EventId = 42, Level = LogLevel.Information, Message = "Waiting for instance '{instanceId}' to start.")]
+#pragma warning disable SYSLIB1015 // Argument is not referenced from the logging message
         public static partial void WaitingForInstanceStart(this ILogger logger, string instanceId, bool fetchInputsAndOutputs);
+#pragma warning restore SYSLIB1015 // Argument is not referenced from the logging message
 
         // NOTE: fetchInputsAndOutputs seems like something that could be left out of the text message and just included in the structured logs
         [LoggerMessage(EventId = 43, Level = LogLevel.Information, Message = "Waiting for instance '{instanceId}' to complete, fail, or terminate.")]
+#pragma warning disable SYSLIB1015 // Argument is not referenced from the logging message
         public static partial void WaitingForInstanceCompletion(this ILogger logger, string instanceId, bool fetchInputsAndOutputs);
+#pragma warning restore SYSLIB1015 // Argument is not referenced from the logging message
 
         [LoggerMessage(EventId = 44, Level = LogLevel.Information, Message = "Terminating instance '{instanceId}'.")]
         public static partial void TerminatingInstance(this ILogger logger, string instanceId);

--- a/test/DurableTask.Generators.Tests/Microsoft.DurableTask.Generators.Tests.csproj
+++ b/test/DurableTask.Generators.Tests/Microsoft.DurableTask.Generators.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.0-beta" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.1-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fix test project nuget package reference `0.4.0-beta` -> `0.4.1-beta`
- Suppress logger message warnings - they are intentional. We want those values as dimensions, but not in the message.
- Suppress packaging of samples
- Suppress erroneous NU5128 with generator project via `SuppressDependenciesWhenPacking`