### PR TITLE
Auto-register default DurableTaskClient. Fix multiple registrations

### DIFF
--- a/src/Client/Core/DependencyInjection/DefaultDurableTaskClientProvider.cs
+++ b/src/Client/Core/DependencyInjection/DefaultDurableTaskClientProvider.cs
@@ -10,13 +10,13 @@ namespace Microsoft.DurableTask.Client;
 /// </summary>
 class DefaultDurableTaskClientProvider : IDurableTaskClientProvider
 {
-    readonly IEnumerable<DurableTaskClient> clients;
+    readonly IEnumerable<ClientContainer> clients;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultDurableTaskClientProvider"/> class.
     /// </summary>
     /// <param name="clients">The set of clients.</param>
-    public DefaultDurableTaskClientProvider(IEnumerable<DurableTaskClient> clients)
+    public DefaultDurableTaskClientProvider(IEnumerable<ClientContainer> clients)
     {
         this.clients = clients;
     }
@@ -25,7 +25,7 @@ class DefaultDurableTaskClientProvider : IDurableTaskClientProvider
     public DurableTaskClient GetClient(string? name = null)
     {
         name ??= Options.DefaultName;
-        DurableTaskClient? client = this.clients.FirstOrDefault(
+        ClientContainer? client = this.clients.FirstOrDefault(
             x => string.Equals(name, x.Name, StringComparison.Ordinal)); // options are case sensitive.
 
         if (client is null)
@@ -35,6 +35,31 @@ class DefaultDurableTaskClientProvider : IDurableTaskClientProvider
                 nameof(name), name, $"The value of this argument must be in the set of available clients: [{names}].");
         }
 
-        return client;
+        return client.Client;
+    }
+
+    /// <summary>
+    /// Container for holding a client in memory.
+    /// </summary>
+    internal class ClientContainer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientContainer"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        public ClientContainer(DurableTaskClient client)
+        {
+            this.Client = Check.NotNull(client);
+        }
+
+        /// <summary>
+        /// Gets the client name.
+        /// </summary>
+        public string Name => this.Client.Name;
+
+        /// <summary>
+        /// Gets the client.
+        /// </summary>
+        public DurableTaskClient Client { get; }
     }
 }

--- a/src/Client/Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Client/Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,7 +43,16 @@ public static class ServiceCollectionExtensions
             // The added toggle logic is because we cannot use TryAddEnumerable logic as
             // we would have to dynamically compile a lambda to have it work correctly.
             ConfigureDurableOptions(services, name);
-            services.AddSingleton(sp => builder.Build(sp));
+
+            // We do not want to register DurableTaskClient type directly so we can keep a max of 1 DurableTaskClients
+            // registered, allowing for direct-DI of the default client.
+            services.AddSingleton(sp => new DefaultDurableTaskClientProvider.ClientContainer(builder.Build(sp)));
+
+            if (name == Options.DefaultName)
+            {
+                // If we have the default options name here, we will inject this client directly.
+                builder.RegisterDirectly();
+            }
         }
 
         return services;

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientProviderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientProviderTests.cs
@@ -40,12 +40,12 @@ public class DefaultDurableTaskClientProviderTests
         client.Name.Should().Be("client1");
     }
 
-    static List<DurableTaskClient> CreateClients(params string[] names)
+    static List<DefaultDurableTaskClientProvider.ClientContainer> CreateClients(params string[] names)
     {
         return names.Select(n =>
         {
             Mock<DurableTaskClient> client = new(n, new DurableTaskClientOptions());
-            return client.Object;
+            return new DefaultDurableTaskClientProvider.ClientContainer(client.Object);
         }).ToList();
     }
 }

--- a/test/Client/Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -28,6 +28,19 @@ public class ServiceCollectionExtensionsTests
         services.AddDurableTaskClient(builder => { });
         services.Should().ContainSingle(
             x => x.ServiceType == typeof(IDurableTaskClientProvider) && x.Lifetime == ServiceLifetime.Singleton);
+        services.Should().ContainSingle(
+            x => x.ServiceType == typeof(DurableTaskClient) && x.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddDurableTaskClient_Named_HostedServiceAdded()
+    {
+        ServiceCollection services = new();
+        services.AddDurableTaskClient("named", builder => { });
+        services.Should().ContainSingle(
+            x => x.ServiceType == typeof(IDurableTaskClientProvider) && x.Lifetime == ServiceLifetime.Singleton);
+        services.Should().NotContain(
+            x => x.ServiceType == typeof(DurableTaskClient) && x.Lifetime == ServiceLifetime.Singleton);
     }
 
     [Fact]


### PR DESCRIPTION
This PR performs two key changes:

1. Fixes an issue where we would register multiple `DurableTaskClient` to the DI container, hampering the ability to directly import a client in the multi-client scenario.
2. Auto-registers the default client directly to the DI container. This will help the common scenario with default (nameless) `DurableTaskClient`s.