### PR TITLE
Extract interface slice from client for code-gen

### DIFF
--- a/src/Abstractions/Client/IOrchestrationSubmitter.cs
+++ b/src/Abstractions/Client/IOrchestrationSubmitter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Client;
+
+/// <summary>
+/// Contract for submitting orchestrations to be ran.
+/// </summary>
+/// <remarks>
+/// <b>Do not</b> implement directly, instead use "DurableTaskClient" from the client package instead. This interface's
+/// only purpose is to expose some methods to the abstraction layer for code generation.
+/// </remarks>
+public interface IOrchestrationSubmitter
+{
+    /// <summary>
+    /// Schedules a new orchestration instance for execution.
+    /// </summary>
+    /// <param name="orchestratorName">The name of the orchestrator to schedule.</param>
+    /// <param name="instanceId">
+    /// The unique ID of the orchestration instance to schedule. If not specified, a randomGUID value is used.
+    /// </param>
+    /// <param name="input">
+    /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
+    /// </param>
+    /// <param name="startTime">
+    /// The time when the orchestration instance should start executing. If not specified or if a date-time in the past
+    /// is specified, the orchestration instance will be scheduled immediately.
+    /// </param>
+    /// <returns>
+    /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
+    /// the instance ID of the scheduled orchestration instance. If a non-null <paramref name="instanceId"/> parameter
+    /// value was provided, the same value will be returned by the completed task.
+    /// </returns>
+    Task<string> ScheduleNewOrchestrationInstanceAsync(
+        TaskName orchestratorName, string? instanceId = null, object? input = null, DateTimeOffset? startTime = null);
+}

--- a/src/Abstractions/Internal/IOrchestrationSubmitter.cs
+++ b/src/Abstractions/Internal/IOrchestrationSubmitter.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.DurableTask.Client;
+namespace Microsoft.DurableTask.Internal;
 
 /// <summary>
-/// Contract for submitting orchestrations to be ran.
+/// This is an internal API that supports the DurableTask infrastructure and not subject to
+/// the same compatibility standards as public APIs. It may be changed or removed without notice in
+/// any release. You should only use it directly in your code with extreme caution and knowing that
+/// doing so can result in application failures when updating to a new DurableTask release.
 /// </summary>
 /// <remarks>
 /// <b>Do not</b> implement directly, instead use "DurableTaskClient" from the client package instead. This interface's
@@ -14,6 +17,10 @@ public interface IOrchestrationSubmitter
 {
     /// <summary>
     /// Schedules a new orchestration instance for execution.
+    /// This is an internal API that supports the DurableTask infrastructure and not subject to
+    /// the same compatibility standards as public APIs. It may be changed or removed without notice in
+    /// any release. You should only use it directly in your code with extreme caution and knowing that
+    /// doing so can result in application failures when updating to a new DurableTask release.
     /// </summary>
     /// <param name="orchestratorName">The name of the orchestrator to schedule.</param>
     /// <param name="instanceId">

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DurableTask.Client;
 /// performance.
 /// </para>
 /// </remarks>
-public abstract class DurableTaskClient : IAsyncDisposable
+public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DurableTaskClient"/> class.
@@ -87,10 +87,7 @@ public abstract class DurableTaskClient : IAsyncDisposable
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="orchestratorName"/> is empty.</exception>
     public abstract Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName,
-        string? instanceId = null,
-        object? input = null,
-        DateTimeOffset? startTime = null);
+        TaskName orchestratorName, string? instanceId = null, object? input = null, DateTimeOffset? startTime = null);
 
     /// <summary>
     /// Sends an event notification message to a waiting orchestration instance.

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.DurableTask.Internal;
+
 namespace Microsoft.DurableTask.Client;
 
 /// <summary>


### PR DESCRIPTION
This PR extracts a very small interface from `DurableTaskClient` into the Abstractions layer to enable code-generation. Instead of moving all the client types over to abstractions, this smaller contract was chosen to be extracted as this is the only method code-generation will need for now. This interface is public, but lives in the `Microsoft.DurableTask.Internal` namespace and has a disclaimer telling customers to not use it directly.