### PR TITLE
Add global json, dirs.proj, tweak CI definitions

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -8,22 +8,39 @@ on:
     branches: [ main ]
     paths-ignore: [ '**.md' ]
 
+env:
+  solution: Microsoft.DurableTask.sln
+  config: Release
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
+
     - name: Enable App Service MyGet feed
       run: dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json --name appservice-myget 
+
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore $solution
+
     - name: Build
-      run: dotnet build --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER
+      run: dotnet build $solution --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER
+
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test $solution --configuration $config --no-build --verbosity normal
+
+    - name: Pack
+      run: dotnet pack $solution --configuration $config --no-build
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: pkg
+        path: out/pkg

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -18,7 +18,7 @@ steps:
   displayName: 'Use the .NET 6 SDK'
   inputs:
     packageType: 'sdk'
-    version: '6.0.x'
+    useGlobalJson: true
 
 # Start by restoring all the dependencies. This needs to be its own task.
 - task: DotNetCoreCLI@2

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -22,22 +22,19 @@ steps:
 
 # Start by restoring all the dependencies. This needs to be its own task.
 - task: DotNetCoreCLI@2
-  displayName: 'Restore nuget dependencies'
+  displayName: 'Restore'
   inputs:
     command: restore
     verbosityRestore: Minimal
-    projects: 'src/**/*.csproj'
+    projects: 'src/dirs.proj'
 
-# Build the entire solution. This will also build all the tests, which
-# isn't strictly necessary...
-- task: VSBuild@1
+# Build source directory
+- task: DotNetCoreCLI@2
   displayName: 'Build'
   inputs:
-    solution: 'src/**/*.csproj'
-    vsVersion: 'latest'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+    command: build
+    arguments: --no-restore -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
+    projects: 'src/dirs.proj'
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.
@@ -88,7 +85,7 @@ steps:
     configuration: Release
     nobuild: true
     packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/**/*.csproj'
+    packagesToPack: 'src/dirs.proj'
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.5.6",
+    "Microsoft.Build.NoTargets": "3.5.6"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,6 +4,7 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.5.6"
+    "Microsoft.Build.NoTargets": "3.5.6",
+    "Microsoft.Build.Traversal": "3.2.0"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "6.0.401",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.5.6",
+  }
+}

--- a/misc/misc.csproj
+++ b/misc/misc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.5.6">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
 
   <!--
     This project is a way to show miscelaneous files in VS without

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.5.6">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <!--
     This project is to never be referenced directly. Instead, the files are directly

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal">
+
+  <ItemGroup>
+    <ProjectReference Include="**/*.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Introduce `global.json` to pin the dotnet SDK versions we use (this is so there are no unforeseen issues with differences between SDK versions, and "works on my machine" as a result)
- Add `sln/dirs.proj` so we can `dotnet build` for that directory to build just source
- Tweak CI files (github and ADO) to use global.json and dirs.proj
- Addition tweaks to CI:
    - github: add pack and upload steps, so you can grab artifacts from a PR build inspect/verify them before trying the release build. Now also builds release config (to ensure it is as similar to actual release as possible).
    - ADO: replace VSBuild with dotnet build step for consistency