### PR TITLE
Fix code generation for Durable Functions function-based syntax.

### DIFF
--- a/src/DurableTask.Generators/AzureFunctions/DurableFunction.cs
+++ b/src/DurableTask.Generators/AzureFunctions/DurableFunction.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
                 returnType = ((GenericNameSyntax)returnType).TypeArgumentList.Arguments[0];
             }
 
-            if (!SyntaxNodeUtility.TryGetParameter(method, kind, out TypedParameter? parameter) || parameter == null)
+            if (!SyntaxNodeUtility.TryGetParameter(model, method, kind, out TypedParameter? parameter) || parameter == null)
             {
                 return false;
             }

--- a/src/DurableTask.Generators/AzureFunctions/DurableFunction.cs
+++ b/src/DurableTask.Generators/AzureFunctions/DurableFunction.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
 {
     public enum DurableFunctionKind
     {
-        Unknonwn,
+        Unknown,
         Orchestration,
         Activity
     }
@@ -50,6 +50,14 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
             if (!SyntaxNodeUtility.TryGetReturnType(method, out TypeSyntax returnType))
             {
                 return false;
+            }
+
+            INamedTypeSymbol taskSymbol = model.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1")!;
+            INamedTypeSymbol returnSymbol = (INamedTypeSymbol)model.GetTypeInfo(returnType).Type!;
+            if (SymbolEqualityComparer.Default.Equals(returnSymbol.OriginalDefinition, taskSymbol))
+            {
+                // this is a Task<T> return value, lets pull out the generic.
+                returnType = ((GenericNameSyntax)returnType).TypeArgumentList.Arguments[0];
             }
 
             if (!SyntaxNodeUtility.TryGetParameter(method, kind, out TypedParameter? parameter) || parameter == null)

--- a/src/DurableTask.Generators/AzureFunctions/SyntaxNodeUtility.cs
+++ b/src/DurableTask.Generators/AzureFunctions/SyntaxNodeUtility.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,17 +11,23 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
     {
         public static bool TryGetFunctionName(SemanticModel model, MethodDeclarationSyntax method, out string? functionName)
         {
+            functionName = null;
             if (TryGetAttributeByName(method, "Function", out AttributeSyntax? functionNameAttribute) && functionNameAttribute != null)
             {
                 if (functionNameAttribute.ArgumentList?.Arguments.Count == 1)
                 {
                     ExpressionSyntax expression = functionNameAttribute.ArgumentList.Arguments.First().Expression;
-                    functionName = model.GetConstantValue(expression).Value?.ToString();
-                    return functionName != null;
+                    Optional<object?> constant = model.GetConstantValue(expression);
+                    if (!constant.HasValue)
+                    {
+                        return false;
+                    }
+
+                    functionName = constant.ToString();
+                    return true;
                 }
             }
 
-            functionName = null;
             return false;
         }
 
@@ -57,7 +61,7 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
                 }
             }
 
-            kind = DurableFunctionKind.Unknonwn;
+            kind = DurableFunctionKind.Unknown;
             return false;
         }
 

--- a/src/DurableTask.Generators/AzureFunctions/TypedParameter.cs
+++ b/src/DurableTask.Generators/AzureFunctions/TypedParameter.cs
@@ -8,17 +8,19 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
     public class TypedParameter
     {
         public TypeSyntax Type { get; }
+        public string ResolvedType { get; }
         public string Name { get; }
 
-        public TypedParameter(TypeSyntax type, string name)
+        public TypedParameter(TypeSyntax type, string resolvedType, string name)
         {
             this.Type = type;
+            this.ResolvedType = resolvedType;
             this.Name = name;
         }
 
         public override string ToString()
         {
-            return $"{this.Type} {this.Name}";
+            return $"{this.ResolvedType} {this.Name}";
         }
     }
 }

--- a/test/DurableTask.Generators.Tests/AzureFunctionsTests.cs
+++ b/test/DurableTask.Generators.Tests/AzureFunctionsTests.cs
@@ -42,6 +42,36 @@ public static Task<int> CallIdentityAsync(this TaskOrchestrationContext ctx, int
             isDurableFunctions: true);
     }
 
+    [Fact]
+    public async Task Activities_SimpleFunctionTrigger_TaskReturning()
+    {
+        string code = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+
+public class Calculator
+{
+    [Function(""Identity"")]
+    public Task<int> IdentityAsync([ActivityTrigger] int input) => Task.FromResult(input);
+}";
+
+        string expectedOutput = TestHelpers.WrapAndFormat(
+            GeneratedClassName,
+            methodList: @"
+public static Task<int> CallIdentityAsync(this TaskOrchestrationContext ctx, int input, TaskOptions? options = null)
+{
+    return ctx.CallActivityAsync<int>(""Identity"", input, options);
+}",
+            isDurableFunctions: true);
+
+        await TestHelpers.RunTestAsync<DurableTaskSourceGenerator>(
+            GeneratedFileName,
+            code,
+            expectedOutput,
+            isDurableFunctions: true);
+    }
+
     /// <summary>
     /// Verifies that using the class-based activity syntax generates a <see cref="TaskOrchestrationContext"/>
     /// extension method as well as an <see cref="ActivityTriggerAttribute"/> function definition.
@@ -172,7 +202,6 @@ public static Task<{outputType}> CallMyOrchestratorAsync(
             expectedOutput,
             isDurableFunctions: true);
     }
-
 
     /// <summary>
     /// Verifies that using the class-based syntax for authoring orchestrations generates 

--- a/test/DurableTask.Generators.Tests/AzureFunctionsTests.cs
+++ b/test/DurableTask.Generators.Tests/AzureFunctionsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask.Generators.Tests.Utils;
 using Xunit;
@@ -60,6 +59,41 @@ public class Calculator
             GeneratedClassName,
             methodList: @"
 public static Task<int> CallIdentityAsync(this TaskOrchestrationContext ctx, int input, TaskOptions? options = null)
+{
+    return ctx.CallActivityAsync<int>(""Identity"", input, options);
+}",
+            isDurableFunctions: true);
+
+        await TestHelpers.RunTestAsync<DurableTaskSourceGenerator>(
+            GeneratedFileName,
+            code,
+            expectedOutput,
+            isDurableFunctions: true);
+    }
+
+    [Fact]
+    public async Task Activities_SimpleFunctionTrigger_CustomType()
+    {
+        string code = @"
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+
+namespace AzureFunctionsTests
+{
+    public record Input(int Value);
+
+    public class Calculator
+    {
+        [Function(""Identity"")]
+        public int Identity([ActivityTrigger] Input input) => input.Value;
+    }
+}";
+
+        string expectedOutput = TestHelpers.WrapAndFormat(
+            GeneratedClassName,
+            methodList: @"
+public static Task<int> CallIdentityAsync(this TaskOrchestrationContext ctx, AzureFunctionsTests.Input input, TaskOptions? options = null)
 {
     return ctx.CallActivityAsync<int>(""Identity"", input, options);
 }",


### PR DESCRIPTION
This PR addresses 2 issues with function based syntax code gen for Durable Functions:

1. Functions returning `Task<T>` would get double nested as `Task<Task<T>>`
2. Functions using custom types would not resolve their fully qualified namespace, leading to compilation issues.

resolves #35 