### PR TITLE
Disable implicit usings on misc.csproj

### DIFF
--- a/misc/misc.csproj
+++ b/misc/misc.csproj
@@ -9,6 +9,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IncludeShared>false</IncludeShared>
+    <ImplicitUsings>disable</ImplicitUsings>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 


### PR DESCRIPTION
Quick PR to add this property. It is just to stop build time from producing a global usings file as it causes some design time errors.