### PR TITLE
Extract IDurableTaskFactory, enclose task invocations with a service scope.

### DIFF
--- a/src/Worker/Core/DurableTaskRegistry.cs
+++ b/src/Worker/Core/DurableTaskRegistry.cs
@@ -15,8 +15,8 @@ public sealed class DurableTaskRegistry
     readonly ImmutableDictionary<TaskName, Func<IServiceProvider, ITaskActivity>>.Builder activitiesBuilder
         = ImmutableDictionary.CreateBuilder<TaskName, Func<IServiceProvider, ITaskActivity>>();
 
-    readonly ImmutableDictionary<TaskName, Func<ITaskOrchestrator>>.Builder orchestratorsBuilder
-        = ImmutableDictionary.CreateBuilder<TaskName, Func<ITaskOrchestrator>>();
+    readonly ImmutableDictionary<TaskName, Func<IServiceProvider, ITaskOrchestrator>>.Builder orchestratorsBuilder
+        = ImmutableDictionary.CreateBuilder<TaskName, Func<IServiceProvider, ITaskOrchestrator>>();
 
     /// <summary>
     /// Registers an activity as a synchronous (blocking) lambda function that doesn't take any input nor returns any output.
@@ -149,7 +149,7 @@ public sealed class DurableTaskRegistry
             throw new ArgumentException($"A task orchestrator named '{name}' is already added.", nameof(name));
         }
 
-        this.orchestratorsBuilder.Add(name, () => FuncTaskOrchestrator.Create(implementation));
+        this.orchestratorsBuilder.Add(name, _ => FuncTaskOrchestrator.Create(implementation));
         return this;
     }
 
@@ -164,7 +164,7 @@ public sealed class DurableTaskRegistry
         string name = GetTaskName(typeof(TOrchestrator));
         this.orchestratorsBuilder.Add(
             name,
-            () =>
+            _ =>
             {
                 // Unlike activities, we don't give orchestrators access to the IServiceProvider collection since
                 // injected services are inherently non-deterministic. If an orchestrator needs access to a service,
@@ -176,10 +176,10 @@ public sealed class DurableTaskRegistry
     }
 
     /// <summary>
-    /// Builds this registry into a <see cref="DurableTaskFactory" />.
+    /// Builds this registry into a <see cref="IDurableTaskFactory" />.
     /// </summary>
-    /// <returns>The built <see cref="DurableTaskFactory" />.</returns>
-    internal DurableTaskFactory Build()
+    /// <returns>The built <see cref="IDurableTaskFactory" />.</returns>
+    internal IDurableTaskFactory Build()
     {
         return new DurableTaskFactory(this.activitiesBuilder.ToImmutable(), this.orchestratorsBuilder.ToImmutable());
     }

--- a/src/Worker/Core/Hosting/DurableTaskWorker.cs
+++ b/src/Worker/Core/Hosting/DurableTaskWorker.cs
@@ -17,7 +17,7 @@ public abstract class DurableTaskWorker : BackgroundService
     /// <param name="factory">The durable factory.</param>
     /// <param name="options">The worker options.</param>
     protected DurableTaskWorker(
-        string? name, DurableTaskFactory factory, DurableTaskWorkerOptions options)
+        string? name, IDurableTaskFactory factory, DurableTaskWorkerOptions options)
     {
         this.Name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
         this.Factory = Check.NotNull(factory);
@@ -30,10 +30,10 @@ public abstract class DurableTaskWorker : BackgroundService
     protected virtual string Name { get; }
 
     /// <summary>
-    /// Gets the <see cref="DurableTaskFactory" /> which has been initialized from
+    /// Gets the <see cref="IDurableTaskFactory" /> which has been initialized from
     /// the configured tasks during host construction.
     /// </summary>
-    protected virtual DurableTaskFactory Factory { get; }
+    protected virtual IDurableTaskFactory Factory { get; }
 
     /// <summary>
     /// Gets the worker options.

--- a/src/Worker/Core/IDurableTaskFactory.cs
+++ b/src/Worker/Core/IDurableTaskFactory.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DurableTask.Worker;
+
+/// <summary>
+/// A factory for creating orchestrators and activities.
+/// </summary>
+public interface IDurableTaskFactory
+{
+    /// <summary>
+    /// Tries to creates an activity given a name.
+    /// </summary>
+    /// <param name="name">The name of the activity.</param>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="activity">The activity or <c>null</c> if it does not exist.</param>
+    /// <returns>True if activity was created, false otherwise.</returns>
+    bool TryCreateActivity(
+        TaskName name, IServiceProvider serviceProvider, [NotNullWhen(true)] out ITaskActivity? activity);
+
+    /// <summary>
+    /// Tries to creates an orchestrator given a name.
+    /// </summary>
+    /// <param name="name">The name of the orchestrator.</param>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="orchestrator">The orchestrator or <c>null</c> if it does not exist.</param>
+    /// <returns>True if orchestrator was created, false otherwise.</returns>
+    /// <remarks>
+    /// While <paramref name="serviceProvider" /> is provided here, it is not required to be used to construct
+    /// orchestrators. Individual implementations of this contract may use it in different ways. The default
+    /// implementation does not use it.
+    /// </remarks>
+    bool TryCreateOrchestrator(
+        TaskName name, IServiceProvider serviceProvider, [NotNullWhen(true)] out ITaskOrchestrator? orchestrator);
+}

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -196,7 +196,8 @@ sealed partial class GrpcDurableTaskWorker
                     runtimeState.PastEvents.Count,
                     runtimeState.NewEvents.Count);
 
-                if (this.worker.Factory.TryCreateOrchestrator(name, out ITaskOrchestrator? orchestrator))
+                if (this.worker.Factory.TryCreateOrchestrator(
+                    name, this.worker.services, out ITaskOrchestrator? orchestrator))
                 {
                     // Both the factory invocation and the ExecuteAsync could involve user code and need to be handled
                     // as part of try/catch.

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -6,6 +6,7 @@ using DurableTask.Core;
 using DurableTask.Core.History;
 using Grpc.Core;
 using Microsoft.DurableTask.Worker.Shims;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using static Microsoft.DurableTask.Protobuf.TaskHubSidecarService;
 using P = Microsoft.DurableTask.Protobuf;
@@ -196,8 +197,9 @@ sealed partial class GrpcDurableTaskWorker
                     runtimeState.PastEvents.Count,
                     runtimeState.NewEvents.Count);
 
+                await using AsyncServiceScope scope = this.worker.services.CreateAsyncScope();
                 if (this.worker.Factory.TryCreateOrchestrator(
-                    name, this.worker.services, out ITaskOrchestrator? orchestrator))
+                    name, scope.ServiceProvider, out ITaskOrchestrator? orchestrator))
                 {
                     // Both the factory invocation and the ExecuteAsync could involve user code and need to be handled
                     // as part of try/catch.
@@ -285,8 +287,8 @@ sealed partial class GrpcDurableTaskWorker
             P.TaskFailureDetails? failureDetails = null;
             try
             {
-                // TODO: start new service scope for activity.
-                if (this.worker.Factory.TryCreateActivity(name, this.worker.services, out ITaskActivity? activity))
+                await using AsyncServiceScope scope = this.worker.services.CreateAsyncScope();
+                if (this.worker.Factory.TryCreateActivity(name, scope.ServiceProvider, out ITaskActivity? activity))
                 {
                     // Both the factory invocation and the RunAsync could involve user code and need to be handled as
                     // part of try/catch.

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -29,7 +29,7 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
     /// <param name="loggerFactory">The logger.</param>
     public GrpcDurableTaskWorker(
         string name,
-        DurableTaskFactory factory,
+        IDurableTaskFactory factory,
         DurableTaskWorkerOptions options,
         IOptionsMonitor<GrpcDurableTaskWorkerOptions> grpcOptions,
         IServiceProvider services,

--- a/test/Worker/Core.Tests/DependencyInjection/DefaultDurableTaskBuilderTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/DefaultDurableTaskBuilderTests.cs
@@ -75,7 +75,7 @@ public class DefaultDurableTaskBuilderTests
 
         public new string Name => base.Name;
 
-        public new DurableTaskFactory Factory => base.Factory;
+        public new IDurableTaskFactory Factory => base.Factory;
 
         public new DurableTaskWorkerOptions Options => base.Options;
 

--- a/test/Worker/Core.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -78,7 +78,7 @@ public class DurableTaskBuilderExtensionsTests
 
         public new string Name => base.Name;
 
-        public new DurableTaskFactory Factory => base.Factory;
+        public new IDurableTaskFactory Factory => base.Factory;
 
         public new DurableTaskWorkerOptions Options => base.Options;
 


### PR DESCRIPTION
This PR does the following:

1. Extracts a contract `IDurableTaskFactory` and makes the existing `DurableTaskFactory` implementation `internal`.
    - The goal here is two-fold: 1) hide our internal implementation and improve unit testability. and 2) to set us up for user supplied and aggregate factories (post GA, will need more design/thinking).
2. Adds `IServiceProvider` argument to `ITaskOrchestrator` construction. However, **it is not used** at the moment.
    - This is to make the structure consistent with `ITaskActivity` construction.
    - We can use this in the future to provide a _limited and customized_ set of services to `ITaskOrchestrator` construction (replay safe `ILogger`, `IOptions<T>` which have been snapshotted in place as a history event).
3. Encloses `ITaskOrchestrator` and `ITaskActivity` invocations in a new service scope. This enables use of scoped services for invocations.