### PR TITLE
Multi-target gRPC packages. Use protobuf directly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,16 @@
 # Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
+# XML project files
+[*.{csproj,proj}]
+indent_size = 2
+indent_style = space
+
+# XML config files
+[*.{props,targets,resx,nuspec,config,ruleset}]
+indent_size = 2
+indent_style = space
+
 # C# files
 [*.cs]
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "eng/proto"]
+	path = eng/proto
+	url = https://github.com/microsoft/durabletask-protobuf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `DurableTaskClient` methods have been touched up to ensure `CancellationToken` is included, as well as is the last parameter.
 - Removed obsolete/unimplemented local lambda activity calls from `TaskOrchestrationContext`
 - Input is now an optional parameter on `TaskOrchestrationContext.ContinueAsNew`
+- Multi-target gRPC projects to now use `Grpc.Net.Client` when appropriate (.NET5.0 and up)
 
 ## v1.0.0-rc.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `DurableTaskClient` methods have been touched up to ensure `CancellationToken` is included, as well as is the last parameter.
 - Removed obsolete/unimplemented local lambda activity calls from `TaskOrchestrationContext`
 - Input is now an optional parameter on `TaskOrchestrationContext.ContinueAsNew`
-- Multi-target gRPC projects to now use `Grpc.Net.Client` when appropriate (.NET5.0 and up)
+- Multi-target gRPC projects to now use `Grpc.Net.Client` when appropriate (.NET6.0 and up)
 
 ## v1.0.0-rc.1
 

--- a/Microsoft.DurableTask.sln
+++ b/Microsoft.DurableTask.sln
@@ -57,6 +57,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "src\Shared\Shared
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "misc", "misc\misc.csproj", "{1E135970-60CF-470A-9270-4560BFA0A7DF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc", "src\Grpc\Grpc.csproj", "{44AD321D-96D4-481E-BD41-D0B12A619833}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,10 @@ Global
 		{1E135970-60CF-470A-9270-4560BFA0A7DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E135970-60CF-470A-9270-4560BFA0A7DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E135970-60CF-470A-9270-4560BFA0A7DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44AD321D-96D4-481E-BD41-D0B12A619833}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44AD321D-96D4-481E-BD41-D0B12A619833}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44AD321D-96D4-481E-BD41-D0B12A619833}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44AD321D-96D4-481E-BD41-D0B12A619833}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,6 +177,7 @@ Global
 		{8A0156E6-F033-49AB-AB0C-6698CE1DB24F} = {EFF7632B-821E-4CFC-B4A0-ED4B24296B17}
 		{21AF0D71-6D32-483F-B6E8-3B28EE432560} = {EFF7632B-821E-4CFC-B4A0-ED4B24296B17}
 		{57A4C812-B0D9-49E9-9EBE-7E94D3D78ED7} = {8AFC9781-F6F1-4696-BB4A-9ED7CA9D612B}
+		{44AD321D-96D4-481E-BD41-D0B12A619833} = {8AFC9781-F6F1-4696-BB4A-9ED7CA9D612B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB41CB55-35EA-4986-A522-387AB3402E71}

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -8,6 +8,9 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 steps:
+- checkout: self
+  submodules: true
+
 - task: UseDotNet@2
   displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
   inputs:

--- a/src/Client/Grpc/Client.Grpc.csproj
+++ b/src/Client/Grpc/Client.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageDescription>The gRPC client for the Durable Task Framework.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
   </PropertyGroup>
@@ -13,18 +13,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.39.1" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Core/Client.csproj" />
+    <ProjectReference Include="../../Grpc/Grpc.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <SharedSection Include="Core" />
+    <SharedSection Include="Grpc" />
   </ItemGroup>
 
 </Project>

--- a/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -4,14 +4,6 @@
 using Microsoft.DurableTask.Client.Grpc;
 using Microsoft.Extensions.DependencyInjection;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Client;
 
 /// <summary>

--- a/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Grpc/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -1,9 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
 using Microsoft.DurableTask.Client.Grpc;
 using Microsoft.Extensions.DependencyInjection;
+
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETSTANDARD2_0
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Client;
 
@@ -44,7 +51,7 @@ public static class DurableTaskClientBuilderExtensions
     /// <param name="builder">The builder to configure.</param>
     /// <param name="channel">The channel for the Durable Task sidecar endpoint.</param>
     /// <returns>The original builder, for call chaining.</returns>
-    public static IDurableTaskClientBuilder UseGrpc(this IDurableTaskClientBuilder builder, Channel channel)
+    public static IDurableTaskClientBuilder UseGrpc(this IDurableTaskClientBuilder builder, GrpcChannel channel)
         => builder.UseGrpc(opt => opt.Channel = channel);
 
     /// <summary>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -10,14 +10,6 @@ using Microsoft.Extensions.Options;
 using static Microsoft.DurableTask.Protobuf.TaskHubSidecarService;
 using P = Microsoft.DurableTask.Protobuf;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Client.Grpc;
 
 /// <summary>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -10,6 +10,14 @@ using Microsoft.Extensions.Options;
 using static Microsoft.DurableTask.Protobuf.TaskHubSidecarService;
 using P = Microsoft.DurableTask.Protobuf;
 
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETSTANDARD2_0
+using GrpcChannel = Grpc.Core.Channel;
+#endif
+
 namespace Microsoft.DurableTask.Client.Grpc;
 
 /// <summary>
@@ -20,7 +28,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     readonly ILogger logger;
     readonly TaskHubSidecarServiceClient sidecarClient;
     readonly GrpcDurableTaskClientOptions options;
-    readonly AsyncDisposable asyncDisposable;
+    AsyncDisposable asyncDisposable;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GrpcDurableTaskClient"/> class.
@@ -46,7 +54,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     {
         this.logger = Check.NotNull(logger);
         this.options = Check.NotNull(options);
-        this.asyncDisposable = this.BuildChannel(out Channel channel);
+        this.asyncDisposable = BuildChannel(options, out GrpcChannel channel);
         this.sidecarClient = new TaskHubSidecarServiceClient(channel);
     }
 
@@ -294,6 +302,43 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         return this.PurgeInstancesCoreAsync(request, cancellation);
     }
 
+    static AsyncDisposable BuildChannel(GrpcDurableTaskClientOptions options, out GrpcChannel channel)
+    {
+        if (options.Channel is GrpcChannel c)
+        {
+            channel = c;
+            return default;
+        }
+
+        c = GetChannel(options.Address);
+        channel = c;
+        return new AsyncDisposable(async () => await c.ShutdownAsync());
+    }
+
+#if NET6_0_OR_GREATER
+    static GrpcChannel GetChannel(string? address)
+    {
+        if (string.IsNullOrEmpty(address))
+        {
+            address = "http://localhost:4001";
+        }
+
+        return GrpcChannel.ForAddress(address);
+    }
+#endif
+
+#if NETSTANDARD2_0
+    static GrpcChannel GetChannel(string? address)
+    {
+        if (string.IsNullOrEmpty(address))
+        {
+            address = "localhost:4001";
+        }
+
+        return new(address, ChannelCredentials.Insecure);
+    }
+#endif
+
     async Task<PurgeResult> PurgeInstancesCoreAsync(
         P.PurgeInstancesRequest request, CancellationToken cancellation = default)
     {
@@ -320,24 +365,8 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             SerializedInput = state.Input,
             SerializedOutput = state.Output,
             SerializedCustomStatus = state.CustomStatus,
-            FailureDetails = ProtoUtils.ConvertTaskFailureDetails(state.FailureDetails),
+            FailureDetails = state.FailureDetails.ToTaskFailureDetails(),
             DataConverter = includeInputsAndOutputs ? this.DataConverter : null,
         };
-    }
-
-    AsyncDisposable BuildChannel(out Channel channel)
-    {
-        if (this.options.Channel is Channel c)
-        {
-            channel = c;
-            return default;
-        }
-
-        string address = string.IsNullOrEmpty(this.options.Address) ? "localhost:4001" : this.options.Address!;
-
-        // TODO: use SSL channel by default?
-        c = new(address, ChannelCredentials.Insecure);
-        channel = c;
-        return new AsyncDisposable(async () => await c.ShutdownAsync());
     }
 }

--- a/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETSTANDARD2_0
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Client.Grpc;
 
@@ -18,5 +24,5 @@ public sealed class GrpcDurableTaskClientOptions : DurableTaskClientOptions
     /// <summary>
     /// Gets or sets the gRPC channel to use. Will supersede <see cref="Address" /> when provided.
     /// </summary>
-    public Channel? Channel { get; set; }
+    public GrpcChannel? Channel { get; set; }
 }

--- a/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Client.Grpc;
 
 /// <summary>

--- a/src/Client/Grpc/ProtoUtils.cs
+++ b/src/Client/Grpc/ProtoUtils.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using DurableTask.Core;
-using Google.Protobuf.WellKnownTypes;
 using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.DurableTask.Client.Grpc;
@@ -12,49 +10,6 @@ namespace Microsoft.DurableTask.Client.Grpc;
 /// </summary>
 static class ProtoUtils
 {
-    /// <summary>
-    /// Converts a <see cref="DateTime" /> to a gRPC <see cref="Timestamp" />.
-    /// </summary>
-    /// <param name="dateTime">The date-time to convert.</param>
-    /// <returns>The gRPC timestamp.</returns>
-    internal static Timestamp ToTimestamp(this DateTime dateTime)
-    {
-        // The protobuf libraries require timestamps to be in UTC
-        if (dateTime.Kind == DateTimeKind.Unspecified)
-        {
-            dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
-        }
-        else if (dateTime.Kind == DateTimeKind.Local)
-        {
-            dateTime = dateTime.ToUniversalTime();
-        }
-
-        return Timestamp.FromDateTime(dateTime);
-    }
-
-    /// <summary>
-    /// Converts a <see cref="DateTime" /> to a gRPC <see cref="Timestamp" />.
-    /// </summary>
-    /// <param name="dateTime">The date-time to convert.</param>
-    /// <returns>The gRPC timestamp.</returns>
-    internal static Timestamp? ToTimestamp(this DateTime? dateTime)
-        => dateTime.HasValue ? dateTime.Value.ToTimestamp() : null;
-
-    /// <summary>
-    /// Converts a <see cref="DateTimeOffset" /> to a gRPC <see cref="Timestamp" />.
-    /// </summary>
-    /// <param name="dateTime">The date-time to convert.</param>
-    /// <returns>The gRPC timestamp.</returns>
-    internal static Timestamp ToTimestamp(this DateTimeOffset dateTime) => Timestamp.FromDateTimeOffset(dateTime);
-
-    /// <summary>
-    /// Converts a <see cref="DateTime" /> to a gRPC <see cref="Timestamp" />.
-    /// </summary>
-    /// <param name="dateTime">The date-time to convert.</param>
-    /// <returns>The gRPC timestamp.</returns>
-    internal static Timestamp? ToTimestamp(this DateTimeOffset? dateTime)
-        => dateTime.HasValue ? dateTime.Value.ToTimestamp() : null;
-
 #pragma warning disable 0618 // Referencing Obsolete member. This is intention as we are only converting it.
     /// <summary>
     /// Converts <see cref="OrchestrationRuntimeStatus" /> to <see cref="P.OrchestrationStatus" />.
@@ -74,76 +29,4 @@ static class ProtoUtils
             _ => throw new ArgumentOutOfRangeException(nameof(status), "Unexpected value"),
         };
 #pragma warning restore 0618 // Referencing Obsolete member.
-
-    /// <summary>
-    /// Converts a <see cref="P.TaskFailureDetails" /> to a <see cref="TaskFailureDetails" />.
-    /// </summary>
-    /// <param name="failureDetails">The failure details to convert.</param>
-    /// <returns>The converted failure details.</returns>
-    internal static TaskFailureDetails? ConvertTaskFailureDetails(P.TaskFailureDetails? failureDetails)
-    {
-        if (failureDetails == null)
-        {
-            return null;
-        }
-
-        return new TaskFailureDetails(
-            failureDetails.ErrorType,
-            failureDetails.ErrorMessage,
-            failureDetails.StackTrace,
-            ConvertTaskFailureDetails(failureDetails.InnerFailure));
-    }
-
-    /// <summary>
-    /// Converts <see cref="Exception" /> to a <see cref="P.TaskFailureDetails" />.
-    /// </summary>
-    /// <param name="e">The exception to convert.</param>
-    /// <returns>The converted failure details.</returns>
-    internal static P.TaskFailureDetails? ToTaskFailureDetails(Exception? e)
-    {
-        if (e == null)
-        {
-            return null;
-        }
-
-        return new P.TaskFailureDetails
-        {
-            ErrorType = e.GetType().FullName,
-            ErrorMessage = e.Message,
-            StackTrace = e.StackTrace,
-            InnerFailure = ToTaskFailureDetails(e.InnerException),
-        };
-    }
-
-    static FailureDetails? ConvertFailureDetails(P.TaskFailureDetails? failureDetails)
-    {
-        if (failureDetails == null)
-        {
-            return null;
-        }
-
-        return new FailureDetails(
-            failureDetails.ErrorType,
-            failureDetails.ErrorMessage,
-            failureDetails.StackTrace,
-            ConvertFailureDetails(failureDetails.InnerFailure),
-            failureDetails.IsNonRetriable);
-    }
-
-    static P.TaskFailureDetails? ConvertFailureDetails(FailureDetails? failureDetails)
-    {
-        if (failureDetails == null)
-        {
-            return null;
-        }
-
-        return new P.TaskFailureDetails
-        {
-            ErrorType = failureDetails.ErrorType ?? "(unkown)",
-            ErrorMessage = failureDetails.ErrorMessage ?? "(unkown)",
-            StackTrace = failureDetails.StackTrace,
-            IsNonRetriable = failureDetails.IsNonRetriable,
-            InnerFailure = ConvertFailureDetails(failureDetails.InnerFailure),
-        };
-    }
 }

--- a/src/Grpc/Grpc.csproj
+++ b/src/Grpc/Grpc.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <PackageDescription>The gRPC Protobuf .NET services for Durable Task Framework.</PackageDescription>
+  </PropertyGroup>
+
+  <!-- Version info -->
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>rc.1</VersionSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.Tools" Version="2.51.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Grpc.Core" Version="2.46.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="$(EngRoot)proto/protos/orchestrator_service.proto" GrpcServices="both" Link="proto/orchestrator_service.proto" />
+  </ItemGroup>
+
+</Project>

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -338,10 +338,31 @@ static class ProtoUtils
     }
 
     /// <summary>
+    /// Converts a <see cref="P.TaskFailureDetails" /> to a <see cref="TaskFailureDetails" />.
+    /// </summary>
+    /// <param name="failureDetails">The failure details to convert.</param>
+    /// <returns>The converted failure details.</returns>
+    [return: NotNullIfNotNull("failureDetails")]
+    internal static TaskFailureDetails? ToTaskFailureDetails(this P.TaskFailureDetails? failureDetails)
+    {
+        if (failureDetails == null)
+        {
+            return null;
+        }
+
+        return new TaskFailureDetails(
+            failureDetails.ErrorType,
+            failureDetails.ErrorMessage,
+            failureDetails.StackTrace,
+            failureDetails.InnerFailure.ToTaskFailureDetails());
+    }
+
+    /// <summary>
     /// Converts a <see cref="Exception" /> to <see cref="P.TaskFailureDetails" />.
     /// </summary>
     /// <param name="e">The exception to convert.</param>
     /// <returns>The task failure details.</returns>
+    [return: NotNullIfNotNull("e")]
     internal static P.TaskFailureDetails? ToTaskFailureDetails(this Exception? e)
     {
         if (e == null)

--- a/src/Shared/Grpc/Usings.cs
+++ b/src/Shared/Grpc/Usings.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-global using FluentAssertions;
-global using Moq;
-global using Xunit;
-
 #if NET6_0_OR_GREATER
 global using Grpc.Net.Client;
 #endif
 
-#if NETFRAMEWORK
+#if NETSTANDARD2_0
 global using Grpc.Core;
 global using GrpcChannel = Grpc.Core.Channel;
 #endif

--- a/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -1,9 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
 using Microsoft.DurableTask.Worker.Grpc;
 using Microsoft.Extensions.DependencyInjection;
+
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETSTANDARD2_0
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Worker;
 
@@ -24,15 +31,12 @@ public static class DurableTaskWorkerBuilderExtensions
         => builder.UseGrpc(opt => { });
 
     /// <summary>
-    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to use the gRPC worker.
+    /// Configures the <see cref="IDurableTaskWorkerBuilder" /> to be a gRPC client.
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
-    /// <param name="channel">The gRPC channel to use.</param>
+    /// <param name="channel">The channel for the Durable Task sidecar endpoint.</param>
     /// <returns>The original builder, for call chaining.</returns>
-    /// <remarks>
-    /// <b>Note:</b> only 1 instance of gRPC worker is supported per sidecar.
-    /// </remarks>
-    public static IDurableTaskWorkerBuilder UseGrpc(this IDurableTaskWorkerBuilder builder, Channel channel)
+    public static IDurableTaskWorkerBuilder UseGrpc(this IDurableTaskWorkerBuilder builder, GrpcChannel channel)
         => builder.UseGrpc(opt => opt.Channel = channel);
 
     /// <summary>

--- a/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Grpc/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -4,14 +4,6 @@
 using Microsoft.DurableTask.Worker.Grpc;
 using Microsoft.Extensions.DependencyInjection;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Worker;
 
 /// <summary>

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -231,7 +231,7 @@ sealed partial class GrpcDurableTaskWorker
             {
                 // This is not expected: Normally TaskOrchestrationExecutor handles exceptions in user code.
                 this.Logger.OrchestratorFailed(name, request.InstanceId, unexpected.ToString());
-                failureDetails = ProtoUtils.ToTaskFailureDetails(unexpected);
+                failureDetails = unexpected.ToTaskFailureDetails();
             }
 
             P.OrchestratorResponse response;

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -5,15 +5,6 @@ using Microsoft.DurableTask.Worker.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using Grpc.Core;
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Worker.Grpc;
 
 /// <summary>

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETSTANDARD2_0
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Worker.Grpc;
 
@@ -18,5 +24,5 @@ public sealed class GrpcDurableTaskWorkerOptions : DurableTaskWorkerOptions
     /// <summary>
     /// Gets or sets the gRPC channel to use. Will supersede <see cref="Address" /> when provided.
     /// </summary>
-    public Channel? Channel { get; set; }
+    public GrpcChannel? Channel { get; set; }
 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETSTANDARD2_0
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Worker.Grpc;
 
 /// <summary>

--- a/src/Worker/Grpc/Worker.Grpc.csproj
+++ b/src/Worker/Grpc/Worker.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageDescription>The gRPC worker for the Durable Task Framework.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
   </PropertyGroup>

--- a/src/Worker/Grpc/Worker.Grpc.csproj
+++ b/src/Worker/Grpc/Worker.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageDescription>The gRPC worker for the Durable Task Framework.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
   </PropertyGroup>
@@ -13,16 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.39.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../../Abstractions/Abstractions.csproj" />
     <ProjectReference Include="../Core/Worker.csproj" />
+    <ProjectReference Include="../../Abstractions/Abstractions.csproj" />
+    <ProjectReference Include="../../Grpc/Grpc.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Client/Grpc.Tests/Client.Grpc.Tests.csproj
+++ b/test/Client/Grpc.Tests/Client.Grpc.Tests.csproj
@@ -1,4 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -3,15 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETFRAMEWORK
-using Grpc.Core;
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Client.Grpc.Tests;
 
 public class DurableTaskClientBuilderExtensionsTests

--- a/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
+
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETFRAMEWORK
+using Grpc.Core;
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Client.Grpc.Tests;
 
@@ -41,7 +49,7 @@ public class DurableTaskClientBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Channel_Sets()
     {
-        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
+        GrpcChannel c = GetChannel();
         ServiceCollection services = new();
         DefaultDurableTaskClientBuilder builder = new(null, services);
         builder.UseGrpc(c);
@@ -56,7 +64,7 @@ public class DurableTaskClientBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Callback_Sets()
     {
-        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
+        GrpcChannel c = GetChannel();
         ServiceCollection services = new();
         DefaultDurableTaskClientBuilder builder = new(null, services);
         builder.UseGrpc(opt => opt.Channel = c);
@@ -67,4 +75,12 @@ public class DurableTaskClientBuilderExtensionsTests
         options.Channel.Should().Be(c);
         options.Address.Should().BeNull();
     }
+
+#if NET6_0_OR_GREATER
+    static GrpcChannel GetChannel() => GrpcChannel.ForAddress("http://localhost:9001");
+#endif
+
+#if NETFRAMEWORK
+    static GrpcChannel GetChannel() => new("http://localhost:9001", ChannelCredentials.Insecure);
+#endif
 }

--- a/test/Grpc.IntegrationTests/GrpcSidecarFixture.cs
+++ b/test/Grpc.IntegrationTests/GrpcSidecarFixture.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using DurableTask.Core;
-using Grpc.Core;
+using Grpc.Net.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -16,9 +16,7 @@ namespace Microsoft.DurableTask.Grpc.Tests;
 
 public sealed class GrpcSidecarFixture : IDisposable
 {
-    // Use a random port number to allow multiple instances to run in parallel
     const string ListenHost = "localhost";
-    readonly int ListenPort = Random.Shared.Next(30000, 40000);
 
     readonly IWebHost host;
 
@@ -26,6 +24,8 @@ public sealed class GrpcSidecarFixture : IDisposable
     {
         InMemoryOrchestrationService service = new();
 
+        // Use a random port number to allow multiple instances to run in parallel
+        string address = $"http://{ListenHost}:{Random.Shared.Next(30000, 40000)}";
         this.host = new WebHostBuilder()
             .UseKestrel(options =>
             {
@@ -33,7 +33,7 @@ public sealed class GrpcSidecarFixture : IDisposable
                 // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.0
                 options.ConfigureEndpointDefaults(listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
             })
-            .UseUrls($"http://{ListenHost}:{this.ListenPort}")
+            .UseUrls(address)
             .ConfigureServices(services =>
             {
                 services.AddGrpc();
@@ -53,10 +53,10 @@ public sealed class GrpcSidecarFixture : IDisposable
 
         this.host.Start();
 
-        this.Channel = new Channel(ListenHost, this.ListenPort, ChannelCredentials.Insecure);
+        this.Channel = GrpcChannel.ForAddress(address);
     }
 
-    public Channel Channel { get; }
+    public GrpcChannel Channel { get; }
 
     public void Dispose()
     {

--- a/test/TestHelpers/TestHelpers.csproj
+++ b/test/TestHelpers/TestHelpers.csproj
@@ -1,4 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />

--- a/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
+
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#endif
+
+#if NETFRAMEWORK
+using Grpc.Core;
+using GrpcChannel = Grpc.Core.Channel;
+#endif
 
 namespace Microsoft.DurableTask.Worker.Grpc.Tests;
 
@@ -41,7 +49,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Channel_Sets()
     {
-        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
+        GrpcChannel c = GetChannel();
         ServiceCollection services = new();
         DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(c);
@@ -56,7 +64,7 @@ public class DurableTaskBuilderExtensionsTests
     [Fact]
     public void UseGrpc_Callback_Sets()
     {
-        Channel c = new("localhost:9001", ChannelCredentials.Insecure);
+        GrpcChannel c = GetChannel();
         ServiceCollection services = new();
         DefaultDurableTaskWorkerBuilder builder = new(null, services);
         builder.UseGrpc(opt => opt.Channel = c);
@@ -67,4 +75,12 @@ public class DurableTaskBuilderExtensionsTests
         options.Channel.Should().Be(c);
         options.Address.Should().BeNull();
     }
+
+#if NET6_0_OR_GREATER
+    static GrpcChannel GetChannel() => GrpcChannel.ForAddress("http://localhost:9001");
+#endif
+
+#if NETFRAMEWORK
+    static GrpcChannel GetChannel() => new("http://localhost:9001", ChannelCredentials.Insecure);
+#endif
 }

--- a/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
+++ b/test/Worker/Grpc.Tests/DependencyInjection/DurableTaskBuilderExtensionsTests.cs
@@ -3,15 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#if NET6_0_OR_GREATER
-using Grpc.Net.Client;
-#endif
-
-#if NETFRAMEWORK
-using Grpc.Core;
-using GrpcChannel = Grpc.Core.Channel;
-#endif
-
 namespace Microsoft.DurableTask.Worker.Grpc.Tests;
 
 public class DurableTaskBuilderExtensionsTests

--- a/test/Worker/Grpc.Tests/Usings.cs
+++ b/test/Worker/Grpc.Tests/Usings.cs
@@ -4,3 +4,12 @@
 global using FluentAssertions;
 global using Moq;
 global using Xunit;
+
+#if NET6_0_OR_GREATER
+global using Grpc.Net.Client;
+#endif
+
+#if NETFRAMEWORK
+global using Grpc.Core;
+global using GrpcChannel = Grpc.Core.Channel;
+#endif

--- a/test/Worker/Grpc.Tests/Worker.Grpc.Tests.csproj
+++ b/test/Worker/Grpc.Tests/Worker.Grpc.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR does some significant overhauling of gRPC dependencies. The changes breakdown as follows:

1. `Microsoft.DurableTask.Sidecar.Protobuf` dependency removed. https://github.com/microsoft/durabletask-protobuf is not a direct submodule.
1. `Microsoft.DurableTask.Grpc` project & package added, which is purely the dotnet gRPC services for the above protobuf spec.
    - This means it is a duplicate of `Microsoft.DurableTask.Sidecar.Protobuf`, but I figure this belongs in this repo anyways. I am open to a different naming.
    - This does have a meaningful (and necessary) change from the  `Microsoft.DurableTask.Sidecar.Protobuf`: it is multi-target of `netstandard2.0` and `net6.0`. Using `Grpc.Core` and `Grpc.Net.Client` respectively.'
    - I intentionally did not add the `Shared/Grpc` files to this project because I am still unsure what the full picture of this new project is yet. Does it take a dependency on `Microsoft.DurableTask.Abstractions`? Should its name be changed as it is confusing with the two existing gRPC packages?
1. `Microsoft.DurableTask.Client.Grpc` and `Microsoft.DurableTask.Worker.Grpc` have also been multi-targeted, using the newer `Grpc.Net.Client` when targeting `net6.0` and above.
1. Several types were affected to accomplish the multi-targeting. They are minimal changes, mostly branching between `Grpc.Core.Channel` and `Grpc.Net.Client.GrpcChannel` via `#ifdef` statements. 
1. Some gRPC test projects were updated to also be multi-target
    - I couldn't update the integration tests, as they rely on `Microsoft.DurableTask.Sidecar` which is not compatible with netfx.
1. Unnecessary packages were removed from `Microsoft.DurableTask.Worker.Grpc`

Resolves #96 