### PR TITLE
Allow for inheriting DurableTask client/worker options

### DIFF
--- a/samples/NetFxConsoleApp/Program.cs
+++ b/samples/NetFxConsoleApp/Program.cs
@@ -24,7 +24,7 @@ namespace NetFxConsoleApp
                 });
             });
 
-            Channel channel = new("127.0.0.1:4001", ChannelCredentials.Insecure);
+            Channel channel = new("localhost:4001", ChannelCredentials.Insecure);
 
             DurableTaskGrpcWorker worker = DurableTaskGrpcWorker.CreateBuilder()
                 .AddTasks(tasks =>

--- a/src/Abstractions/Converters/JsonDataConverter.cs
+++ b/src/Abstractions/Converters/JsonDataConverter.cs
@@ -18,7 +18,11 @@ public class JsonDataConverter : DataConverter
 
     readonly JsonSerializerOptions? options;
 
-    JsonDataConverter(JsonSerializerOptions? options = null)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonDataConverter"/> class.
+    /// </summary>
+    /// <param name="options">The serializer options.</param>
+    public JsonDataConverter(JsonSerializerOptions? options = null)
     {
         this.options = options ?? DefaultOptions;
     }

--- a/src/Client/Core/DependencyInjection/DefaultDurableTaskClientBuilder.cs
+++ b/src/Client/Core/DependencyInjection/DefaultDurableTaskClientBuilder.cs
@@ -56,9 +56,7 @@ public class DefaultDurableTaskClientBuilder : IDurableTaskClientBuilder
                 + " 'UseBuildTarget(Type target)'. An example of a valid client is '.UseGrpc()'.");
         }
 
-        DurableTaskClientOptions options = serviceProvider.GetOptions<DurableTaskClientOptions>(this.Name);
-        return (DurableTaskClient)ActivatorUtilities.CreateInstance(
-            serviceProvider, this.buildTarget, this.Name, options);
+        return (DurableTaskClient)ActivatorUtilities.CreateInstance(serviceProvider, this.buildTarget, this.Name);
     }
 
     static bool IsValidBuildTarget(Type? type)

--- a/src/Client/Core/DependencyInjection/DefaultDurableTaskClientProvider.cs
+++ b/src/Client/Core/DependencyInjection/DefaultDurableTaskClientProvider.cs
@@ -41,7 +41,7 @@ class DefaultDurableTaskClientProvider : IDurableTaskClientProvider
     /// <summary>
     /// Container for holding a client in memory.
     /// </summary>
-    internal class ClientContainer
+    internal class ClientContainer : IAsyncDisposable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientContainer"/> class.
@@ -61,5 +61,8 @@ class DefaultDurableTaskClientProvider : IDurableTaskClientProvider
         /// Gets the client.
         /// </summary>
         public DurableTaskClient Client { get; }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync() => this.Client.DisposeAsync();
     }
 }

--- a/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class DurableTaskBuilderExtensions
     {
         builder.UseBuildTarget(typeof(TTarget));
         builder.Services.AddOptions<TOptions>(builder.Name)
-            .Configure<IOptionsMonitor<DurableTaskClientOptions>>((options, baseOptions) =>
+            .PostConfigure<IOptionsMonitor<DurableTaskClientOptions>>((options, baseOptions) =>
             {
                 DurableTaskClientOptions input = baseOptions.Get(builder.Name);
                 input.ApplyTo(options);

--- a/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DurableTask.Client;
 
@@ -66,4 +67,26 @@ public static class DurableTaskBuilderExtensions
     public static IDurableTaskClientBuilder UseBuildTarget<TTarget>(this IDurableTaskClientBuilder builder)
         where TTarget : DurableTaskClient
         => builder.UseBuildTarget(typeof(TTarget));
+
+    /// <summary>
+    /// Sets the build target for this builder. Additionally populates default options values for the provided
+    /// <typeparamref name="TOptions" />.
+    /// </summary>
+    /// <typeparam name="TTarget">The builder target type.</typeparam>
+    /// <typeparam name="TOptions">The options for this builder.</typeparam>
+    /// <param name="builder">The builder to set the builder target for.</param>
+    /// <returns>The original builder, for call chaining.</returns>
+    public static IDurableTaskClientBuilder UseBuildTarget<TTarget, TOptions>(this IDurableTaskClientBuilder builder)
+        where TTarget : DurableTaskClient
+        where TOptions : DurableTaskClientOptions
+    {
+        builder.UseBuildTarget(typeof(TTarget));
+        builder.Services.AddOptions<TOptions>(builder.Name)
+            .Configure<IOptionsMonitor<DurableTaskClientOptions>>((options, baseOptions) =>
+            {
+                DurableTaskClientOptions input = baseOptions.Get(builder.Name);
+                input.ApplyTo(options);
+            });
+        return builder;
+    }
 }

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -30,22 +30,15 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// Initializes a new instance of the <see cref="DurableTaskClient"/> class.
     /// </summary>
     /// <param name="name">The name of the client.</param>
-    /// <param name="options">The client options.</param>
-    protected DurableTaskClient(string name, DurableTaskClientOptions options)
+    protected DurableTaskClient(string name)
     {
         this.Name = name;
-        this.Options = options;
     }
 
     /// <summary>
     /// Gets the name of the client.
     /// </summary>
     public string Name { get; }
-
-    /// <summary>
-    /// Gets the common client options.
-    /// </summary>
-    protected DurableTaskClientOptions Options { get; }
 
     /// <summary>
     /// Schedules a new orchestration instance for execution.

--- a/src/Client/Core/DurableTaskClientOptions.cs
+++ b/src/Client/Core/DurableTaskClientOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DurableTask.Client;
 /// <summary>
 /// Common options for <see cref="DurableTaskClient" />.
 /// </summary>
-public sealed class DurableTaskClientOptions
+public class DurableTaskClientOptions
 {
     DataConverter dataConverter = JsonDataConverter.Default;
 
@@ -56,4 +56,17 @@ public sealed class DurableTaskClientOptions
     /// behavior is consistently irrespective of option configuration ordering.
     /// </remarks>
     internal bool DataConverterExplicitlySet { get; private set; }
+
+    /// <summary>
+    /// Applies these option values to another.
+    /// </summary>
+    /// <param name="other">The other options object to apply to.</param>
+    internal void ApplyTo(DurableTaskClientOptions other)
+    {
+        if (other is not null)
+        {
+            // Make sure to keep this up to date as values are added.
+            other.DataConverter = this.DataConverter;
+        }
+    }
 }

--- a/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -60,6 +60,6 @@ public static class DurableTaskClientBuilderExtensions
         this IDurableTaskClientBuilder builder, Action<GrpcDurableTaskClientOptions> configure)
     {
         builder.Services.Configure(builder.Name, configure);
-        return builder.UseBuildTarget<GrpcDurableTaskClient>();
+        return builder.UseBuildTarget<GrpcDurableTaskClient, GrpcDurableTaskClientOptions>();
     }
 }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -335,7 +335,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             return default;
         }
 
-        string address = string.IsNullOrEmpty(this.options.Address) ? "127.0.0.1:4001" : this.options.Address!;
+        string address = string.IsNullOrEmpty(this.options.Address) ? "localhost:4001" : this.options.Address!;
 
         // TODO: use SSL channel by default?
         c = new(address, ChannelCredentials.Insecure);

--- a/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DurableTask.Client.Grpc;
 /// <summary>
 /// The gRPC client options.
 /// </summary>
-public sealed class GrpcDurableTaskClientOptions
+public sealed class GrpcDurableTaskClientOptions : DurableTaskClientOptions
 {
     /// <summary>
     /// Gets or sets the address of the gRPC endpoint to connect to. Default is 127.0.0.1:4001.

--- a/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DurableTask.Client.Grpc;
 public sealed class GrpcDurableTaskClientOptions : DurableTaskClientOptions
 {
     /// <summary>
-    /// Gets or sets the address of the gRPC endpoint to connect to. Default is 127.0.0.1:4001.
+    /// Gets or sets the address of the gRPC endpoint to connect to. Default is localhost:4001.
     /// </summary>
     public string? Address { get; set; }
 

--- a/src/Worker/Core/DependencyInjection/DefaultDurableTaskWorkerBuilder.cs
+++ b/src/Worker/Core/DependencyInjection/DefaultDurableTaskWorkerBuilder.cs
@@ -10,16 +10,16 @@ namespace Microsoft.DurableTask.Worker;
 /// <summary>
 /// The default builder for durable task.
 /// </summary>
-public class DefaultDurableTaskBuilder : IDurableTaskBuilder
+public class DefaultDurableTaskWorkerBuilder : IDurableTaskWorkerBuilder
 {
     Type? buildTarget;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DefaultDurableTaskBuilder" /> class.
+    /// Initializes a new instance of the <see cref="DefaultDurableTaskWorkerBuilder" /> class.
     /// </summary>
     /// <param name="services">The service collection for this builder.</param>
     /// <param name="name">The name for this builder.</param>
-    public DefaultDurableTaskBuilder(string? name, IServiceCollection services)
+    public DefaultDurableTaskWorkerBuilder(string? name, IServiceCollection services)
     {
         this.Name = name ?? Extensions.Options.Options.DefaultName;
         this.Services = Check.NotNull(services);
@@ -54,8 +54,7 @@ public class DefaultDurableTaskBuilder : IDurableTaskBuilder
         Verify.NotNull(this.buildTarget, error);
 
         DurableTaskRegistry registry = serviceProvider.GetOptions<DurableTaskRegistry>(this.Name);
-        DurableTaskWorkerOptions options = serviceProvider.GetOptions<DurableTaskWorkerOptions>(this.Name);
         return (IHostedService)ActivatorUtilities.CreateInstance(
-            serviceProvider, this.buildTarget, this.Name, registry.BuildFactory(), options);
+            serviceProvider, this.buildTarget, this.Name, registry.BuildFactory());
     }
 }

--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -79,7 +79,7 @@ public static class DurableTaskWorkerBuilderExtensions
     {
         builder.UseBuildTarget(typeof(TTarget));
         builder.Services.AddOptions<TOptions>(builder.Name)
-            .Configure<IOptionsMonitor<DurableTaskWorkerOptions>>((options, baseOptions) =>
+            .PostConfigure<IOptionsMonitor<DurableTaskWorkerOptions>>((options, baseOptions) =>
             {
                 DurableTaskWorkerOptions input = baseOptions.Get(builder.Name);
                 input.ApplyTo(options);

--- a/src/Worker/Core/DependencyInjection/IDurableTaskWorkerBuilder.cs
+++ b/src/Worker/Core/DependencyInjection/IDurableTaskWorkerBuilder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DurableTask.Worker;
 /// <summary>
 /// Contract for building DurableTask worker.
 /// </summary>
-public interface IDurableTaskBuilder
+public interface IDurableTaskWorkerBuilder
 {
     /// <summary>
     /// Gets the name of this builder.

--- a/src/Worker/Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class ServiceCollectionExtensions
     /// <param name="configure">The callback to configure the builder.</param>
     /// <returns>The service collection for call chaining.</returns>
     public static IServiceCollection AddDurableTaskWorker(
-        this IServiceCollection services, Action<IDurableTaskBuilder> configure)
+        this IServiceCollection services, Action<IDurableTaskWorkerBuilder> configure)
     {
         Check.NotNull(services);
         Check.NotNull(configure);
@@ -33,13 +33,13 @@ public static class ServiceCollectionExtensions
     /// <param name="configure">The callback to configure the builder.</param>
     /// <returns>The service collection for call chaining.</returns>
     public static IServiceCollection AddDurableTaskWorker(
-        this IServiceCollection services, string name, Action<IDurableTaskBuilder> configure)
+        this IServiceCollection services, string name, Action<IDurableTaskWorkerBuilder> configure)
     {
         Check.NotNull(services);
         Check.NotNull(name);
         Check.NotNull(configure);
 
-        IDurableTaskBuilder builder = GetBuilder(services, name, out bool added);
+        IDurableTaskWorkerBuilder builder = GetBuilder(services, name, out bool added);
         configure.Invoke(builder);
 
         if (added)
@@ -68,7 +68,7 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    static IDurableTaskBuilder GetBuilder(IServiceCollection services, string name, out bool added)
+    static IDurableTaskWorkerBuilder GetBuilder(IServiceCollection services, string name, out bool added)
     {
         // To ensure the builders are tracked with this service collection, we use a singleton service descriptor as a
         // holder for all builders.
@@ -89,7 +89,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     class BuilderContainer
     {
-        readonly Dictionary<string, IDurableTaskBuilder> builders = new();
+        readonly Dictionary<string, IDurableTaskWorkerBuilder> builders = new();
         readonly IServiceCollection services;
 
         public BuilderContainer(IServiceCollection services)
@@ -97,12 +97,12 @@ public static class ServiceCollectionExtensions
             this.services = services;
         }
 
-        public IDurableTaskBuilder GetOrAdd(string name, out bool added)
+        public IDurableTaskWorkerBuilder GetOrAdd(string name, out bool added)
         {
             added = false;
-            if (!this.builders.TryGetValue(name, out IDurableTaskBuilder builder))
+            if (!this.builders.TryGetValue(name, out IDurableTaskWorkerBuilder builder))
             {
-                builder = new DefaultDurableTaskBuilder(name, this.services);
+                builder = new DefaultDurableTaskWorkerBuilder(name, this.services);
                 this.builders[name] = builder;
                 added = true;
             }

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DurableTask.Worker;
 /// <summary>
 /// Options for the Durable Task worker.
 /// </summary>
-public sealed class DurableTaskWorkerOptions
+public class DurableTaskWorkerOptions
 {
     DataConverter dataConverter = JsonDataConverter.Default;
 
@@ -87,4 +87,18 @@ public sealed class DurableTaskWorkerOptions
     /// behavior is consistently irrespective of option configuration ordering.
     /// </remarks>
     internal bool DataConverterExplicitlySet { get; private set; }
+
+    /// <summary>
+    /// Applies these option values to another.
+    /// </summary>
+    /// <param name="other">The other options object to apply to.</param>
+    internal void ApplyTo(DurableTaskWorkerOptions other)
+    {
+        if (other is not null)
+        {
+            // Make sure to keep this up to date as values are added.
+            other.DataConverter = this.DataConverter;
+            other.MaximumTimerInterval = this.MaximumTimerInterval;
+        }
+    }
 }

--- a/src/Worker/Core/Hosting/DurableTaskWorker.cs
+++ b/src/Worker/Core/Hosting/DurableTaskWorker.cs
@@ -15,13 +15,10 @@ public abstract class DurableTaskWorker : BackgroundService
     /// </summary>
     /// <param name="name">The name of the worker.</param>
     /// <param name="factory">The durable factory.</param>
-    /// <param name="options">The worker options.</param>
-    protected DurableTaskWorker(
-        string? name, IDurableTaskFactory factory, DurableTaskWorkerOptions options)
+    protected DurableTaskWorker(string? name, IDurableTaskFactory factory)
     {
         this.Name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
         this.Factory = Check.NotNull(factory);
-        this.Options = Check.NotNull(options);
     }
 
     /// <summary>
@@ -34,9 +31,4 @@ public abstract class DurableTaskWorker : BackgroundService
     /// the configured tasks during host construction.
     /// </summary>
     protected virtual IDurableTaskFactory Factory { get; }
-
-    /// <summary>
-    /// Gets the worker options.
-    /// </summary>
-    protected virtual DurableTaskWorkerOptions Options { get; }
 }

--- a/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -8,23 +8,23 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.DurableTask.Worker;
 
 /// <summary>
-/// Extension methods for registering gRPC to <see cref="IDurableTaskBuilder" />.
+/// Extension methods for registering gRPC to <see cref="IDurableTaskWorkerBuilder" />.
 /// </summary>
-public static class DurableTaskBuilderExtensions
+public static class DurableTaskWorkerBuilderExtensions
 {
     /// <summary>
-    /// Configures the <see cref="IDurableTaskBuilder" /> to use the gRPC worker.
+    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to use the gRPC worker.
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
     /// <returns>The original builder, for call chaining.</returns>
     /// <remarks>
     /// <b>Note:</b> only 1 instance of gRPC worker is supported per sidecar.
     /// </remarks>
-    public static IDurableTaskBuilder UseGrpc(this IDurableTaskBuilder builder)
+    public static IDurableTaskWorkerBuilder UseGrpc(this IDurableTaskWorkerBuilder builder)
         => builder.UseGrpc(opt => { });
 
     /// <summary>
-    /// Configures the <see cref="IDurableTaskBuilder" /> to use the gRPC worker.
+    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to use the gRPC worker.
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
     /// <param name="channel">The gRPC channel to use.</param>
@@ -32,11 +32,11 @@ public static class DurableTaskBuilderExtensions
     /// <remarks>
     /// <b>Note:</b> only 1 instance of gRPC worker is supported per sidecar.
     /// </remarks>
-    public static IDurableTaskBuilder UseGrpc(this IDurableTaskBuilder builder, Channel channel)
+    public static IDurableTaskWorkerBuilder UseGrpc(this IDurableTaskWorkerBuilder builder, Channel channel)
         => builder.UseGrpc(opt => opt.Channel = channel);
 
     /// <summary>
-    /// Configures the <see cref="IDurableTaskBuilder" /> to use the gRPC worker.
+    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to use the gRPC worker.
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
     /// <param name="address">The gRPC address to use.</param>
@@ -44,11 +44,11 @@ public static class DurableTaskBuilderExtensions
     /// <remarks>
     /// <b>Note:</b> only 1 instance of gRPC worker is supported per sidecar.
     /// </remarks>
-    public static IDurableTaskBuilder UseGrpc(this IDurableTaskBuilder builder, string address)
+    public static IDurableTaskWorkerBuilder UseGrpc(this IDurableTaskWorkerBuilder builder, string address)
         => builder.UseGrpc(opt => opt.Address = address);
 
     /// <summary>
-    /// Configures the <see cref="IDurableTaskBuilder" /> to use the gRPC worker.
+    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to use the gRPC worker.
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
     /// <param name="configure">The callback for configuring gRPC options.</param>
@@ -56,12 +56,12 @@ public static class DurableTaskBuilderExtensions
     /// <remarks>
     /// <b>Note:</b> only 1 instance of gRPC worker is supported per sidecar.
     /// </remarks>
-    public static IDurableTaskBuilder UseGrpc(
-        this IDurableTaskBuilder builder, Action<GrpcDurableTaskWorkerOptions> configure)
+    public static IDurableTaskWorkerBuilder UseGrpc(
+        this IDurableTaskWorkerBuilder builder, Action<GrpcDurableTaskWorkerOptions> configure)
     {
         Check.NotNull(builder);
         Check.NotNull(configure);
         builder.Services.Configure(builder.Name, configure);
-        return builder.UseBuildTarget<GrpcDurableTaskWorker>();
+        return builder.UseBuildTarget<GrpcDurableTaskWorker, GrpcDurableTaskWorkerOptions>();
     }
 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -30,7 +30,7 @@ sealed partial class GrpcDurableTaskWorker
         {
             this.worker = worker;
             this.sidecar = sidecar;
-            this.shimFactory = new DurableTaskShimFactory(this.worker.Options, this.worker.loggerFactory);
+            this.shimFactory = new DurableTaskShimFactory(this.worker.options, this.worker.loggerFactory);
         }
 
         ILogger Logger => this.worker.logger;

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -56,7 +56,7 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
             return default;
         }
 
-        string address = string.IsNullOrEmpty(this.options.Address) ? "127.0.0.1:4001" : this.options.Address!;
+        string address = string.IsNullOrEmpty(this.options.Address) ? "localhost:4001" : this.options.Address!;
 
         // TODO: use SSL channel by default?
         c = new(address, ChannelCredentials.Insecure);

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DurableTask.Worker.Grpc;
 /// </summary>
 sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
 {
-    readonly GrpcDurableTaskWorkerOptions grpcOptions;
+    readonly GrpcDurableTaskWorkerOptions options;
     readonly IServiceProvider services;
     readonly ILoggerFactory loggerFactory;
     readonly ILogger logger;
@@ -23,20 +23,18 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
     /// </summary>
     /// <param name="name">The name of the worker.</param>
     /// <param name="factory">The task factory.</param>
-    /// <param name="options">The common worker options.</param>
-    /// <param name="grpcOptions">The gRPC worker options.</param>
+    /// <param name="options">The gRPC worker options.</param>
     /// <param name="services">The service provider.</param>
     /// <param name="loggerFactory">The logger.</param>
     public GrpcDurableTaskWorker(
         string name,
         IDurableTaskFactory factory,
-        DurableTaskWorkerOptions options,
-        IOptionsMonitor<GrpcDurableTaskWorkerOptions> grpcOptions,
+        IOptionsMonitor<GrpcDurableTaskWorkerOptions> options,
         IServiceProvider services,
         ILoggerFactory loggerFactory)
-        : base(name, factory, options)
+        : base(name, factory)
     {
-        this.grpcOptions = Check.NotNull(grpcOptions).Get(name);
+        this.options = Check.NotNull(options).Get(name);
         this.services = Check.NotNull(services);
         this.loggerFactory = Check.NotNull(loggerFactory);
         this.logger = loggerFactory.CreateLogger("Microsoft.DurableTask"); // TODO: use better category name.
@@ -52,13 +50,13 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
 
     AsyncDisposable BuildChannel(out Channel channel)
     {
-        if (this.grpcOptions.Channel is Channel c)
+        if (this.options.Channel is Channel c)
         {
             channel = c;
             return default;
         }
 
-        string address = string.IsNullOrEmpty(this.grpcOptions.Address) ? "127.0.0.1:4001" : this.grpcOptions.Address!;
+        string address = string.IsNullOrEmpty(this.options.Address) ? "127.0.0.1:4001" : this.options.Address!;
 
         // TODO: use SSL channel by default?
         c = new(address, ChannelCredentials.Insecure);

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DurableTask.Worker.Grpc;
 /// <summary>
 /// The gRPC worker options.
 /// </summary>
-public sealed class GrpcDurableTaskWorkerOptions
+public sealed class GrpcDurableTaskWorkerOptions : DurableTaskWorkerOptions
 {
     /// <summary>
     /// Gets or sets the address of the gRPC endpoint to connect to. Default is 127.0.0.1:4001.

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DurableTask.Worker.Grpc;
 public sealed class GrpcDurableTaskWorkerOptions : DurableTaskWorkerOptions
 {
     /// <summary>
-    /// Gets or sets the address of the gRPC endpoint to connect to. Default is 127.0.0.1:4001.
+    /// Gets or sets the address of the gRPC endpoint to connect to. Default is localhost:4001.
     /// </summary>
     public string? Address { get; set; }
 

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DurableTask.Client.Tests;
 
@@ -61,14 +62,15 @@ public class DefaultDurableTaskClientBuilderTests
 
     class GoodBuildTarget : DurableTaskClient
     {
-        public GoodBuildTarget(string name, DurableTaskClientOptions options)
-            : base(name, options)
+        public GoodBuildTarget(string name, IOptionsMonitor<DurableTaskClientOptions> options)
+            : base(name)
         {
+            this.Options = options.Get(name);
         }
 
         public new string Name => base.Name;
 
-        public new DurableTaskClientOptions Options => base.Options;
+        public DurableTaskClientOptions Options { get; }
 
         public override ValueTask DisposeAsync()
         {

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientProviderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientProviderTests.cs
@@ -44,7 +44,7 @@ public class DefaultDurableTaskClientProviderTests
     {
         return names.Select(n =>
         {
-            Mock<DurableTaskClient> client = new(n, new DurableTaskClientOptions());
+            Mock<DurableTaskClient> client = new(n);
             return new DefaultDurableTaskClientProvider.ClientContainer(client.Object);
         }).ToList();
     }

--- a/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -29,19 +29,19 @@ public class DurableTaskClientBuilderExtensionsTests
     {
         ServiceCollection services = new();
         DefaultDurableTaskClientBuilder builder = new(null, services);
-        builder.UseGrpc("127.0.0.1:9001");
+        builder.UseGrpc("localhost:9001");
 
         IServiceProvider provider = services.BuildServiceProvider();
         GrpcDurableTaskClientOptions options = provider.GetOptions<GrpcDurableTaskClientOptions>();
 
-        options.Address.Should().Be("127.0.0.1:9001");
+        options.Address.Should().Be("localhost:9001");
         options.Channel.Should().BeNull();
     }
 
     [Fact]
     public void UseGrpc_Channel_Sets()
     {
-        Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
+        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
         DefaultDurableTaskClientBuilder builder = new(null, services);
         builder.UseGrpc(c);
@@ -56,7 +56,7 @@ public class DurableTaskClientBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Callback_Sets()
     {
-        Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
+        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
         DefaultDurableTaskClientBuilder builder = new(null, services);
         builder.UseGrpc(opt => opt.Channel = c);

--- a/test/Grpc.IntegrationTests/GrpcSidecarFixture.cs
+++ b/test/Grpc.IntegrationTests/GrpcSidecarFixture.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DurableTask.Grpc.Tests;
 public sealed class GrpcSidecarFixture : IDisposable
 {
     // Use a random port number to allow multiple instances to run in parallel
-    const string ListenHost = "127.0.0.1";
+    const string ListenHost = "localhost";
     readonly int ListenPort = Random.Shared.Next(30000, 40000);
 
     readonly IWebHost host;

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -43,7 +43,7 @@ public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposabl
         GC.SuppressFinalize(this);
     }
 
-    protected async Task<HostTestLifetime> StartWorkerAsync(Action<IDurableTaskBuilder> configure)
+    protected async Task<HostTestLifetime> StartWorkerAsync(Action<IDurableTaskWorkerBuilder> configure)
     {
         IHost host = this.CreateHostBuilder(configure).Build();
         await host.StartAsync(this.TimeoutToken);
@@ -54,7 +54,7 @@ public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposabl
     /// Creates a <see cref="IHostBuilder"/> configured to output logs to xunit logging infrastructure.
     /// </summary>
     /// <param name="configure">Configures the durable task builder.</param>
-    protected IHostBuilder CreateHostBuilder(Action<IDurableTaskBuilder> configure)
+    protected IHostBuilder CreateHostBuilder(Action<IDurableTaskWorkerBuilder> configure)
     {
         return Host.CreateDefaultBuilder()
             .ConfigureLogging(b =>

--- a/test/Worker/Core.Tests/DependencyInjection/DefaultDurableTaskBuilderTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/DefaultDurableTaskBuilderTests.cs
@@ -12,7 +12,7 @@ public class DefaultDurableTaskBuilderTests
     [Fact]
     public void BuildTarget_InvalidType_Throws()
     {
-        DefaultDurableTaskBuilder builder = new("test", new ServiceCollection());
+        DefaultDurableTaskWorkerBuilder builder = new("test", new ServiceCollection());
         Action act = () => builder.BuildTarget = typeof(BadBuildTarget);
         act.Should().ThrowExactly<ArgumentException>().WithParameterName("value");
     }
@@ -20,7 +20,7 @@ public class DefaultDurableTaskBuilderTests
     [Fact]
     public void BuildTarget_ValidType_Sets()
     {
-        DefaultDurableTaskBuilder builder = new("test", new ServiceCollection());
+        DefaultDurableTaskWorkerBuilder builder = new("test", new ServiceCollection());
         Action act = () => builder.BuildTarget = typeof(GoodBuildTarget);
         act.Should().NotThrow();
         builder.BuildTarget.Should().Be(typeof(GoodBuildTarget));
@@ -33,7 +33,7 @@ public class DefaultDurableTaskBuilderTests
     public void Build_NoTarget_Throws()
     {
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new("test", services);
+        DefaultDurableTaskWorkerBuilder builder = new("test", services);
         Action act = () => builder.Build(services.BuildServiceProvider());
         act.Should().ThrowExactly<InvalidOperationException>();
     }
@@ -45,7 +45,7 @@ public class DefaultDurableTaskBuilderTests
         ServiceCollection services = new();
         services.AddOptions();
         services.Configure<DurableTaskWorkerOptions>("test", x => x.DataConverter = converter);
-        DefaultDurableTaskBuilder builder = new("test", services)
+        DefaultDurableTaskWorkerBuilder builder = new("test", services)
         {
             BuildTarget = typeof(GoodBuildTarget),
         };

--- a/test/Worker/Core.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -12,7 +12,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseBuildTarget_InvalidType_Throws()
     {
-        DefaultDurableTaskBuilder builder = new("test", new ServiceCollection());
+        DefaultDurableTaskWorkerBuilder builder = new("test", new ServiceCollection());
         Action act = () => builder.UseBuildTarget(typeof(BadBuildTarget));
         act.Should().ThrowExactly<ArgumentException>().WithParameterName("value");
     }
@@ -20,7 +20,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseBuildTarget_ValidType_Sets()
     {
-        DefaultDurableTaskBuilder builder = new("test", new ServiceCollection());
+        DefaultDurableTaskWorkerBuilder builder = new("test", new ServiceCollection());
         Action act = () => builder.UseBuildTarget(typeof(GoodBuildTarget));
         act.Should().NotThrow();
         builder.BuildTarget.Should().Be(typeof(GoodBuildTarget));
@@ -29,7 +29,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseBuildTargetT_ValidType_Sets()
     {
-        DefaultDurableTaskBuilder builder = new("test", new ServiceCollection());
+        DefaultDurableTaskWorkerBuilder builder = new("test", new ServiceCollection());
         Action act = () => builder.UseBuildTarget<GoodBuildTarget>();
         act.Should().NotThrow();
         builder.BuildTarget.Should().Be(typeof(GoodBuildTarget));
@@ -39,7 +39,7 @@ public class DurableTaskBuilderExtensionsTests
     public void AddTasks_ConfiguresRegistry()
     {
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new("test", services);
+        DefaultDurableTaskWorkerBuilder builder = new("test", services);
 
         DurableTaskRegistry? actual = null;
         builder.AddTasks(registry => actual = registry);
@@ -52,7 +52,7 @@ public class DurableTaskBuilderExtensionsTests
     public void Configure_ConfiguresOptions()
     {
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new("test", services);
+        DefaultDurableTaskWorkerBuilder builder = new("test", services);
 
         DurableTaskWorkerOptions? actual = null;
         builder.Configure(options => actual = options);

--- a/test/Worker/Core.Tests/DependencyInjection/DurableTaskWorkerBuilderExtensionsTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/DurableTaskWorkerBuilderExtensionsTests.cs
@@ -4,10 +4,11 @@
 using Microsoft.DurableTask.Worker.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.DurableTask.Worker.Tests;
 
-public class DurableTaskBuilderExtensionsTests
+public class DurableTaskBuilderWorkerExtensionsTests
 {
     [Fact]
     public void UseBuildTarget_InvalidType_Throws()
@@ -71,16 +72,18 @@ public class DurableTaskBuilderExtensionsTests
 
     class GoodBuildTarget : DurableTaskWorker
     {
-        public GoodBuildTarget(string name, DurableTaskFactory factory, DurableTaskWorkerOptions options)
-            : base(name, factory, options)
+        public GoodBuildTarget(
+            string name, DurableTaskFactory factory, IOptions<DurableTaskWorkerOptions> options)
+            : base(name, factory)
         {
+            this.Options = options.Value;
         }
 
         public new string Name => base.Name;
 
         public new IDurableTaskFactory Factory => base.Factory;
 
-        public new DurableTaskWorkerOptions Options => base.Options;
+        public DurableTaskWorkerOptions Options { get; }
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {

--- a/test/Worker/Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -13,8 +13,8 @@ public class ServiceCollectionExtensionsTests
     public void AddDurableTaskWorker_SameInstance()
     {
         ServiceCollection services = new();
-        IDurableTaskBuilder? actual1 = null;
-        IDurableTaskBuilder? actual2 = null;
+        IDurableTaskWorkerBuilder? actual1 = null;
+        IDurableTaskWorkerBuilder? actual2 = null;
         services.AddDurableTaskWorker(builder => actual1 = builder);
         services.AddDurableTaskWorker(builder => actual2 = builder);
 

--- a/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -12,7 +12,7 @@ public class DurableTaskBuilderExtensionsTests
     public void UseGrpc_Sets()
     {
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new(null, services);
+        DefaultDurableTaskWorkerBuilder builder = new(null, services);
         Action act = () => builder.UseGrpc();
         act.Should().NotThrow();
         builder.BuildTarget.Should().Be(typeof(GrpcDurableTaskWorker));
@@ -28,7 +28,7 @@ public class DurableTaskBuilderExtensionsTests
     public void UseGrpc_Address_Sets()
     {
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new(null, services);
+        DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc("127.0.0.1:9001");
 
         IServiceProvider provider = services.BuildServiceProvider();
@@ -43,7 +43,7 @@ public class DurableTaskBuilderExtensionsTests
     {
         Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new(null, services);
+        DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(c);
 
         IServiceProvider provider = services.BuildServiceProvider();
@@ -58,7 +58,7 @@ public class DurableTaskBuilderExtensionsTests
     {
         Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
-        DefaultDurableTaskBuilder builder = new(null, services);
+        DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(opt => opt.Channel = c);
 
         IServiceProvider provider = services.BuildServiceProvider();

--- a/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -29,19 +29,19 @@ public class DurableTaskBuilderExtensionsTests
     {
         ServiceCollection services = new();
         DefaultDurableTaskWorkerBuilder builder = new(null, services);
-        builder.UseGrpc("127.0.0.1:9001");
+        builder.UseGrpc("localhost:9001");
 
         IServiceProvider provider = services.BuildServiceProvider();
         GrpcDurableTaskWorkerOptions options = provider.GetOptions<GrpcDurableTaskWorkerOptions>();
 
-        options.Address.Should().Be("127.0.0.1:9001");
+        options.Address.Should().Be("localhost:9001");
         options.Channel.Should().BeNull();
     }
 
     [Fact]
     public void UseGrpc_Channel_Sets()
     {
-        Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
+        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
         DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(c);
@@ -56,7 +56,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Callback_Sets()
     {
-        Channel c = new("127.0.0.1:9001", ChannelCredentials.Insecure);
+        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
         ServiceCollection services = new();
         DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(opt => opt.Channel = c);


### PR DESCRIPTION
This PR refactors the worker and client options pattern to reduce total options needed for the final classes. This is done via the following:

1. `DurableTaskWorkerOptions` and `DurableTaskClientOptions` are now inheritable.
2. You can _optionally_ inherit from those types and use the `.UseBuildTarget<TTarget, TOptions>()` extension for the respective builder
3. Configuration done on the base type will be mapped to your derived type.
4. This is all optional - an implementation can choose to only use the base options type, or no options at all.

Additional changes in this PR:

1. Made `JsonDataConverter` constructor public (so users can specify their own options)
2. Added "Worker" to the naming of all the builder types in `Microsoft.DurableTask.Worker`.
3. Exposed a public simpler ctor for `GrpcDurableTaskClient` and made the type public. This is to enable construction during `IInputConverter` in durable functions.