### PR TITLE
Refactor TaskActivity and TaskOrchestrator base classes

### DIFF
--- a/src/Abstractions/DurableTaskAttribute.cs
+++ b/src/Abstractions/DurableTaskAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DurableTask;
 /// </summary>
 /// <remarks>
 /// This attribute is meant to be used on class definitions that derive from
-/// <see cref="TaskOrchestratorBase{TInput, TOutput}"/> or <see cref="TaskActivityBase{TInput, TOutput}"/>.
+/// <see cref="TaskOrchestrator{TInput, TOutput}"/> or <see cref="TaskActivity{TInput, TOutput}"/>.
 /// It is used specifically by build-time source generators to generate type-safe methods for invoking
 /// orchestrations or activities.
 /// </remarks>

--- a/src/Abstractions/TaskActivity.cs
+++ b/src/Abstractions/TaskActivity.cs
@@ -78,8 +78,6 @@ public abstract class TaskActivity<TInput, TOutput> : ITaskActivity
             throw new ArgumentException($"Input type '{input?.GetType()}' does not match expected type '{typeof(TInput)}'.");
         }
 
-        // Input very well may be null here. However, as explained above, we need to let later code decide what to do
-        // with a null value. So we use '!' just to suppress the warning.
         return await this.RunAsync(context, typedInput);
     }
 
@@ -111,7 +109,9 @@ public abstract class TaskActivity<TInput, TOutput> : ITaskActivity
         }
 
         // Input is null and did not match a nullable value type. We do not have enough information to tell if it is
-        // valid or not. We will have to defer this decision to the implementation.
+        // valid or not. We will have to defer this decision to the implementation. Additionally, we will coerce a null
+        // input to a default value type here. This is to keep the two RunAsync(context, default) overloads to have
+        // identical behavior.
         typedInput = default!;
         return true;
     }

--- a/src/Abstractions/TaskActivity.cs
+++ b/src/Abstractions/TaskActivity.cs
@@ -78,6 +78,8 @@ public abstract class TaskActivity<TInput, TOutput> : ITaskActivity
             throw new ArgumentException($"Input type '{input?.GetType()}' does not match expected type '{typeof(TInput)}'.");
         }
 
+        // Input very well may be null here. However, as explained above, we need to let later code decide what to do
+        // with a null value. So we use '!' just to suppress the warning.
         return await this.RunAsync(context, typedInput);
     }
 
@@ -96,27 +98,20 @@ public abstract class TaskActivity<TInput, TOutput> : ITaskActivity
     /// </summary>
     static bool IsValidInput(object? input, [NotNullWhen(true)] out TInput? typedInput)
     {
-        Type inputType = typeof(TInput);
         if (input is TInput typed)
         {
             // Quick pattern check.
             typedInput = typed;
             return true;
         }
-        else if (input is not null && inputType != input.GetType())
+        else if (input is not null && typeof(TInput) != input.GetType())
         {
-            typedInput = default;
-            return false;
-        }
-        else if (input is null && inputType.IsValueType && Nullable.GetUnderlyingType(inputType) is null)
-        {
-            // We have a non-nullable value type, but null was supplied. This is invalid input.
             typedInput = default;
             return false;
         }
 
-        // Input is null. We do not have enough information to tell if it is valid or not. We cannot tell at runtime if
-        // the customer used nullable reference types or not. We will have to defer this decision to the implementation.
+        // Input is null and did not match a nullable value type. We do not have enough information to tell if it is
+        // valid or not. We will have to defer this decision to the implementation.
         typedInput = default!;
         return true;
     }

--- a/src/Abstractions/TaskOrchestrator.cs
+++ b/src/Abstractions/TaskOrchestrator.cs
@@ -129,8 +129,6 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
             throw new ArgumentException($"Input type '{input?.GetType()}' does not match expected type '{typeof(TInput)}'.");
         }
 
-        // Input very well may be null here. However, as explained above, we need to let later code decide what to do
-        // with a null value. So we use '!' just to suppress the warning.
         return await this.RunAsync(context, typedInput);
     }
 
@@ -162,7 +160,9 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
         }
 
         // Input is null and did not match a nullable value type. We do not have enough information to tell if it is
-        // valid or not. We will have to defer this decision to the implementation.
+        // valid or not. We will have to defer this decision to the implementation. Additionally, we will coerce a null
+        // input to a default value type here. This is to keep the two RunAsync(context, default) overloads to have
+        // identical behavior.
         typedInput = default!;
         return true;
     }

--- a/src/Abstractions/TaskOrchestrator.cs
+++ b/src/Abstractions/TaskOrchestrator.cs
@@ -129,8 +129,6 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
             throw new ArgumentException($"Input type '{input?.GetType()}' does not match expected type '{typeof(TInput)}'.");
         }
 
-        // Input very well may be null here. However, as explained above, we need to let later code decide what to do
-        // with a null value. So we use '!' just to suppress the warning.
         return await this.RunAsync(context, typedInput);
     }
 
@@ -149,20 +147,27 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
     /// </summary>
     static bool IsValidInput(object? input, [NotNullWhen(true)] out TInput? typedInput)
     {
+        Type inputType = typeof(TInput);
         if (input is TInput typed)
         {
             // Quick pattern check.
             typedInput = typed;
             return true;
         }
-        else if (input is not null && typeof(TInput) != input.GetType())
+        else if (input is not null && inputType != input.GetType())
         {
             typedInput = default;
             return false;
         }
+        else if (input is null && inputType.IsValueType && Nullable.GetUnderlyingType(inputType) is null)
+        {
+            // We have a non-nullable value type, but null was supplied. This is invalid input.
+            typedInput = default;
+            return false;
+        }
 
-        // Input is null and did not match a nullable value type. We do not have enough information to tell if it is
-        // valid or not. We will have to defer this decision to the implementation.
+        // Input is null. We do not have enough information to tell if it is valid or not. We cannot tell at runtime if
+        // the customer used nullable reference types or not. We will have to defer this decision to the implementation.
         typedInput = default!;
         return true;
     }

--- a/src/Abstractions/TaskOrchestrator.cs
+++ b/src/Abstractions/TaskOrchestrator.cs
@@ -129,6 +129,8 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
             throw new ArgumentException($"Input type '{input?.GetType()}' does not match expected type '{typeof(TInput)}'.");
         }
 
+        // Input very well may be null here. However, as explained above, we need to let later code decide what to do
+        // with a null value. So we use '!' just to suppress the warning.
         return await this.RunAsync(context, typedInput);
     }
 
@@ -147,27 +149,20 @@ public abstract class TaskOrchestrator<TInput, TOutput> : ITaskOrchestrator
     /// </summary>
     static bool IsValidInput(object? input, [NotNullWhen(true)] out TInput? typedInput)
     {
-        Type inputType = typeof(TInput);
         if (input is TInput typed)
         {
             // Quick pattern check.
             typedInput = typed;
             return true;
         }
-        else if (input is not null && inputType != input.GetType())
+        else if (input is not null && typeof(TInput) != input.GetType())
         {
-            typedInput = default;
-            return false;
-        }
-        else if (input is null && inputType.IsValueType && Nullable.GetUnderlyingType(inputType) is null)
-        {
-            // We have a non-nullable value type, but null was supplied. This is invalid input.
             typedInput = default;
             return false;
         }
 
-        // Input is null. We do not have enough information to tell if it is valid or not. We cannot tell at runtime if
-        // the customer used nullable reference types or not. We will have to defer this decision to the implementation.
+        // Input is null and did not match a nullable value type. We do not have enough information to tell if it is
+        // valid or not. We will have to defer this decision to the implementation.
         typedInput = default!;
         return true;
     }

--- a/src/Worker/Core/DurableTaskRegistry.cs
+++ b/src/Worker/Core/DurableTaskRegistry.cs
@@ -54,11 +54,11 @@ public sealed class DurableTaskRegistry
     /// <inheritdoc cref="AddActivity(TaskName, Action{TaskActivityContext})"/>
     public DurableTaskRegistry AddActivity<TInput, TOutput>(
         TaskName name,
-        Func<TaskActivityContext, TInput?, TOutput?> implementation)
+        Func<TaskActivityContext, TInput, TOutput> implementation)
     {
         Check.NotDefault(name);
         Check.NotNull(implementation);
-        return this.AddActivity<TInput, TOutput?>(
+        return this.AddActivity<TInput, TOutput>(
             name, (context, input) => Task.FromResult(implementation(context, input)));
     }
 
@@ -70,7 +70,7 @@ public sealed class DurableTaskRegistry
     /// <inheritdoc cref="AddActivity(TaskName, Action{TaskActivityContext})"/>
     public DurableTaskRegistry AddActivity<TInput, TOutput>(
         TaskName name,
-        Func<TaskActivityContext, TInput?, Task<TOutput?>> implementation)
+        Func<TaskActivityContext, TInput, Task<TOutput>> implementation)
     {
         Check.NotDefault(name);
         Check.NotNull(implementation);
@@ -123,7 +123,7 @@ public sealed class DurableTaskRegistry
     /// <inheritdoc cref="AddOrchestrator{TInput, TOutput}"/>
     public DurableTaskRegistry AddOrchestrator<TOutput>(
         TaskName name,
-        Func<TaskOrchestrationContext, Task<TOutput?>> implementation)
+        Func<TaskOrchestrationContext, Task<TOutput>> implementation)
     {
         Check.NotDefault(name);
         Check.NotNull(implementation);
@@ -140,7 +140,7 @@ public sealed class DurableTaskRegistry
     /// <returns>Returns this <see cref="DurableTaskRegistry"/> instance.</returns>
     public DurableTaskRegistry AddOrchestrator<TInput, TOutput>(
         TaskName name,
-        Func<TaskOrchestrationContext, TInput?, Task<TOutput?>> implementation)
+        Func<TaskOrchestrationContext, TInput, Task<TOutput>> implementation)
     {
         Check.NotDefault(name);
         Check.NotNull(implementation);

--- a/src/Worker/Core/Shims/FuncTaskActivity.cs
+++ b/src/Worker/Core/Shims/FuncTaskActivity.cs
@@ -9,41 +9,41 @@ namespace Microsoft.DurableTask.Shims;
 public static class FuncTaskActivity
 {
     /// <summary>
-    /// Creates a new <see cref="TaskActivityBase{TInput, TOutput}" /> with
+    /// Creates a new <see cref="TaskActivity{TInput, TOutput}" /> with
     /// the provided function as the implementation.
     /// </summary>
     /// <typeparam name="TInput">The input type.</typeparam>
     /// <typeparam name="TOutput">The output type.</typeparam>
     /// <param name="implementation">The activity implementation.</param>
     /// <returns>A new activity.</returns>
-    public static TaskActivityBase<TInput, TOutput> Create<TInput, TOutput>(
-        Func<TaskActivityContext, TInput?, Task<TOutput?>> implementation)
+    public static TaskActivity<TInput, TOutput> Create<TInput, TOutput>(
+        Func<TaskActivityContext, TInput, Task<TOutput>> implementation)
     {
         Check.NotNull(implementation);
         return new Implementation<TInput, TOutput>(implementation);
     }
 
     /// <summary>
-    /// Implementation of <see cref="TaskActivityBase{TInput, TOutput}"/> that uses
+    /// Implementation of <see cref="TaskActivity{TInput, TOutput}"/> that uses
     /// a <see cref="Func{T, TResult}"/> delegate as its implementation.
     /// </summary>
     /// <typeparam name="TInput">The Activity input type.</typeparam>
     /// <typeparam name="TOutput">The Activity output type.</typeparam>
-    class Implementation<TInput, TOutput> : TaskActivityBase<TInput, TOutput>
+    class Implementation<TInput, TOutput> : TaskActivity<TInput, TOutput>
     {
-        readonly Func<TaskActivityContext, TInput?, Task<TOutput?>> implementation;
+        readonly Func<TaskActivityContext, TInput, Task<TOutput>> implementation;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Implementation{TInput, TOutput}"/> class.
         /// </summary>
         /// <param name="implementation">The Activity function.</param>
-        public Implementation(Func<TaskActivityContext, TInput?, Task<TOutput?>> implementation)
+        public Implementation(Func<TaskActivityContext, TInput, Task<TOutput>> implementation)
         {
             this.implementation = implementation;
         }
 
         /// <inheritdoc/>
-        protected override Task<TOutput?> OnRunAsync(TaskActivityContext context, TInput? input)
+        public override Task<TOutput> RunAsync(TaskActivityContext context, TInput input)
         {
             return this.implementation(context, input);
         }

--- a/src/Worker/Core/Shims/FuncTaskOrchestrator.cs
+++ b/src/Worker/Core/Shims/FuncTaskOrchestrator.cs
@@ -9,41 +9,41 @@ namespace Microsoft.DurableTask.Shims;
 public static class FuncTaskOrchestrator
 {
     /// <summary>
-    /// Creates a new <see cref="TaskOrchestratorBase{TInput, TOutput}" /> with
+    /// Creates a new <see cref="TaskOrchestrator{TInput, TOutput}" /> with
     /// the provided function as the implementation.
     /// </summary>
     /// <typeparam name="TInput">The input type.</typeparam>
     /// <typeparam name="TOutput">The output type.</typeparam>
     /// <param name="implementation">The orchestrator implementation.</param>
     /// <returns>A new orchestrator.</returns>
-    public static TaskOrchestratorBase<TInput, TOutput> Create<TInput, TOutput>(
-        Func<TaskOrchestrationContext, TInput?, Task<TOutput?>> implementation)
+    public static TaskOrchestrator<TInput, TOutput> Create<TInput, TOutput>(
+        Func<TaskOrchestrationContext, TInput, Task<TOutput>> implementation)
     {
         Check.NotNull(implementation);
         return new Implementation<TInput, TOutput>(implementation);
     }
 
     /// <summary>
-    /// Implementation of <see cref="TaskOrchestratorBase{TInput, TOutput}"/> that uses
+    /// Implementation of <see cref="TaskOrchestrator{TInput, TOutput}"/> that uses
     /// a <see cref="Func{T, TResult}"/> delegate as its implementation.
     /// </summary>
     /// <typeparam name="TInput">The orchestrator input type.</typeparam>
     /// <typeparam name="TOutput">The orchestrator output type.</typeparam>
-    class Implementation<TInput, TOutput> : TaskOrchestratorBase<TInput, TOutput>
+    class Implementation<TInput, TOutput> : TaskOrchestrator<TInput, TOutput>
     {
-        readonly Func<TaskOrchestrationContext, TInput?, Task<TOutput?>> implementation;
+        readonly Func<TaskOrchestrationContext, TInput, Task<TOutput>> implementation;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Implementation{TInput, TOutput}"/> class.
         /// </summary>
         /// <param name="implementation">The orchestrator function.</param>
-        public Implementation(Func<TaskOrchestrationContext, TInput?, Task<TOutput?>> implementation)
+        public Implementation(Func<TaskOrchestrationContext, TInput, Task<TOutput>> implementation)
         {
             this.implementation = implementation;
         }
 
         /// <inheritdoc/>
-        protected override Task<TOutput?> OnRunAsync(TaskOrchestrationContext context, TInput? input)
+        public override Task<TOutput> RunAsync(TaskOrchestrationContext context, TInput input)
         {
             return this.implementation(context, input);
         }

--- a/test/Abstractions.Tests/TaskActivityTests.cs
+++ b/test/Abstractions.Tests/TaskActivityTests.cs
@@ -7,24 +7,27 @@ public class TaskActivityTests
 {
     [Theory]
     [InlineData(typeof(ReferenceActivity), null)]
+    [InlineData(typeof(ReferenceActivity), "")]
     [InlineData(typeof(ReferenceActivity), "input")]
     [InlineData(typeof(NullableReferenceActivity), null)]
+    [InlineData(typeof(NullableReferenceActivity), "")]
     [InlineData(typeof(NullableReferenceActivity), "input")]
-    [InlineData(typeof(ValueActivity), null)]
+    [InlineData(typeof(ValueActivity), 0)]
     [InlineData(typeof(ValueActivity), 1)]
     [InlineData(typeof(NullableValueActivity), null)]
+    [InlineData(typeof(NullableValueActivity), 0)]
     [InlineData(typeof(NullableValueActivity), 1)]
     public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
     {
         ITaskActivity activity = (ITaskActivity)Activator.CreateInstance(t)!;
         object? obj = await activity.RunAsync(Mock.Of<TaskActivityContext>(), input);
-        object? expected = t == typeof(ValueActivity) && input is null ? 0 : input; // need to special case the value type.
-        obj.Should().Be(expected);
+        obj.Should().Be(input);
     }
 
     [Theory]
     [InlineData(typeof(ReferenceActivity), 1)]
     [InlineData(typeof(NullableReferenceActivity), 1)]
+    [InlineData(typeof(ValueActivity), null)]
     [InlineData(typeof(ValueActivity), "input")]
     [InlineData(typeof(NullableValueActivity), "input")]
     public async Task Run_WrongType_Throws(Type t, object? input)

--- a/test/Abstractions.Tests/TaskActivityTests.cs
+++ b/test/Abstractions.Tests/TaskActivityTests.cs
@@ -7,27 +7,24 @@ public class TaskActivityTests
 {
     [Theory]
     [InlineData(typeof(ReferenceActivity), null)]
-    [InlineData(typeof(ReferenceActivity), "")]
     [InlineData(typeof(ReferenceActivity), "input")]
     [InlineData(typeof(NullableReferenceActivity), null)]
-    [InlineData(typeof(NullableReferenceActivity), "")]
     [InlineData(typeof(NullableReferenceActivity), "input")]
-    [InlineData(typeof(ValueActivity), 0)]
+    [InlineData(typeof(ValueActivity), null)]
     [InlineData(typeof(ValueActivity), 1)]
     [InlineData(typeof(NullableValueActivity), null)]
-    [InlineData(typeof(NullableValueActivity), 0)]
     [InlineData(typeof(NullableValueActivity), 1)]
     public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
     {
         ITaskActivity activity = (ITaskActivity)Activator.CreateInstance(t)!;
         object? obj = await activity.RunAsync(Mock.Of<TaskActivityContext>(), input);
-        obj.Should().Be(input);
+        object? expected = t == typeof(ValueActivity) && input is null ? 0 : input; // need to special case the value type.
+        obj.Should().Be(expected);
     }
 
     [Theory]
     [InlineData(typeof(ReferenceActivity), 1)]
     [InlineData(typeof(NullableReferenceActivity), 1)]
-    [InlineData(typeof(ValueActivity), null)]
     [InlineData(typeof(ValueActivity), "input")]
     [InlineData(typeof(NullableValueActivity), "input")]
     public async Task Run_WrongType_Throws(Type t, object? input)

--- a/test/Abstractions.Tests/TaskActivityTests.cs
+++ b/test/Abstractions.Tests/TaskActivityTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Tests;
+
+public class TaskActivityTests
+{
+    [Theory]
+    [InlineData(typeof(ReferenceActivity), null)]
+    [InlineData(typeof(ReferenceActivity), "input")]
+    [InlineData(typeof(NullableReferenceActivity), null)]
+    [InlineData(typeof(NullableReferenceActivity), "input")]
+    [InlineData(typeof(ValueActivity), null)]
+    [InlineData(typeof(ValueActivity), 1)]
+    [InlineData(typeof(NullableValueActivity), null)]
+    [InlineData(typeof(NullableValueActivity), 1)]
+    public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
+    {
+        ITaskActivity activity = (ITaskActivity)Activator.CreateInstance(t)!;
+        object? obj = await activity.RunAsync(Mock.Of<TaskActivityContext>(), input);
+        object? expected = t == typeof(ValueActivity) && input is null ? 0 : input; // need to special case the value type.
+        obj.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(typeof(ReferenceActivity), 1)]
+    [InlineData(typeof(NullableReferenceActivity), 1)]
+    [InlineData(typeof(ValueActivity), "input")]
+    [InlineData(typeof(NullableValueActivity), "input")]
+    public async Task Run_WrongType_Throws(Type t, object? input)
+    {
+        ITaskActivity activity = (ITaskActivity)Activator.CreateInstance(t)!;
+        Func<Task> act = () => activity.RunAsync(Mock.Of<TaskActivityContext>(), input);
+        await act.Should().ThrowExactlyAsync<ArgumentException>();
+    }
+
+    class ReferenceActivity : TaskActivity<string, string>
+    {
+        public override Task<string> RunAsync(TaskActivityContext context, string input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class NullableReferenceActivity : TaskActivity<string?, string?>
+    {
+        public override Task<string?> RunAsync(TaskActivityContext context, string? input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class ValueActivity : TaskActivity<int, int>
+    {
+        public override Task<int> RunAsync(TaskActivityContext context, int input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class NullableValueActivity : TaskActivity<int?, int?>
+    {
+        public override Task<int?> RunAsync(TaskActivityContext context, int? input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+}

--- a/test/Abstractions.Tests/TaskOrchestratorTests.cs
+++ b/test/Abstractions.Tests/TaskOrchestratorTests.cs
@@ -7,24 +7,27 @@ public class TaskOrchestratorTests
 {
     [Theory]
     [InlineData(typeof(ReferenceOrchestrator), null)]
+    [InlineData(typeof(ReferenceOrchestrator), "")]
     [InlineData(typeof(ReferenceOrchestrator), "input")]
     [InlineData(typeof(NullableReferenceOrchestrator), null)]
+    [InlineData(typeof(NullableReferenceOrchestrator), "")]
     [InlineData(typeof(NullableReferenceOrchestrator), "input")]
-    [InlineData(typeof(ValueOrchestrator), null)]
+    [InlineData(typeof(ValueOrchestrator), 0)]
     [InlineData(typeof(ValueOrchestrator), 1)]
     [InlineData(typeof(NullableValueOrchestrator), null)]
+    [InlineData(typeof(NullableValueOrchestrator), 0)]
     [InlineData(typeof(NullableValueOrchestrator), 1)]
     public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
     {
         ITaskOrchestrator orchestrator = (ITaskOrchestrator)Activator.CreateInstance(t)!;
         object? obj = await orchestrator.RunAsync(Mock.Of<TaskOrchestrationContext>(), input);
-        object? expected = t == typeof(ValueOrchestrator) && input is null ? 0 : input; // need to special case the value type.
-        obj.Should().Be(expected);
+        obj.Should().Be(input);
     }
 
     [Theory]
     [InlineData(typeof(ReferenceOrchestrator), 1)]
     [InlineData(typeof(NullableReferenceOrchestrator), 1)]
+    [InlineData(typeof(ValueOrchestrator), null)]
     [InlineData(typeof(ValueOrchestrator), "input")]
     [InlineData(typeof(NullableValueOrchestrator), "input")]
     public async Task Run_WrongType_Throws(Type t, object? input)

--- a/test/Abstractions.Tests/TaskOrchestratorTests.cs
+++ b/test/Abstractions.Tests/TaskOrchestratorTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Tests;
+
+public class TaskOrchestratorTests
+{
+    [Theory]
+    [InlineData(typeof(ReferenceOrchestrator), null)]
+    [InlineData(typeof(ReferenceOrchestrator), "input")]
+    [InlineData(typeof(NullableReferenceOrchestrator), null)]
+    [InlineData(typeof(NullableReferenceOrchestrator), "input")]
+    [InlineData(typeof(ValueOrchestrator), null)]
+    [InlineData(typeof(ValueOrchestrator), 1)]
+    [InlineData(typeof(NullableValueOrchestrator), null)]
+    [InlineData(typeof(NullableValueOrchestrator), 1)]
+    public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
+    {
+        ITaskOrchestrator orchestrator = (ITaskOrchestrator)Activator.CreateInstance(t)!;
+        object? obj = await orchestrator.RunAsync(Mock.Of<TaskOrchestrationContext>(), input);
+        object? expected = t == typeof(ValueOrchestrator) && input is null ? 0 : input; // need to special case the value type.
+        obj.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(typeof(ReferenceOrchestrator), 1)]
+    [InlineData(typeof(NullableReferenceOrchestrator), 1)]
+    [InlineData(typeof(ValueOrchestrator), "input")]
+    [InlineData(typeof(NullableValueOrchestrator), "input")]
+    public async Task Run_WrongType_Throws(Type t, object? input)
+    {
+        ITaskOrchestrator orchestrator = (ITaskOrchestrator)Activator.CreateInstance(t)!;
+        Func<Task> act = () => orchestrator.RunAsync(Mock.Of<TaskOrchestrationContext>(), input);
+        await act.Should().ThrowExactlyAsync<ArgumentException>();
+    }
+
+    class ReferenceOrchestrator : TaskOrchestrator<string, string>
+    {
+        public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class NullableReferenceOrchestrator : TaskOrchestrator<string?, string?>
+    {
+        public override Task<string?> RunAsync(TaskOrchestrationContext context, string? input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class ValueOrchestrator : TaskOrchestrator<int, int>
+    {
+        public override Task<int> RunAsync(TaskOrchestrationContext context, int input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+
+    class NullableValueOrchestrator : TaskOrchestrator<int?, int?>
+    {
+        public override Task<int?> RunAsync(TaskOrchestrationContext context, int? input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+}

--- a/test/Abstractions.Tests/TaskOrchestratorTests.cs
+++ b/test/Abstractions.Tests/TaskOrchestratorTests.cs
@@ -7,27 +7,24 @@ public class TaskOrchestratorTests
 {
     [Theory]
     [InlineData(typeof(ReferenceOrchestrator), null)]
-    [InlineData(typeof(ReferenceOrchestrator), "")]
     [InlineData(typeof(ReferenceOrchestrator), "input")]
     [InlineData(typeof(NullableReferenceOrchestrator), null)]
-    [InlineData(typeof(NullableReferenceOrchestrator), "")]
     [InlineData(typeof(NullableReferenceOrchestrator), "input")]
-    [InlineData(typeof(ValueOrchestrator), 0)]
+    [InlineData(typeof(ValueOrchestrator), null)]
     [InlineData(typeof(ValueOrchestrator), 1)]
     [InlineData(typeof(NullableValueOrchestrator), null)]
-    [InlineData(typeof(NullableValueOrchestrator), 0)]
     [InlineData(typeof(NullableValueOrchestrator), 1)]
     public async Task Run_CorrectType_DoesNotThrow(Type t, object? input)
     {
         ITaskOrchestrator orchestrator = (ITaskOrchestrator)Activator.CreateInstance(t)!;
         object? obj = await orchestrator.RunAsync(Mock.Of<TaskOrchestrationContext>(), input);
-        obj.Should().Be(input);
+        object? expected = t == typeof(ValueOrchestrator) && input is null ? 0 : input; // need to special case the value type.
+        obj.Should().Be(expected);
     }
 
     [Theory]
     [InlineData(typeof(ReferenceOrchestrator), 1)]
     [InlineData(typeof(NullableReferenceOrchestrator), 1)]
-    [InlineData(typeof(ValueOrchestrator), null)]
     [InlineData(typeof(ValueOrchestrator), "input")]
     [InlineData(typeof(NullableValueOrchestrator), "input")]
     public async Task Run_WrongType_Throws(Type t, object? input)

--- a/test/Abstractions.Tests/Usings.cs
+++ b/test/Abstractions.Tests/Usings.cs
@@ -1,1 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+global using FluentAssertions;
+global using Moq;
 global using Xunit;

--- a/test/Grpc.IntegrationTests/DurableTaskGrpcClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/DurableTaskGrpcClientIntegrationTests.cs
@@ -141,7 +141,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
 
     Task<AsyncDisposable> StartAsync()
     {
-        static async Task<string?> Orchestration(TaskOrchestrationContext context, bool shouldThrow)
+        static async Task<string> Orchestration(TaskOrchestrationContext context, bool shouldThrow)
         {
             context.SetCustomStatus("waiting");
             await context.WaitForExternalEvent<string>("event");

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -270,7 +270,7 @@ public class OrchestrationPatterns : IntegrationTestBase
                     Array.Reverse(results);
                     return results;
                 })
-                .AddActivity<object, string>(toStringActivity, (ctx, input) => input.ToString()!));
+                .AddActivity<object, string?>(toStringActivity, (ctx, input) => input.ToString()));
         });
 
         DurableTaskClient client = this.CreateDurableTaskClient();

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -174,7 +174,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         {
             b.AddTasks(tasks => tasks
                 .AddOrchestrator<string, string>(
-                    orchestratorName, (ctx, input) => ctx.CallActivityAsync<string?>(sayHelloActivityName, input))
+                    orchestratorName, (ctx, input) => ctx.CallActivityAsync<string>(sayHelloActivityName, input))
                 .AddActivity<string, string>(sayHelloActivityName, (ctx, name) => $"Hello, {name}!"));
         });
 
@@ -199,7 +199,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         {
             b.AddTasks(tasks => tasks
                 .AddOrchestrator<string, string>(
-                    orchestratorName, (ctx, input) => ctx.CallActivityAsync<string?>(sayHelloActivityName, input))
+                    orchestratorName, (ctx, input) => ctx.CallActivityAsync<string>(sayHelloActivityName, input))
                 .AddActivity<string, string>(
                     sayHelloActivityName, async (ctx, name) => await Task.FromResult($"Hello, {name}!")));
         });
@@ -270,7 +270,7 @@ public class OrchestrationPatterns : IntegrationTestBase
                     Array.Reverse(results);
                     return results;
                 })
-                .AddActivity<object, string>(toStringActivity, (ctx, input) => input!.ToString()));
+                .AddActivity<object, string>(toStringActivity, (ctx, input) => input.ToString()!));
         });
 
         DurableTaskClient client = this.CreateDurableTaskClient();
@@ -531,9 +531,9 @@ public class OrchestrationPatterns : IntegrationTestBase
                         throw new ArgumentNullException(nameof(input));
                     }
 
-                    return ctx.CallActivityAsync<JsonNode?>("SpecialSerialization_Activity", input);
+                    return ctx.CallActivityAsync<JsonNode>("SpecialSerialization_Activity", input);
                 })
-                .AddActivity<JsonNode, JsonNode>("SpecialSerialization_Activity", (ctx, input) =>
+                .AddActivity<JsonNode, JsonNode?>("SpecialSerialization_Activity", (ctx, input) =>
                 {
                     if (input is not null)
                     {

--- a/test/Grpc.IntegrationTests/PageableIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/PageableIntegrationTests.cs
@@ -24,7 +24,7 @@ public class PageableIntegrationTests : IntegrationTestBase
             b.AddTasks(tasks => tasks
                 .AddOrchestrator<string, int>(
                     orchestratorName, (ctx, input) => PageableOrchestrationAsync(ctx, input))
-                .AddActivity<PageRequest, Page<string>>(
+                .AddActivity<PageRequest, Page<string>?>(
                     nameof(PageableActivityAsync), (_, input) => PageableActivityAsync(input)));
         });
 


### PR DESCRIPTION
This PR refactors `TaskActivity` and `TaskOrchestrator` classes.

# Summary of changes

1. `TaskActivityBase`, `TaskOrchestratorBase` renamed to `TaskActivity`, `TaskOchestrator` respectively.
    - This follows the dotnet guideline: https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/base-classes-for-implementing-abstractions
    - > ❌ AVOID naming base classes with a "Base" suffix if the class is intended for use in public APIs.
1. Removed nullability on generic params in `TaskActivity` and `TaskOrchestrator` APIs.
    - It should be up to the implementor to add nullability to their generic closure or not. ie: I can implement `MyOrchestrator<string, string>` OR `MyOrchestrator<string?, string?>` (or any other variation). I am not forced into using `?` on my types.
1. Renames `OnRunAsync` to `RunAsync` and makes this public.
    - This is for a couple reasons. First, for testability. I can instantiate and invoke `RunAsync` on my derived class. Second, these types effectively are more specific overloads of the interface `Task<object?> RunAsync(..., object? input);`, so they can have the same name.
1. Remove the synchronous `TaskActivity.Run` method.
    - I want to make sure at least on method is `abstract` on `TaskActivity` to force a compiler error if it is not implemented.
    - This method is not providing an actual benefit, but a small shim of `Task.FromResult(...)` - I'd rather leave that to implementors to determine how they want to handle sync-within-async.
    - If synchronous activities are a common use case, we should evaluate `ValueTask<T>`, as then there is an _actual_ performance benefit for the "sometimes-async" scenario.