### PR TITLE
Update protobuf, add suspend and resume event support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.0.0
+
+- Added `SuspendInstanceAsync` and `ResumeInstanceAsync` to `DurableTaskClient`.
+
 ## v1.0.0-rc.1
 
 ### Included Packages

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -135,6 +135,33 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task TerminateAsync(string instanceId, object? output);
 
     /// <summary>
+    /// Suspends an orchestration instance, halting processing of it until <see cref="ResumeInstanceAsync" /> is used
+    /// to resume the orchestration.
+    /// </summary>
+    /// <param name="instanceId">The instance ID of the orchestration to suspend.</param>
+    /// <param name="reason">The optional suspension reason.</param>
+    /// <param name="cancellation">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the suspend operation. Note, cancelling this token
+    /// does <b>not</b> resume the orchestration if suspend was successful.
+    /// </param>
+    /// <returns>A task that completes when the suspend has been committed to the backend.</returns>
+    public abstract Task SuspendInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Resumes an orchestration instance that was suspended via <see cref="SuspendInstanceAsync" />.
+    /// </summary>
+    /// <param name="instanceId">The instance ID of the orchestration to resume.</param>
+    /// <param name="reason">The optional resume reason.</param>
+    /// <param name="cancellation">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the resume operation. Note, cancelling this token
+    /// does <b>not</b> re-suspend the orchestration if resume was successful.
+    /// </param>
+    /// <returns>A task that completes when the resume has been committed to the backend.</returns>
+    public abstract Task ResumeInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default);
+
+    /// <summary>
     /// Waits for an orchestration to start running and returns a <see cref="OrchestrationMetadata"/>
     /// object that contains metadata about the started instance.
     /// </summary>

--- a/src/Client/Core/OrchestrationRuntimeStatus.cs
+++ b/src/Client/Core/OrchestrationRuntimeStatus.cs
@@ -44,4 +44,9 @@ public enum OrchestrationRuntimeStatus
     /// The orchestration was scheduled but hasn't started running.
     /// </summary>
     Pending,
+
+    /// <summary>
+    /// The orchestration is in a suspended state.
+    /// </summary>
+    Suspended,
 }

--- a/src/Client/Grpc/Client.Grpc.csproj
+++ b/src/Client/Grpc/Client.Grpc.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.39.1" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
+    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -129,6 +129,50 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
+    public override async Task SuspendInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        P.SuspendRequest request = new()
+        {
+            InstanceId = instanceId,
+            Reason = reason,
+        };
+
+        try
+        {
+            await this.sidecarClient.SuspendInstanceAsync(
+                request, cancellationToken: cancellation);
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException(
+                $"The {nameof(this.SuspendInstanceAsync)} operation was canceled.", e, cancellation);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task ResumeInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        P.ResumeRequest request = new()
+        {
+            InstanceId = instanceId,
+            Reason = reason,
+        };
+
+        try
+        {
+            await this.sidecarClient.ResumeInstanceAsync(
+                request, cancellationToken: cancellation);
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException(
+                $"The {nameof(this.ResumeInstanceAsync)} operation was canceled.", e, cancellation);
+        }
+    }
+
+    /// <inheritdoc/>
     public override async Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
         string instanceId,
         bool getInputsAndOutputs = false)

--- a/src/Client/Grpc/ProtoUtils.cs
+++ b/src/Client/Grpc/ProtoUtils.cs
@@ -71,6 +71,7 @@ static class ProtoUtils
             OrchestrationRuntimeStatus.Pending => P.OrchestrationStatus.Pending,
             OrchestrationRuntimeStatus.Running => P.OrchestrationStatus.Running,
             OrchestrationRuntimeStatus.Terminated => P.OrchestrationStatus.Terminated,
+            OrchestrationRuntimeStatus.Suspended => P.OrchestrationStatus.Suspended,
             _ => throw new ArgumentOutOfRangeException(nameof(status), "Unexpected value"),
         };
 #pragma warning restore 0618 // Referencing Obsolete member.

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -60,6 +60,12 @@ static class ProtoUtils
             case P.HistoryEvent.EventTypeOneofCase.ExecutionTerminated:
                 historyEvent = new ExecutionTerminatedEvent(proto.EventId, proto.ExecutionTerminated.Input);
                 break;
+            case P.HistoryEvent.EventTypeOneofCase.ExecutionSuspended:
+                historyEvent = new ExecutionSuspendedEvent(proto.EventId, proto.ExecutionSuspended.Input);
+                break;
+            case P.HistoryEvent.EventTypeOneofCase.ExecutionResumed:
+                historyEvent = new ExecutionResumedEvent(proto.EventId, proto.ExecutionResumed.Input);
+                break;
             case P.HistoryEvent.EventTypeOneofCase.TaskScheduled:
                 historyEvent = new TaskScheduledEvent(
                     proto.EventId,

--- a/src/Worker/Grpc/Worker.Grpc.csproj
+++ b/src/Worker/Grpc/Worker.Grpc.csproj
@@ -13,10 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.39.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
+    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="1.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -106,10 +106,20 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
+        public override Task ResumeInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
             StartOrchestrationOptions? options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task SuspendInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -137,10 +137,20 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
+        public override Task ResumeInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
             StartOrchestrationOptions? options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task SuspendInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
1. Updates `Microsoft.DurableTask.SideCar.Protobuf` to `1.0.0`
2. Adds `SuspendInstanceAsync` and `ResumeInstanceAsync` to `DurableTaskClient`.

## TODO

- [x] Add new Suspended state to other locations in the code base.
- [x] Add unit and integration tests -- **NOT DONE** - sidecar is not updated with Suspend functionality.