### PR TITLE
Update DurableTaskClient API to have consistent cancellation tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.0.0
+
+- `DurableTaskClient` methods have been touched up to ensure `CancellationToken` is included, as well as is the last parameter.
+
 ## v1.0.0-rc.1
 
 ### Included Packages

--- a/src/Abstractions/Internal/IOrchestrationSubmitter.cs
+++ b/src/Abstractions/Internal/IOrchestrationSubmitter.cs
@@ -27,11 +27,18 @@ public interface IOrchestrationSubmitter
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
     /// <param name="options">The options to start the new orchestration with.</param>
+    /// <param name="cancellation">
+    /// The cancellation token. This only cancels enqueueing the new orchestration to the backend. Does not cancel the
+    /// orchestration once enqueued.
+    /// </param>
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
     /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
     /// <paramref name="options" />, the same value will be returned by the completed task.
     /// </returns>
     Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null);
+        TaskName orchestratorName,
+        object? input = null,
+        StartOrchestrationOptions? options = null,
+        CancellationToken cancellation = default);
 }

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -40,6 +40,16 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </summary>
     public string Name { get; }
 
+    /// <inheritdoc cref="ScheduleNewOrchestrationInstanceAsync(TaskName, object, StartOrchestrationOptions, CancellationToken)"/>
+    public virtual Task<string> ScheduleNewOrchestrationInstanceAsync(
+        TaskName orchestratorName, CancellationToken cancellation)
+        => this.ScheduleNewOrchestrationInstanceAsync(orchestratorName, null, null, cancellation);
+
+    /// <inheritdoc cref="ScheduleNewOrchestrationInstanceAsync(TaskName, object, StartOrchestrationOptions, CancellationToken)"/>
+    public virtual Task<string> ScheduleNewOrchestrationInstanceAsync(
+        TaskName orchestratorName, object? input, CancellationToken cancellation)
+        => this.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input, null, cancellation);
+
     /// <summary>
     /// Schedules a new orchestration instance for execution.
     /// </summary>
@@ -58,10 +68,11 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// and health of the backend task hub, and whether a start time was provided via <paramref name="options" />.
     /// </para><para>
     /// The task associated with this method completes after the orchestration instance was successfully scheduled. You
-    /// can use the <see cref="GetInstanceMetadataAsync"/> to query the status of the scheduled instance, the
-    /// <see cref="WaitForInstanceStartAsync"/> method to wait for the instance to transition out of the
-    /// <see cref="OrchestrationRuntimeStatus.Pending"/> status, or the <see cref="WaitForInstanceCompletionAsync"/>
-    /// method to wait for the instance to reach a terminal state (Completed, Terminated, Failed, etc.).
+    /// can use the <see cref="GetInstanceMetadataAsync(string, bool, CancellationToken)"/> to query the status of the
+    /// scheduled instance, the <see cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/> method to wait
+    /// for the instance to transition out of the <see cref="OrchestrationRuntimeStatus.Pending"/> status, or the
+    /// <see cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/> method to wait for the instance to
+    /// reach a terminal state (Completed, Terminated, Failed, etc.).
     /// </para>
     /// </remarks>
     /// <param name="orchestratorName">The name of the orchestrator to schedule.</param>
@@ -69,6 +80,10 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
     /// <param name="options">The options to start the new orchestration with.</param>
+    /// <param name="cancellation">
+    /// The cancellation token. This only cancels enqueueing the new orchestration to the backend. Does not cancel the
+    /// orchestration once enqueued.
+    /// </param>
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
     /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
@@ -76,7 +91,15 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="orchestratorName"/> is empty.</exception>
     public abstract Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null);
+        TaskName orchestratorName,
+        object? input = null,
+        StartOrchestrationOptions? options = null,
+        CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="RaiseEventAsync(string, string, object, CancellationToken)"/>
+    public virtual Task RaiseEventAsync(
+        string instanceId, string eventName, CancellationToken cancellation)
+        => this.RaiseEventAsync(instanceId, eventName, null, cancellation);
 
     /// <summary>
     /// Sends an event notification message to a waiting orchestration instance.
@@ -101,11 +124,21 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <param name="instanceId">The ID of the orchestration instance that will handle the event.</param>
     /// <param name="eventName">The name of the event. Event names are case-insensitive.</param>
     /// <param name="eventPayload">The serializable data payload to include with the event.</param>
+    /// <param name="cancellation">
+    /// The cancellation token. This only cancels enqueueing the event to the backend. Does not abort sending the event
+    /// once enqueued.
+    /// </param>
     /// <returns>A task that completes when the event notification message has been enqueued.</returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="instanceId"/> or <paramref name="eventName"/> is null or empty.
     /// </exception>
-    public abstract Task RaiseEventAsync(string instanceId, string eventName, object? eventPayload);
+    public abstract Task RaiseEventAsync(
+        string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="TerminateAsync(string, object, CancellationToken)"/>
+    public virtual Task TerminateAsync(
+        string instanceId, CancellationToken cancellation)
+        => this.TerminateAsync(instanceId, null, cancellation);
 
     /// <summary>
     /// Terminates a running orchestration instance and updates its runtime status to
@@ -116,7 +149,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// This method internally enqueues a "terminate" message in the task hub. When the task hub worker processes
     /// this message, it will update the runtime status of the target instance to
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/>. You can use the
-    /// <see cref="WaitForInstanceCompletionAsync"/> to wait for the instance to reach the terminated state.
+    /// <see cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/> to wait for the instance to reach
+    /// the terminated state.
     /// </para>
     /// <para>
     /// Terminating an orchestration instance has no effect on any in-flight activity function executions
@@ -131,8 +165,18 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </remarks>
     /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
     /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
+    /// <param name="cancellation">
+    /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
+    /// termination of the orchestration once enqueued.
+    /// </param>
     /// <returns>A task that completes when the terminate message is enqueued.</returns>
-    public abstract Task TerminateAsync(string instanceId, object? output);
+    public abstract Task TerminateAsync(
+        string instanceId, object? output = null, CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/>
+    public virtual Task<OrchestrationMetadata> WaitForInstanceStartAsync(
+        string instanceId, CancellationToken cancellation)
+        => this.WaitForInstanceStartAsync(instanceId, false, cancellation);
 
     /// <summary>
     /// Waits for an orchestration to start running and returns a <see cref="OrchestrationMetadata"/>
@@ -147,22 +191,23 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The unique ID of the orchestration instance to wait for.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> that can be used to cancel the wait operation.
-    /// </param>
     /// <param name="getInputsAndOutputs">
     /// Specify <c>true</c> to fetch the orchestration instance's inputs, outputs, and custom status, or <c>false</c> to
     /// omit them. The default value is <c>false</c> to minimize the network bandwidth, serialization, and memory costs
     /// associated with fetching the instance metadata.
     /// </param>
+    /// <param name="cancellation">A <see cref="CancellationToken"/> that can be used to cancel the wait operation.</param>
     /// <returns>
     /// Returns a <see cref="OrchestrationMetadata"/> record that describes the orchestration instance and its execution
     /// status or <c>null</c> if no instance with ID <paramref name="instanceId"/> is found.
     /// </returns>
     public abstract Task<OrchestrationMetadata> WaitForInstanceStartAsync(
-        string instanceId,
-        CancellationToken cancellationToken,
-        bool getInputsAndOutputs = false);
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/>
+    public virtual Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
+        string instanceId, CancellationToken cancellation)
+        => this.WaitForInstanceCompletionAsync(instanceId, false, cancellation);
 
     /// <summary>
     /// Waits for an orchestration to complete and returns a <see cref="OrchestrationMetadata"/>
@@ -177,16 +222,19 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// Orchestrations are long-running and could take hours, days, or months before completing.
     /// Orchestrations can also be eternal, in which case they'll never complete unless terminated.
     /// In such cases, this call may block indefinitely, so care must be taken to ensure appropriate timeouts are
-    /// enforced using the <paramref name="cancellationToken"/> parameter.
+    /// enforced using the <paramref name="cancellation"/> parameter.
     /// </para><para>
     /// If an orchestration instance is already complete when this method is called, the method will return immediately.
     /// </para>
     /// </remarks>
-    /// <inheritdoc cref="WaitForInstanceStartAsync(string, CancellationToken, bool)"/>
+    /// <inheritdoc cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/>
     public abstract Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
-        string instanceId,
-        CancellationToken cancellationToken,
-        bool getInputsAndOutputs = false);
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="GetInstanceMetadataAsync(string, bool, CancellationToken)"/>
+    public virtual Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+        string instanceId, CancellationToken cancellation)
+        => this.GetInstanceMetadataAsync(instanceId, false, cancellation);
 
     /// <summary>
     /// Fetches orchestration instance metadata from the configured durable store.
@@ -197,13 +245,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// recommended that you set this parameter to <c>false</c> to minimize the network bandwidth, serialization, and
     /// memory costs associated with fetching the instance metadata.
     /// </remarks>
-    /// <param name="instanceId">The unique ID of the orchestration instance to fetch.</param>
-    /// <param name="getInputsAndOutputs">
-    /// Specify <c>true</c> to fetch the orchestration instance's inputs, outputs, and custom status, or <c>false</c> to
-    /// omit them.
-    /// </param>
-    /// <inheritdoc cref="WaitForInstanceStartAsync(string, CancellationToken, bool)"/>
-    public abstract Task<OrchestrationMetadata?> GetInstanceMetadataAsync(string instanceId, bool getInputsAndOutputs);
+    /// <inheritdoc cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/>
+    public abstract Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
     /// <summary>
     /// Queries orchestration instances.

--- a/src/Client/Core/OrchestrationMetadata.cs
+++ b/src/Client/Core/OrchestrationMetadata.cs
@@ -11,9 +11,9 @@ namespace Microsoft.DurableTask.Client;
 /// </summary>
 /// <remarks>
 /// Instances of this class are produced by methods in the <see cref="DurableTaskClient"/> class, such as
-/// <see cref="DurableTaskClient.GetInstanceMetadataAsync"/>,
-/// <see cref="DurableTaskClient.WaitForInstanceStartAsync"/> and
-/// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync"/>.
+/// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/>,
+/// <see cref="DurableTaskClient.WaitForInstanceStartAsync(string, CancellationToken)"/> and
+/// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/>.
 /// </remarks>
 public sealed class OrchestrationMetadata
 {
@@ -117,9 +117,9 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync"/> or
-    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync"/> method that produced this
-    /// <see cref="OrchestrationMetadata"/> object.
+    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
+    /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>
     /// <typeparam name="T">The type to deserialize the orchestration input into.</typeparam>
     /// <returns>Returns the deserialized input value.</returns>
@@ -143,9 +143,9 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync"/> or
-    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync"/> method that produced this
-    /// <see cref="OrchestrationMetadata"/> object.
+    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
+    /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>
     /// <typeparam name="T">The type to deserialize the orchestration output into.</typeparam>
     /// <returns>Returns the deserialized output value.</returns>
@@ -169,9 +169,9 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync"/> or
-    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync"/> method that produced this
-    /// <see cref="OrchestrationMetadata"/> object.
+    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
+    /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>
     /// <typeparam name="T">The type to deserialize the orchestration' custom status into.</typeparam>
     /// <returns>Returns the deserialized custom status value.</returns>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -60,7 +60,10 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<string> ScheduleNewOrchestrationInstanceAsync(
-        TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null)
+        TaskName orchestratorName,
+        object? input = null,
+        StartOrchestrationOptions? options = null,
+        CancellationToken cancellation = default)
     {
         var request = new P.CreateInstanceRequest
         {
@@ -83,12 +86,14 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             request.ScheduledStartTimestamp = Timestamp.FromDateTimeOffset(startAt.Value.ToUniversalTime());
         }
 
-        P.CreateInstanceResponse? result = await this.sidecarClient.StartInstanceAsync(request);
+        P.CreateInstanceResponse? result = await this.sidecarClient.StartInstanceAsync(
+            request, cancellationToken: cancellation);
         return result.InstanceId;
     }
 
     /// <inheritdoc/>
-    public override async Task RaiseEventAsync(string instanceId, string eventName, object? eventPayload)
+    public override async Task RaiseEventAsync(
+        string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(instanceId))
         {
@@ -107,11 +112,12 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             Input = this.DataConverter.Serialize(eventPayload),
         };
 
-        await this.sidecarClient.RaiseEventAsync(request);
+        await this.sidecarClient.RaiseEventAsync(request, cancellationToken: cancellation);
     }
 
     /// <inheritdoc/>
-    public override async Task TerminateAsync(string instanceId, object? output)
+    public override async Task TerminateAsync(
+        string instanceId, object? output = null, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(instanceId))
         {
@@ -121,17 +127,18 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         this.logger.TerminatingInstance(instanceId);
 
         string? serializedOutput = this.DataConverter.Serialize(output);
-        await this.sidecarClient.TerminateInstanceAsync(new P.TerminateRequest
-        {
-            InstanceId = instanceId,
-            Output = serializedOutput,
-        });
+        await this.sidecarClient.TerminateInstanceAsync(
+            new P.TerminateRequest
+            {
+                InstanceId = instanceId,
+                Output = serializedOutput,
+            },
+            cancellationToken: cancellation);
     }
 
     /// <inheritdoc/>
     public override async Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
-        string instanceId,
-        bool getInputsAndOutputs = false)
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(instanceId))
         {
@@ -143,7 +150,8 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             {
                 InstanceId = instanceId,
                 GetInputsAndOutputs = getInputsAndOutputs,
-            });
+            },
+            cancellationToken: cancellation);
 
         // REVIEW: Should we return a non-null value instead of !exists?
         if (!response.Exists)
@@ -204,9 +212,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<OrchestrationMetadata> WaitForInstanceStartAsync(
-        string instanceId,
-        CancellationToken cancellationToken,
-        bool getInputsAndOutputs = false)
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {
         this.logger.WaitingForInstanceStart(instanceId, getInputsAndOutputs);
 
@@ -216,27 +222,22 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             GetInputsAndOutputs = getInputsAndOutputs,
         };
 
-        P.GetInstanceResponse response;
         try
         {
-            response = await this.sidecarClient.WaitForInstanceStartAsync(
-                request,
-                cancellationToken: cancellationToken);
+            P.GetInstanceResponse response = await this.sidecarClient.WaitForInstanceStartAsync(
+                request, cancellationToken: cancellation);
+            return this.CreateMetadata(response.OrchestrationState, getInputsAndOutputs);
         }
         catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
         {
             throw new OperationCanceledException(
-                $"The {nameof(this.WaitForInstanceStartAsync)} operation was canceled.", e, cancellationToken);
+                $"The {nameof(this.WaitForInstanceStartAsync)} operation was canceled.", e, cancellation);
         }
-
-        return this.CreateMetadata(response.OrchestrationState, getInputsAndOutputs);
     }
 
     /// <inheritdoc/>
     public override async Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
-        string instanceId,
-        CancellationToken cancellationToken,
-        bool getInputsAndOutputs = false)
+        string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {
         this.logger.WaitingForInstanceCompletion(instanceId, getInputsAndOutputs);
 
@@ -246,20 +247,17 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             GetInputsAndOutputs = getInputsAndOutputs,
         };
 
-        P.GetInstanceResponse response;
         try
         {
-            response = await this.sidecarClient.WaitForInstanceCompletionAsync(
-                request,
-                cancellationToken: cancellationToken);
+            P.GetInstanceResponse response = await this.sidecarClient.WaitForInstanceCompletionAsync(
+                request, cancellationToken: cancellation);
+            return this.CreateMetadata(response.OrchestrationState, getInputsAndOutputs);
         }
         catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
         {
             throw new OperationCanceledException(
-                $"The {nameof(this.WaitForInstanceCompletionAsync)} operation was canceled.", e, cancellationToken);
+                $"The {nameof(this.WaitForInstanceCompletionAsync)} operation was canceled.", e, cancellation);
         }
-
-        return this.CreateMetadata(response.OrchestrationState, getInputsAndOutputs);
     }
 
     /// <inheritdoc/>

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -78,7 +78,7 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
-            string instanceId, bool getInputsAndOutputs)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
@@ -101,7 +101,7 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task RaiseEventAsync(
-            string instanceId, string eventName, object? eventPayload)
+            string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
@@ -109,24 +109,26 @@ public class DefaultDurableTaskClientBuilderTests
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
-            StartOrchestrationOptions? options = null)
+            StartOrchestrationOptions? options = null,
+            CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task TerminateAsync(string instanceId, object? output)
+        public override Task TerminateAsync(
+            string instanceId, object? output = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
-            string instanceId, CancellationToken cancellationToken, bool getInputsAndOutputs = false)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<OrchestrationMetadata> WaitForInstanceStartAsync(
-            string instanceId, CancellationToken cancellationToken, bool getInputsAndOutputs = false)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -108,13 +108,12 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
-            string instanceId, bool getInputsAndOutputs)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstances(
-            OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetInstances(OrchestrationQuery? query = null)
         {
             throw new NotImplementedException();
         }
@@ -132,7 +131,7 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task RaiseEventAsync(
-            string instanceId, string eventName, object? eventPayload)
+            string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
@@ -140,24 +139,26 @@ public class DurableTaskClientBuilderExtensionsTests
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
-            StartOrchestrationOptions? options = null)
+            StartOrchestrationOptions? options = null,
+            CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task TerminateAsync(string instanceId, object? output)
+        public override Task TerminateAsync(
+            string instanceId, object? output = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
-            string instanceId, CancellationToken cancellationToken, bool getInputsAndOutputs = false)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<OrchestrationMetadata> WaitForInstanceStartAsync(
-            string instanceId, CancellationToken cancellationToken, bool getInputsAndOutputs = false)
+            string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -99,7 +99,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
 
         await ForEachOrchestrationAsync(
             x => server.Client.ScheduleNewOrchestrationInstanceAsync(
-                OrchestrationName, input: false, new() { InstanceId = x }));
+                OrchestrationName, input: false, new StartOrchestrationOptions(x)));
         AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);
 
         await ForEachOrchestrationAsync(x => server.Client.WaitForInstanceStartAsync(x, default));
@@ -125,7 +125,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         for (int i = 0; i < 21; i++)
         {
             await server.Client.ScheduleNewOrchestrationInstanceAsync(
-                OrchestrationName, input: false, new() { InstanceId = $"GetInstances_AsPages_EndToEnd-{i}" });
+                OrchestrationName, input: false, new StartOrchestrationOptions($"GetInstances_AsPages_EndToEnd-{i}"));
         }
 
         AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -41,9 +41,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
@@ -93,9 +91,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
@@ -144,9 +140,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
@@ -206,9 +200,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
@@ -251,9 +243,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
@@ -313,9 +303,7 @@ public class OrchestrationErrorHandling : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -110,9 +110,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         List<bool>? results = metadata.ReadOutputAs<List<bool>>();
         Assert.NotNull(results);
@@ -154,9 +152,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.True(metadata.ReadOutputAs<bool>());
@@ -178,9 +174,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input: "World");
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal("Hello, World!", metadata.ReadOutputAs<string>());
@@ -203,9 +197,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input: "World");
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal("Hello, World!", metadata.ReadOutputAs<string>());
@@ -235,9 +227,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input: "World");
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal(10, metadata.ReadOutputAs<int>());
@@ -270,9 +260,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
 
@@ -315,9 +303,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         // Once the orchestration receives all the events it is expecting, it should complete.
         metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
 
@@ -342,9 +328,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         await server.Client.TerminateAsync(instanceId, expectedOutput);
 
         metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(OrchestrationRuntimeStatus.Terminated, metadata.RuntimeStatus);
@@ -376,9 +360,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal(10, metadata.ReadOutputAs<int>());
@@ -406,9 +388,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input: 1);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal(15, metadata.ReadOutputAs<int>());
@@ -433,9 +413,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         // To ensure consistency, wait for the instance to start before sending the events
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceStartAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal("Started!", metadata.ReadCustomStatusAs<string>());
 
@@ -448,9 +426,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         // Once the orchestration receives all the events it is expecting, it should complete.
         metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal(eventPayload, metadata.ReadCustomStatusAs<(string, int)>());
@@ -498,9 +474,7 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.True(metadata.ReadOutputAs<bool>());
@@ -536,7 +510,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(
             "SpecialSerialization_Orchestration", input: input);
         OrchestrationMetadata result = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId, this.TimeoutToken, getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
         JsonNode? output = result.ReadOutputAs<JsonNode>();
 
         Assert.NotNull(output);

--- a/test/Grpc.IntegrationTests/PageableIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/PageableIntegrationTests.cs
@@ -32,9 +32,7 @@ public class PageableIntegrationTests : IntegrationTestBase
         string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(
             orchestratorName, input: string.Empty);
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
-            instanceId,
-            this.TimeoutToken,
-            getInputsAndOutputs: true);
+            instanceId, getInputsAndOutputs: true, this.TimeoutToken);
 
         metadata.ReadOutputAs<int>().Should().Be(9);
     }


### PR DESCRIPTION
This PR introduces some (breaking) changes to `DurableTaskClient`.

1. Ensure all `async` methods take in `CancellationToken`.
2. Ensure that the `CancellationToken` is the _last_ parameter
3. Add some QoL `virtual` overloads to get to the `CancellationToken` faster, skipping optional parameters.
    - This is also important when one of those parameters is `object`, to avoid mistakenly providing `CancellationToken` as that `object` parameter.