### PR TITLE
Update sign task, snupkg symbols, readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ public static class HelloCitiesTypedStarter
 }
 
 [DurableTask(nameof(HelloCitiesTyped))]
-public class HelloCitiesTyped : TaskOrchestratorBase<string, string>
+public class HelloCitiesTyped : TaskOrchestrator<string?, string>
 {
-    protected async override Task<string?> OnRunAsync(TaskOrchestrationContext context, string? input)
+    public async override Task<string> RunAsync(TaskOrchestrationContext context, string? input)
     {
         string result = "";
         result += await context.CallSayHelloTypedAsync("Tokyo") + " ";
@@ -127,7 +127,7 @@ public class HelloCitiesTyped : TaskOrchestratorBase<string, string>
 }
 
 [DurableTask(nameof(SayHelloTyped))]
-public class SayHelloTyped : TaskActivityBase<string, string>
+public class SayHelloTyped : TaskActivity<string, string>
 {
     readonly ILogger? logger;
 
@@ -136,10 +136,10 @@ public class SayHelloTyped : TaskActivityBase<string, string>
         this.logger = loggerFactory?.CreateLogger<SayHelloTyped>();
     }
 
-    protected override string OnRun(TaskActivityContext context, string? cityName)
+    public override Task<string> RunAsync(TaskActivityContext context, string cityName)
     {
         this.logger?.LogInformation("Saying hello to {name}", cityName);
-        return $"Hello, {cityName}!";
+        return Task.FromResult($"Hello, {cityName}!");
     }
 }
 ```
@@ -155,9 +155,6 @@ There are also several features that aren't yet available:
 * Durable Entities is not yet supported.
 * APIs for calling HTTP endpoints are not yet available.
 * Several instance management APIs are not yet implemented.
-* Some orchestration context properties, like the parent instance ID, are not yet available.
-
-Feature parity with Durable Functions can be expected in the 1.0 release.
 
 ## Contributing
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -42,7 +42,7 @@ steps:
   displayName: 'ESRP CodeSigning: Authenticode'
   inputs:
     ConnectedServiceName: 'ESRP Service'
-    FolderPath: 'src'
+    FolderPath: 'out/bin'
     Pattern: 'Microsoft.DurableTask.*.dll'
     signConfigType: inlineSignParams
     inlineOperation: |

--- a/eng/targets/InternalsVisibleTo.targets
+++ b/eng/targets/InternalsVisibleTo.targets
@@ -32,7 +32,7 @@
     Outputs="$(GeneratedInternalsVisibleToFile)"
     DependsOnTargets="PrepareGenerateInternalsVisibleToFile;PrepareForBuild"
     Condition="'@(InternalsVisibleTo)' != ''"
-    BeforeTargets="CoreCompile">
+    BeforeTargets="BeforeCompile">
 
     <WriteCodeFragment AssemblyAttributes="@(_InternalsVisibleToAttribute)" Language="$(Language)" OutputFile="$(GeneratedInternalsVisibleToFile)">
       <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(Language)' == 'F#'" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,8 +25,6 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageReleaseNotes>$(RepositoryUrl)/releases/</PackageReleaseNotes>
     <PackageTags>Microsoft Durable Task Orchestration Workflow Activity Reliable DTFx</PackageTags>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,6 @@
 
   <!-- Common build settings -->
   <PropertyGroup>
-    <DebugType>embedded</DebugType>
     <Company>Microsoft Corporation</Company>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -26,6 +25,8 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageReleaseNotes>$(RepositoryUrl)/releases/</PackageReleaseNotes>
     <PackageTags>Microsoft Durable Task Orchestration Workflow Activity Reliable DTFx</PackageTags>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, $(_DirectoryBuildTargetsFile)))/$(_DirectoryBuildTargetsFile)"
     Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, $(_DirectoryBuildTargetsFile)))' != '' " />
 
+  <PropertyGroup Condition="'$(IsRoslynComponent)' != 'true'">
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>


### PR DESCRIPTION
1. Fixes the path for the sign task `src` --> `out/bin`
2. Switches debug symbols from `embedded` to be delivered via `snupkg`.
    - This reduces the size of our nupkgs, and lets debuggers download the pdb's separately only when needed (this happens automatically for the user via NuGet and snupkg's)
3. Update `readme.md` with the recent API changes, also removed the feature parity callout as we are still addressing that aspect.
4. Moved `InternalsVisibleTo.cs` to be generated earlier in build to address source link issue.