### PR TITLE
Remove setting of TaskName.Version for now

### DIFF
--- a/src/Abstractions/TaskActivityContext.cs
+++ b/src/Abstractions/TaskActivityContext.cs
@@ -7,14 +7,14 @@ namespace Microsoft.DurableTask;
 /// Defines properties and methods for task activity context objects.
 /// </summary>
 /// <remarks>
-/// A new instance of <see cref="TaskActivityContext"/> is passed as a parameter to each
-/// task activity execution. It includes basic information such as the name of the activity, the
-/// ID of the invoking orchestration instance, and a method for reading the activity input.
+/// A new instance of <see cref="TaskActivityContext"/> is passed as a parameter to each task activity execution. It
+/// includes basic information such as the name of the activity, the ID of the invoking orchestration instance, and a
+/// method for reading the activity input.
 /// </remarks>
 public abstract class TaskActivityContext
 {
-    // IMPORTANT: This abstract class is implemented in the output of source generators, so any changes
-    //            to the interface may also need to be reflected in the source generator output.
+    // IMPORTANT: This abstract class is implemented in the output of source generators, so any changes to the interface
+    //            may also need to be reflected in the source generator output.
 
     /// <summary>
     /// Gets the name of the task activity.

--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -14,11 +14,10 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// Initializes a new instance of the <see cref="TaskName"/> struct.
     /// </summary>
     /// <param name="name">The name of the task.</param>
-    /// <param name="version">The version of the task, if applicable.</param>
-    public TaskName(string name, string? version = null)
+    public TaskName(string name)
     {
-        this.Name = name ?? throw new ArgumentNullException(nameof(name));
-        this.Version = version ?? string.Empty;
+        this.Name = Check.NotNullOrEmpty(name);
+        this.Version = string.Empty; // expose setting Version only when we actually consume it.
     }
 
     /// <summary>
@@ -33,7 +32,8 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// Gets the version of the task.
     /// </summary>
     /// <remarks>
-    /// Task versions are currently experimental and their role may change over time.
+    /// Task versions is currently locked to <see cref="string.Empty" /> as it is not yet integrated into task
+    /// identification. This is being left here as we intend to support it soon.
     /// </remarks>
     public string Version { get; }
 
@@ -90,12 +90,12 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
     public override bool Equals(object? obj)
     {
-        if (obj is not TaskName)
+        if (obj is not TaskName other)
         {
             return false;
         }
 
-        return this.Equals((TaskName)obj);
+        return this.Equals(other);
     }
 
     /// <summary>

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -189,7 +189,7 @@ sealed partial class GrpcDurableTaskWorker
             try
             {
                 OrchestrationRuntimeState runtimeState = BuildRuntimeState(request);
-                name = new(runtimeState.Name, runtimeState.Version);
+                name = new(runtimeState.Name);
 
                 this.Logger.ReceivedOrchestratorRequest(
                     name,
@@ -205,7 +205,7 @@ sealed partial class GrpcDurableTaskWorker
                     // as part of try/catch.
                     ParentOrchestrationInstance? parent = runtimeState.ParentInstance switch
                     {
-                        ParentInstance p => new(new(p.Name, p.Version), p.OrchestrationInstance.InstanceId),
+                        ParentInstance p => new(new(p.Name), p.OrchestrationInstance.InstanceId),
                         _ => null,
                     };
 
@@ -280,9 +280,7 @@ sealed partial class GrpcDurableTaskWorker
             this.Logger.ReceivedActivityRequest(request.Name, request.TaskId, instance.InstanceId, inputSize);
 
             TaskContext innerContext = new(instance);
-
-            TaskName name = new(request.Name, request.Version);
-
+            TaskName name = new(request.Name);
             string? output = null;
             P.TaskFailureDetails? failureDetails = null;
             try

--- a/src/Worker/Grpc/GrpcOrchestrationRunner.cs
+++ b/src/Worker/Grpc/GrpcOrchestrationRunner.cs
@@ -105,9 +105,9 @@ public static class GrpcOrchestrationRunner
             runtimeState.AddEvent(newEvent);
         }
 
-        TaskName orchestratorName = new(runtimeState.Name, runtimeState.Version);
+        TaskName orchestratorName = new(runtimeState.Name);
         ParentOrchestrationInstance? parent = runtimeState.ParentInstance is ParentInstance p
-            ? new(new(p.Name, p.Version), p.OrchestrationInstance.InstanceId)
+            ? new(new(p.Name), p.OrchestrationInstance.InstanceId)
             : null;
 
         DurableTaskShimFactory factory = services is null


### PR DESCRIPTION
Due to the fact we do not consider `TaskName.Version` as part of equality checks, it is effectively unusable to customers. You cannot register two tasks with the same name, but different versions. Additionally incoming work requests of the same name will always resolve to the same instance regardless of version matching. I am opting to remove the ability to set this for now as it is misleading to customers. We can add it back in when task versioning is actually supported.