### PR TITLE
Enable NET analyzers

### DIFF
--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DurableTask;
 /// <summary>
 /// The name of a durable task.
 /// </summary>
-public struct TaskName : IEquatable<TaskName>
+public readonly struct TaskName : IEquatable<TaskName>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TaskName"/> struct.
@@ -85,16 +85,16 @@ public struct TaskName : IEquatable<TaskName>
     /// Gets a value indicating whether to <see cref="TaskName"/> objects
     /// are equal using value semantics.
     /// </summary>
-    /// <param name="other">The other object to compare to.</param>
+    /// <param name="obj">The other object to compare to.</param>
     /// <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
-    public override bool Equals(object? other)
+    public override bool Equals(object? obj)
     {
-        if (other is not TaskName)
+        if (obj is not TaskName)
         {
             return false;
         }
 
-        return this.Equals((TaskName)other);
+        return this.Equals((TaskName)obj);
     }
 
     /// <summary>

--- a/src/Client/Grpc/ProtoUtils.cs
+++ b/src/Client/Grpc/ProtoUtils.cs
@@ -43,7 +43,7 @@ static class ProtoUtils
             OrchestrationRuntimeStatus.Pending => P.OrchestrationStatus.Pending,
             OrchestrationRuntimeStatus.Running => P.OrchestrationStatus.Running,
             OrchestrationRuntimeStatus.Terminated => P.OrchestrationStatus.Terminated,
-            _ => throw new ArgumentOutOfRangeException("Unexpected value", nameof(status)),
+            _ => throw new ArgumentOutOfRangeException(nameof(status), "Unexpected value"),
         };
 #pragma warning restore 0618 // Referencing Obsolete member.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <RepositoryUrl>https://github.com/microsoft/durabletask-dotnet</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>recommended</AnalysisMode>
   </PropertyGroup>
 
   <!-- Common NuGet settings -->

--- a/src/Generators/AzureFunctions/SyntaxNodeUtility.cs
+++ b/src/Generators/AzureFunctions/SyntaxNodeUtility.cs
@@ -48,13 +48,13 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
 
                 foreach (var attribute in parameterAttributes)
                 {
-                    if (attribute.ToString().Equals("OrchestrationTrigger"))
+                    if (attribute.ToString().Equals("OrchestrationTrigger", StringComparison.Ordinal))
                     {
                         kind = DurableFunctionKind.Orchestration;
                         return true;
                     }
 
-                    if (attribute.ToString().Equals("ActivityTrigger"))
+                    if (attribute.ToString().Equals("ActivityTrigger", StringComparison.Ordinal))
                     {
                         kind = DurableFunctionKind.Activity;
                         return true;
@@ -159,13 +159,15 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
                 return supportsNullable ? "object?" : "object";
             }
 
-            if (supportsNullable && symbol.IsReferenceType && symbol.NullableAnnotation != NullableAnnotation.Annotated)
+            if (supportsNullable && symbol.IsReferenceType
+                && symbol.NullableAnnotation != NullableAnnotation.Annotated)
             {
                 symbol = symbol.WithNullableAnnotation(NullableAnnotation.Annotated);
             }
 
             string expression = symbol.ToString();
-            if (expression.StartsWith("System.") && symbol.ContainingNamespace.Name == "System")
+            if (expression.StartsWith("System.", StringComparison.Ordinal)
+                && symbol.ContainingNamespace.Name == "System")
             {
                 expression = expression.Substring("System.".Length);
             }
@@ -175,7 +177,8 @@ namespace Microsoft.DurableTask.Generators.AzureFunctions
 
         static bool TryGetAttributeByName(MethodDeclarationSyntax method, string attributeName, out AttributeSyntax? attribute)
         {
-            attribute = method.AttributeLists.SelectMany(a => a.Attributes).FirstOrDefault(a => a.Name.NormalizeWhitespace().ToFullString().Equals(attributeName));
+            attribute = method.AttributeLists.SelectMany(a => a.Attributes).FirstOrDefault(
+                a => a.Name.NormalizeWhitespace().ToFullString().Equals(attributeName, StringComparison.Ordinal));
             return attribute != null;
         }
     }

--- a/src/Generators/DurableTaskSourceGenerator.cs
+++ b/src/Generators/DurableTaskSourceGenerator.cs
@@ -416,13 +416,15 @@ namespace Microsoft.DurableTask
                     return supportsNullable ? "object?" : "object";
                 }
 
-                if (supportsNullable && symbol.IsReferenceType && symbol.NullableAnnotation != NullableAnnotation.Annotated)
+                if (supportsNullable && symbol.IsReferenceType
+                    && symbol.NullableAnnotation != NullableAnnotation.Annotated)
                 {
                     symbol = symbol.WithNullableAnnotation(NullableAnnotation.Annotated);
                 }
 
                 string expression = symbol.ToString();
-                if (expression.StartsWith("System.") && symbol.ContainingNamespace.Name == "System")
+                if (expression.StartsWith("System.", StringComparison.Ordinal)
+                    && symbol.ContainingNamespace.Name == "System")
                 {
                     expression = expression.Substring("System.".Length);
                 }

--- a/src/Shared/CSharpLangCompat.cs
+++ b/src/Shared/CSharpLangCompat.cs
@@ -176,7 +176,9 @@ namespace System
         /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
         public override string ToString()
         {
+#pragma warning disable CA1305 // Specify IFormatProvider -- code from dotnet repo
             return this.IsFromEnd ? "^" + ((uint)this.Value).ToString() : ((uint)this.Value).ToString();
+#pragma warning restore CA1305 // Specify IFormatProvider -- code from dotnet repo
         }
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using DurableTask.Core;
@@ -312,7 +313,7 @@ sealed class TaskOrchestrationContextWrapper : TaskOrchestrationContext
             "_",
             this.CurrentUtcDateTime.ToString("o"),
             "_",
-            this.newGuidCounter.ToString());
+            this.newGuidCounter.ToString(CultureInfo.InvariantCulture));
 
         this.newGuidCounter++;
 
@@ -321,12 +322,14 @@ sealed class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         SwapByteArrayValues(namespaceValueByteArray);
 
         byte[] hashByteArray;
+#pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms -- not for cryptography
         using (HashAlgorithm hashAlgorithm = SHA1.Create())
         {
             hashAlgorithm.TransformBlock(namespaceValueByteArray, 0, namespaceValueByteArray.Length, null, 0);
             hashAlgorithm.TransformFinalBlock(nameByteArray, 0, nameByteArray.Length);
             hashByteArray = hashAlgorithm.Hash;
         }
+#pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms -- not for cryptography
 
         byte[] newGuidByteArray = new byte[16];
         Array.Copy(hashByteArray, 0, newGuidByteArray, 0, 16);


### PR DESCRIPTION
This PR enables .NET6 recommended analyzers. Additionally, it marks `TaskName` as a `readonly` struct.