### PR TITLE
Refactor TaskOptions, wrap InstanceId into them

### DIFF
--- a/src/Abstractions/Internal/IOrchestrationSubmitter.cs
+++ b/src/Abstractions/Internal/IOrchestrationSubmitter.cs
@@ -23,21 +23,15 @@ public interface IOrchestrationSubmitter
     /// doing so can result in application failures when updating to a new DurableTask release.
     /// </summary>
     /// <param name="orchestratorName">The name of the orchestrator to schedule.</param>
-    /// <param name="instanceId">
-    /// The unique ID of the orchestration instance to schedule. If not specified, a randomGUID value is used.
-    /// </param>
     /// <param name="input">
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
-    /// <param name="startTime">
-    /// The time when the orchestration instance should start executing. If not specified or if a date-time in the past
-    /// is specified, the orchestration instance will be scheduled immediately.
-    /// </param>
+    /// <param name="options">The options to start the new orchestration with.</param>
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
-    /// the instance ID of the scheduled orchestration instance. If a non-null <paramref name="instanceId"/> parameter
-    /// value was provided, the same value will be returned by the completed task.
+    /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
+    /// <paramref name="options" />, the same value will be returned by the completed task.
     /// </returns>
     Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName, string? instanceId = null, object? input = null, DateTimeOffset? startTime = null);
+        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null);
 }

--- a/src/Abstractions/TaskOptions.cs
+++ b/src/Abstractions/TaskOptions.cs
@@ -41,54 +41,44 @@ public record TaskOptions
     /// </summary>
     /// <param name="handler">The handler to convert from.</param>
     /// <returns>A <see cref="TaskOptions" /> built from the handler.</returns>
-    public static TaskOptions FromRetryHandler(RetryHandler handler)
-    {
-        Check.NotNull(handler);
-        return FromRetryHandler(context => Task.FromResult(handler.Invoke(context)));
-    }
+    public static TaskOptions FromRetryHandler(RetryHandler handler) => new(handler);
 
     /// <summary>
-    /// Returns a new <see cref="OrchestrationOptions" /> with the provided instance ID. This can be used when starting
-    /// a new sub-orchestration to specify the instance ID.
+    /// Returns a new <see cref="SubOrchestrationOptions" /> with the provided instance ID. This can be used when
+    /// starting a new sub-orchestration to specify the instance ID.
     /// </summary>
     /// <param name="instanceId">The instance ID to use.</param>
-    /// <returns>A new <see cref="OrchestrationOptions" />.</returns>
-    public OrchestrationOptions WithInstanceId(string instanceId) => new(this, instanceId);
-
-    /// <summary>
-    /// Gets the instance ID, if available, for this options instance.
-    /// </summary>
-    /// <returns>The orchestration instance ID if available, <c>null</c> otherwise.</returns>
-    internal string? GetInstanceId() => this is OrchestrationOptions options ? options.InstanceId : null;
+    /// <returns>A new <see cref="SubOrchestrationOptions" />.</returns>
+    public SubOrchestrationOptions WithInstanceId(string instanceId) => new(this, instanceId);
 }
 
 /// <summary>
 /// Options that can be used to control the behavior of orchestrator task execution. This derived type can be used to
 /// supply extra options for orchestrations.
 /// </summary>
-public record OrchestrationOptions : TaskOptions
+public record SubOrchestrationOptions : TaskOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrchestrationOptions"/> class.
+    /// Initializes a new instance of the <see cref="SubOrchestrationOptions"/> class.
     /// </summary>
     /// <param name="retry">The task retry options.</param>
     /// <param name="instanceId">The orchestration instance ID.</param>
-    public OrchestrationOptions(TaskRetryOptions? retry = null, string? instanceId = null)
+    public SubOrchestrationOptions(TaskRetryOptions? retry = null, string? instanceId = null)
         : base(retry)
     {
         this.InstanceId = instanceId;
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrchestrationOptions"/> class.
+    /// Initializes a new instance of the <see cref="SubOrchestrationOptions"/> class.
     /// </summary>
     /// <param name="options">The task options to wrap.</param>
     /// <param name="instanceId">The orchestration instance ID.</param>
-    public OrchestrationOptions(TaskOptions options, string? instanceId = null)
+    public SubOrchestrationOptions(TaskOptions options, string? instanceId = null)
         : base(options)
     {
         this.InstanceId = instanceId;
-        if (instanceId is null && options is OrchestrationOptions derived)
+        if (instanceId is null && options is SubOrchestrationOptions derived)
         {
             this.InstanceId = derived.InstanceId;
         }

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -260,10 +260,9 @@ public abstract class TaskOrchestrationContext
     /// <typeparam name="TResult">
     /// The type into which to deserialize the sub-orchestrator's output.
     /// </typeparam>
-    /// <inheritdoc cref="CallSubOrchestratorAsync(TaskName, string?, object?, TaskOptions?)"/>
+    /// <inheritdoc cref="CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)"/>
     public abstract Task<TResult> CallSubOrchestratorAsync<TResult>(
         TaskName orchestratorName,
-        string? instanceId = null,
         object? input = null,
         TaskOptions? options = null);
 
@@ -291,14 +290,10 @@ public abstract class TaskOrchestrationContext
     /// </para><para>
     /// Because sub-orchestrations are independent of their parents, terminating a parent orchestration does not affect
     /// any sub-orchestrations. You must terminate each sub-orchestration independently using its instance ID, which is
-    /// specified using the <paramref name="instanceId"/>
-    /// parameter.
+    /// specified by supplying <see cref="OrchestrationOptions" /> in place of <see cref="TaskOptions" />.
     /// </para>
     /// </remarks>
     /// <param name="orchestratorName">The name of the orchestrator to call.</param>
-    /// <param name="instanceId">
-    /// A unique ID to use for the sub-orchestration instance. If not specified, a random instance ID will be generated.
-    /// </param>
     /// <param name="input">The serializable input to pass to the sub-orchestrator.</param>
     /// <param name="options">
     /// Additional options that control the execution and processing of the sub-orchestrator.
@@ -314,11 +309,10 @@ public abstract class TaskOrchestrationContext
     /// </exception>
     public Task CallSubOrchestratorAsync(
         TaskName orchestratorName,
-        string? instanceId = null,
         object? input = null,
         TaskOptions? options = null)
     {
-        return this.CallSubOrchestratorAsync<object>(orchestratorName, instanceId, input, options);
+        return this.CallSubOrchestratorAsync<object>(orchestratorName, input, options);
     }
 
     /// <summary>

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -290,13 +290,14 @@ public abstract class TaskOrchestrationContext
     /// </para><para>
     /// Because sub-orchestrations are independent of their parents, terminating a parent orchestration does not affect
     /// any sub-orchestrations. You must terminate each sub-orchestration independently using its instance ID, which is
-    /// specified by supplying <see cref="OrchestrationOptions" /> in place of <see cref="TaskOptions" />.
+    /// specified by supplying <see cref="SubOrchestrationOptions" /> in place of <see cref="TaskOptions" />.
     /// </para>
     /// </remarks>
     /// <param name="orchestratorName">The name of the orchestrator to call.</param>
     /// <param name="input">The serializable input to pass to the sub-orchestrator.</param>
     /// <param name="options">
-    /// Additional options that control the execution and processing of the sub-orchestrator.
+    /// Additional options that control the execution and processing of the sub-orchestrator. Callers can choose to
+    /// supply the derived type <see cref="SubOrchestrationOptions" />.
     /// </param>
     /// <returns>A task that completes when the sub-orchestrator completes or fails.</returns>
     /// <exception cref="ArgumentException">The specified orchestrator does not exist.</exception>

--- a/src/Abstractions/TaskRetryOptions.cs
+++ b/src/Abstractions/TaskRetryOptions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask;
+
+/// <summary>
+/// Task retry options. Can provide either a <see cref="RetryPolicy" /> for declarative retry or a
+/// <see cref="AsyncRetryHandler" /> for imperative retry control.
+/// </summary>
+public sealed class TaskRetryOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskRetryOptions"/> class.
+    /// </summary>
+    /// <param name="policy">The retry policy to use.</param>
+    public TaskRetryOptions(RetryPolicy policy)
+    {
+        this.Policy = Check.NotNull(policy);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskRetryOptions"/> class.
+    /// </summary>
+    /// <param name="handler">The retry handler to use.</param>
+    public TaskRetryOptions(AsyncRetryHandler handler)
+    {
+        this.Handler = Check.NotNull(handler);
+    }
+
+    /// <summary>
+    /// Gets the retry policy. <c>null</c> if <see cref="Handler" /> is set.
+    /// </summary>
+    public RetryPolicy? Policy { get; }
+
+    /// <summary>
+    /// Gets the retry handler. <c>null</c> if <see cref="Policy" /> is set.
+    /// </summary>
+    public AsyncRetryHandler? Handler { get; }
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="RetryPolicy" />.
+    /// </summary>
+    /// <param name="policy">The policy to convert from.</param>
+    public static implicit operator TaskRetryOptions(RetryPolicy policy) => FromRetryPolicy(policy);
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="AsyncRetryHandler" />.
+    /// </summary>
+    /// <param name="handler">The handler to convert from.</param>
+    public static implicit operator TaskRetryOptions(AsyncRetryHandler handler) => FromRetryHandler(handler);
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="RetryHandler" />.
+    /// </summary>
+    /// <param name="handler">The handler to convert from.</param>
+    public static implicit operator TaskRetryOptions(RetryHandler handler) => FromRetryHandler(handler);
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="RetryPolicy" />.
+    /// </summary>
+    /// <param name="policy">The policy to convert from.</param>
+    /// <returns>A <see cref="TaskRetryOptions" /> built from the policy.</returns>
+    public static TaskRetryOptions FromRetryPolicy(RetryPolicy policy) => new(policy);
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="AsyncRetryHandler" />.
+    /// </summary>
+    /// <param name="handler">The handler to convert from.</param>
+    /// <returns>A <see cref="TaskRetryOptions" /> built from the handler.</returns>
+    public static TaskRetryOptions FromRetryHandler(AsyncRetryHandler handler) => new(handler);
+
+    /// <summary>
+    /// Returns a new <see cref="TaskRetryOptions" /> from the provided <see cref="RetryHandler" />.
+    /// </summary>
+    /// <param name="handler">The handler to convert from.</param>
+    /// <returns>A <see cref="TaskRetryOptions" /> built from the handler.</returns>
+    public static TaskRetryOptions FromRetryHandler(RetryHandler handler)
+    {
+        Check.NotNull(handler);
+        return FromRetryHandler(context => Task.FromResult(handler.Invoke(context)));
+    }
+}

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -52,7 +52,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </summary>
     /// <remarks>
     /// <para>All orchestrations must have a unique instance ID. You can provide an instance ID using the
-    /// <paramref name="instanceId"/> parameter or you can omit this parameter and a random instance ID will be
+    /// <paramref name="options"/> parameter or you can omit this and a random instance ID will be
     /// generated for you automatically. If an orchestration with the specified instance ID already exists and is in a
     /// non-terminal state (Pending, Running, etc.), then this operation may fail silently. However, if an orchestration
     /// instance with this ID already exists in a terminal state (Completed, Terminated, Failed, etc.) then the instance
@@ -62,7 +62,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="OrchestrationRuntimeStatus.Pending"/> state and will transition to the
     /// <see cref="OrchestrationRuntimeStatus.Running"/> after successfully awaiting its first task. The exact time it
     /// takes before a scheduled orchestration starts running depends on several factors, including the configuration
-    /// and health of the backend task hub, and whether a <paramref name="startTime"/> value was provided.
+    /// and health of the backend task hub, and whether a start time was provided via <paramref name="options" />.
     /// </para><para>
     /// The task associated with this method completes after the orchestration instance was successfully scheduled. You
     /// can use the <see cref="GetInstanceMetadataAsync"/> to query the status of the scheduled instance, the
@@ -72,24 +72,18 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="orchestratorName">The name of the orchestrator to schedule.</param>
-    /// <param name="instanceId">
-    /// The unique ID of the orchestration instance to schedule. If not specified, a randomGUID value is used.
-    /// </param>
     /// <param name="input">
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
-    /// <param name="startTime">
-    /// The time when the orchestration instance should start executing. If not specified or if a date-time in the past
-    /// is specified, the orchestration instance will be scheduled immediately.
-    /// </param>
+    /// <param name="options">The options to start the new orchestration with.</param>
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
-    /// the instance ID of the scheduled orchestration instance. If a non-null <paramref name="instanceId"/> parameter
-    /// value was provided, the same value will be returned by the completed task.
+    /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
+    /// <paramref name="options" />, the same value will be returned by the completed task.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="orchestratorName"/> is empty.</exception>
     public abstract Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName, string? instanceId = null, object? input = null, DateTimeOffset? startTime = null);
+        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null);
 
     /// <summary>
     /// Sends an event notification message to a waiting orchestration instance.

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -51,29 +51,27 @@ sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName,
-        string? instanceId = null,
-        object? input = null,
-        DateTimeOffset? startTime = null)
+        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null)
     {
         var request = new P.CreateInstanceRequest
         {
             Name = orchestratorName.Name,
             Version = orchestratorName.Version,
-            InstanceId = instanceId ?? Guid.NewGuid().ToString("N"),
+            InstanceId = options?.InstanceId ?? Guid.NewGuid().ToString("N"),
             Input = this.DataConverter.Serialize(input),
         };
 
+        DateTimeOffset? startAt = options?.StartAt;
         this.logger.SchedulingOrchestration(
             request.InstanceId,
             orchestratorName,
             sizeInBytes: request.Input != null ? Encoding.UTF8.GetByteCount(request.Input) : 0,
-            startTime.GetValueOrDefault(DateTimeOffset.UtcNow));
+            startAt.GetValueOrDefault(DateTimeOffset.UtcNow));
 
-        if (startTime.HasValue)
+        if (startAt.HasValue)
         {
             // Convert timestamps to UTC if not already UTC
-            request.ScheduledStartTimestamp = Timestamp.FromDateTimeOffset(startTime.Value.ToUniversalTime());
+            request.ScheduledStartTimestamp = Timestamp.FromDateTimeOffset(startAt.Value.ToUniversalTime());
         }
 
         P.CreateInstanceResponse? result = await this.sidecarClient.StartInstanceAsync(request);

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -88,21 +88,21 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         try
         {
             // TODO: Cancellation (https://github.com/microsoft/durabletask-dotnet/issues/7)
-            if (options?.RetryPolicy != null)
+            if (options?.Retry?.Policy is RetryPolicy policy)
             {
                 return await this.innerContext.ScheduleWithRetry<T>(
                     name.Name,
                     name.Version,
-                    options.RetryPolicy.ToDurableTaskCoreRetryOptions(),
+                    policy.ToDurableTaskCoreRetryOptions(),
                     input);
             }
-            else if (options?.RetryHandler != null)
+            else if (options?.Retry?.Handler is AsyncRetryHandler handler)
             {
                 return await this.InvokeWithCustomRetryHandler(
                     () => this.innerContext.ScheduleTask<T>(name.Name, name.Version, input),
                     name.Name,
-                    options.RetryHandler,
-                    options.CancellationToken);
+                    handler,
+                    default);
             }
             else
             {
@@ -146,24 +146,23 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// <inheritdoc/>
     public override async Task<TResult> CallSubOrchestratorAsync<TResult>(
         TaskName orchestratorName,
-        string? instanceId = null,
         object? input = null,
         TaskOptions? options = null)
     {
         // TODO: Check to see if this orchestrator is defined
-        instanceId ??= this.NewGuid().ToString("N");
+        string instanceId = options?.GetInstanceId() ?? this.NewGuid().ToString("N");
 
         try
         {
-            if (options?.RetryPolicy != null)
+            if (options?.Retry?.Policy is RetryPolicy policy)
             {
                 return await this.innerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
                     orchestratorName.Name,
                     orchestratorName.Version,
-                    options.RetryPolicy.ToDurableTaskCoreRetryOptions(),
+                    policy.ToDurableTaskCoreRetryOptions(),
                     input);
             }
-            else if (options?.RetryHandler != null)
+            else if (options?.Retry?.Handler is AsyncRetryHandler handler)
             {
                 return await this.InvokeWithCustomRetryHandler(
                     () => this.innerContext.CreateSubOrchestrationInstance<TResult>(
@@ -172,8 +171,8 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
                         instanceId,
                         input),
                     orchestratorName.Name,
-                    options.RetryHandler,
-                    options.CancellationToken);
+                    handler,
+                    default);
             }
             else
             {

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -150,7 +150,9 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         TaskOptions? options = null)
     {
         // TODO: Check to see if this orchestrator is defined
-        string instanceId = options?.GetInstanceId() ?? this.NewGuid().ToString("N");
+        static string? GetInstanceId(TaskOptions? options)
+            => options is SubOrchestrationOptions derived ? derived.InstanceId : null;
+        string instanceId = GetInstanceId(options) ?? this.NewGuid().ToString("N");
 
         try
         {

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -106,9 +106,8 @@ public class DefaultDurableTaskClientBuilderTests
 
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
-            string? instanceId = null,
             object? input = null,
-            DateTimeOffset? startTime = null)
+            StartOrchestrationOptions? options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -120,9 +120,8 @@ public class DurableTaskClientBuilderExtensionsTests
 
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
-            string? instanceId = null,
             object? input = null,
-            DateTimeOffset? startTime = null)
+            StartOrchestrationOptions? options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -98,7 +98,8 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
             OrchestrationName, input: false);
 
         await ForEachOrchestrationAsync(
-            x => server.Client.ScheduleNewOrchestrationInstanceAsync(OrchestrationName, x, input: false));
+            x => server.Client.ScheduleNewOrchestrationInstanceAsync(
+                OrchestrationName, input: false, new() { InstanceId = x }));
         AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);
 
         await ForEachOrchestrationAsync(x => server.Client.WaitForInstanceStartAsync(x, default));
@@ -124,7 +125,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         for (int i = 0; i < 21; i++)
         {
             await server.Client.ScheduleNewOrchestrationInstanceAsync(
-                OrchestrationName, $"GetInstances_AsPages_EndToEnd-{i}", input: false);
+                OrchestrationName, input: false, new() { InstanceId = $"GetInstances_AsPages_EndToEnd-{i}" });
         }
 
         AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);


### PR DESCRIPTION
A problem that arose while working on code-generation was parameter ordering inconsistencies between the stringly-typed methods and generated methods. This PR aims to improve this, while also setting up our APIs to be able to expand input options without breaking changes.

### Summary of Changes:

- Refactor `TaskOptions` to be a record type
    - records `with { }` operator is a perfect fit for these options.
- Removed `CancellationToken` from `TaskOptions`. We can add it in without breaking anything when we do intend to support it.
    - I also removed it because I am unsure if having cancellation as a property on the options is the correct choice, or if it should be its own parameter to mesh with cancellation token practices better.
- Pulled the retry options into their own type that uses implicit operators to give a union-esque behavior.
- Added `OrchestrationOptions`, a derived `TaskOptions` which allows for specifying instance ID.
    - `TaskOrchestrationContext` sub-orchestration overloads which take in instance ID have been removed. Instead, you pass in the derived options type and the implementation will use `GetInstanceId()` to see if a specified instance ID was supplied.
- A similar approach was taken for `DurableTaskClient.ScheduleNewOrchestrationInstanceAsync`. Instance ID and start-time are now wrapped into a single `StartOrchestrationOptions` object.