### PR TITLE
Allow for injecting ILogger in ITaskOrchestrator

### DIFF
--- a/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
+++ b/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.DurableTask;
 
 /// <summary>
@@ -37,9 +39,8 @@ public partial class DurableTaskRegistry
     /// <returns>The same registry, for call chaining.</returns>
     public DurableTaskRegistry AddOrchestrator(TaskName name, Type type)
     {
-        // TODO: Compile a constructor expression for performance.
         Check.ConcreteType<ITaskOrchestrator>(type);
-        return this.AddOrchestrator(name, () => (ITaskOrchestrator)Activator.CreateInstance(type));
+        return this.AddOrchestratorCore(name, sp => (ITaskOrchestrator)ActivatorUtilities.CreateInstance(sp, type));
     }
 
     /// <summary>

--- a/src/Abstractions/DurableTaskRegistry.cs
+++ b/src/Abstractions/DurableTaskRegistry.cs
@@ -67,13 +67,20 @@ public sealed partial class DurableTaskRegistry
     {
         Check.NotDefault(name);
         Check.NotNull(factory);
+        return this.AddOrchestratorCore(name, _ => factory());
+    }
+
+    DurableTaskRegistry AddOrchestratorCore(TaskName name, Func<IServiceProvider, ITaskOrchestrator> factory)
+    {
+        Check.NotDefault(name);
+        Check.NotNull(factory);
         if (this.Orchestrators.ContainsKey(name))
         {
             throw new ArgumentException(
                 $"An {nameof(ITaskOrchestrator)} named '{name}' is already added.", nameof(name));
         }
 
-        this.Orchestrators.Add(name, _ => factory());
+        this.Orchestrators.Add(name, sp => factory(sp));
         return this;
     }
 }

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -390,7 +390,7 @@ public abstract class TaskOrchestrationContext
 
         public IDisposable BeginScope<TState>(TState state) => this.logger.BeginScope(state);
 
-        public bool IsEnabled(LogLevel logLevel) => this.logger.IsEnabled(logLevel);
+        public bool IsEnabled(LogLevel logLevel) => !this.context.IsReplaying && this.logger.IsEnabled(logLevel);
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -399,7 +399,7 @@ public abstract class TaskOrchestrationContext
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            if (!this.context.IsReplaying)
+            if (this.IsEnabled(logLevel))
             {
                 this.logger.Log(logLevel, eventId, state, exception, formatter);
             }

--- a/src/Worker/Core/DependencyInjection/OrchestrationServiceProvider.cs
+++ b/src/Worker/Core/DependencyInjection/OrchestrationServiceProvider.cs
@@ -30,6 +30,7 @@ public sealed class OrchestrationServiceProvider : IServiceProvider
     /// <param name="innerProvider">The inner service provider.</param>
     internal OrchestrationServiceProvider(IServiceProvider innerProvider)
     {
+        Check.NotNull(innerProvider);
         this.loggerFactory = new(() =>
         {
             ILoggerFactory inner = innerProvider.GetRequiredService<ILoggerFactory>();
@@ -48,10 +49,11 @@ public sealed class OrchestrationServiceProvider : IServiceProvider
 
         if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(ILogger<>))
         {
-            Type closed = typeof(Logger<>).MakeGenericType(serviceType);
+            Type closed = typeof(Logger<>).MakeGenericType(serviceType.GenericTypeArguments.First());
             return Activator.CreateInstance(closed, this.loggerFactory.Value);
         }
 
+        // TODO: Create and include a support link for more information.
         throw new NotSupportedException($"Type {serviceType} is not supported in orchestrations.");
     }
 }

--- a/src/Worker/Core/DependencyInjection/OrchestrationServiceProvider.cs
+++ b/src/Worker/Core/DependencyInjection/OrchestrationServiceProvider.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask.Worker.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DurableTask.Worker.DependencyInjection;
+
+/// <summary>
+/// A special <see cref="IServiceProvider" /> for orchestrations which will allow for resolving a <b>limited</b> set of
+/// services. These services are carefully chosen to ensure they are orchestration-safe.
+/// </summary>
+/// <remarks>
+/// In most cases, using injected services in an orchestration will lead to replay-idempotence issues, resulting in
+/// hard to diagnose issues. To avoid this, we intentionally block most services from being injected and only allow a
+/// very small set of pre-approved services, where we have wrapped it in a idempotent safe version.
+///
+/// Supported services:
+/// - ILogger{T}. A replay-safe logger.
+/// - ILoggerFactory. Provides replay-safe loggers.
+/// </remarks>
+public sealed class OrchestrationServiceProvider : IServiceProvider
+{
+    readonly Lazy<ILoggerFactory> loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrchestrationServiceProvider"/> class.
+    /// </summary>
+    /// <param name="innerProvider">The inner service provider.</param>
+    internal OrchestrationServiceProvider(IServiceProvider innerProvider)
+    {
+        this.loggerFactory = new(() =>
+        {
+            ILoggerFactory inner = innerProvider.GetRequiredService<ILoggerFactory>();
+            return new OrchestrationLoggerFactory(inner);
+        });
+    }
+
+    /// <inheritdoc/>
+    public object GetService(Type serviceType)
+    {
+        Check.NotNull(serviceType);
+        if (serviceType == typeof(ILoggerFactory))
+        {
+            return this.loggerFactory.Value;
+        }
+
+        if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(ILogger<>))
+        {
+            Type closed = typeof(Logger<>).MakeGenericType(serviceType);
+            return Activator.CreateInstance(closed, this.loggerFactory.Value);
+        }
+
+        throw new NotSupportedException($"Type {serviceType} is not supported in orchestrations.");
+    }
+}

--- a/src/Worker/Core/DurableTaskFactory.cs
+++ b/src/Worker/Core/DurableTaskFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.DurableTask.Worker.DependencyInjection;
 
 namespace Microsoft.DurableTask.Worker;
 
@@ -47,7 +48,7 @@ sealed class DurableTaskFactory : IDurableTaskFactory
     {
         if (this.orchestrators.TryGetValue(name, out Func<IServiceProvider, ITaskOrchestrator>? factory))
         {
-            orchestrator = factory.Invoke(serviceProvider);
+            orchestrator = factory.Invoke(new OrchestrationServiceProvider(serviceProvider));
             return true;
         }
 

--- a/src/Worker/Core/Logging/OrchestrationLoggerFactory.cs
+++ b/src/Worker/Core/Logging/OrchestrationLoggerFactory.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DurableTask.Worker.Logging;
+
+/// <summary>
+/// An <see cref="ILoggerFactory" /> for orchestrations which provides replay-safe <see cref="ILogger" />
+/// implementations.
+/// </summary>
+public sealed class OrchestrationLoggerFactory : ILoggerFactory
+{
+    readonly ILoggerFactory innerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrchestrationLoggerFactory"/> class.
+    /// </summary>
+    /// <param name="innerFactory">The inner logger factory.</param>
+    internal OrchestrationLoggerFactory(ILoggerFactory innerFactory)
+    {
+        this.innerFactory = Check.NotNull(innerFactory);
+    }
+
+    /// <inheritdoc/>
+    public void AddProvider(ILoggerProvider provider)
+    {
+        throw new NotSupportedException($"Adding providers to {typeof(OrchestrationLoggerFactory)} is not supported.");
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName)
+    {
+        TaskOrchestrationContext? context = TaskOrchestrationContextAccessor.Current;
+        if (context is null)
+        {
+            throw new InvalidOperationException(
+                $"{typeof(OrchestrationLoggerFactory)} can only be used from within a {typeof(ITaskOrchestrator)}.");
+        }
+
+        ILogger inner = this.innerFactory.CreateLogger(categoryName);
+        return context.CreateReplaySafeLogger(inner);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // no-op
+    }
+}

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -47,6 +47,7 @@ partial class TaskOrchestrationShim : TaskOrchestration
         object? input = this.DataConverter.Deserialize(rawInput, this.implementation.InputType);
         ILogger contextLogger = this.LoggerFactory.CreateLogger("Microsoft.DurableTask");
         this.wrapperContext = new(innerContext, this.invocationContext, contextLogger, input);
+        TaskOrchestrationContextAccessor.Current = this.wrapperContext;
         object? output = await this.implementation.RunAsync(this.wrapperContext, input);
 
         // Return the output (if any) as a serialized string.

--- a/src/Worker/Core/TaskOrchestrationContextAccessor.cs
+++ b/src/Worker/Core/TaskOrchestrationContextAccessor.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Worker;
+
+/// <summary>
+/// Accessor for the current <see cref="TaskOrchestrationContext" />.
+/// </summary>
+static class TaskOrchestrationContextAccessor
+{
+    static readonly AsyncLocal<TaskOrchestrationContext?> CurrentLocal = new();
+
+    /// <summary>
+    /// Gets or sets the current <see cref="TaskOrchestrationContext" />.
+    /// </summary>
+    public static TaskOrchestrationContext? Current
+    {
+        get => CurrentLocal.Value;
+        set => CurrentLocal.Value = value;
+    }
+}

--- a/test/Worker/Core.Tests/DependencyInjection/OrchestrationServiceProviderTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/OrchestrationServiceProviderTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Microsoft.DurableTask.Worker.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DurableTask.Worker.DependencyInjection.Tests;
+
+public sealed class OrchestrationServiceProviderTests : IDisposable
+{
+    readonly IServiceProvider serviceProvider;
+
+    public OrchestrationServiceProviderTests()
+    {
+        // Ensure not set before test.
+        TaskOrchestrationContextAccessor.Current = null;
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton(new MyService());
+        this.serviceProvider = services.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        // Ensure not set after test.
+        TaskOrchestrationContextAccessor.Current = null;
+    }
+
+    [Fact]
+    public void Ctor_Null_Throws()
+    {
+        Func<OrchestrationServiceProvider> act = () => new OrchestrationServiceProvider(null!);
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("innerProvider");
+    }
+
+    [Fact]
+    public void GetService_Null_Throws()
+    {
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        Action act = () => services.GetService(null!);
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("serviceType");
+    }
+
+    [Fact]
+    public void GetService_UnsupportedType_Throws()
+    {
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        Action act = () => services.GetService(typeof(MyService));
+        act.Should().ThrowExactly<NotSupportedException>();
+    }
+
+    [Fact]
+    public void GetService_LoggerFactory_Success()
+    {
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        object factory = services.GetService(typeof(ILoggerFactory));
+        factory.Should().BeOfType<OrchestrationLoggerFactory>();
+    }
+
+    [Fact]
+    public void GetService_LoggerT_Success()
+    {
+        TaskOrchestrationContextAccessor.Current = Mock.Of<TaskOrchestrationContext>();
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        object logger = services.GetService(typeof(ILogger<OrchestrationServiceProviderTests>));
+
+        logger.Should().BeOfType<Logger<OrchestrationServiceProviderTests>>();
+        VerifyLoggerType(logger);
+    }
+
+    [Fact]
+    public void Activate_Logger_Success()
+    {
+        TaskOrchestrationContextAccessor.Current = Mock.Of<TaskOrchestrationContext>();
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        TestOrchestrator orchestrator = ActivatorUtilities.CreateInstance<TestOrchestrator>(services);
+
+        orchestrator.Logger.Should().NotBeNull();
+        VerifyLoggerType(orchestrator.Logger);
+    }
+
+    [Fact]
+    public void Activate_Options_Throws()
+    {
+        TaskOrchestrationContextAccessor.Current = Mock.Of<TaskOrchestrationContext>();
+        OrchestrationServiceProvider services = new(this.serviceProvider);
+        Action act = () => ActivatorUtilities.CreateInstance<BadOrchestrator>(services);
+
+        act.Should().ThrowExactly<NotSupportedException>();
+    }
+
+    static void VerifyLoggerType(object logger)
+    {
+        // Reflection to verify the inner logger is replay-safe
+        ILogger inner = (ILogger)logger.GetType()
+            .GetField("_logger", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(logger)!;
+        inner.GetType().Name.Should().Be("ReplaySafeLogger");
+    }
+
+    class TestOrchestrator : TaskOrchestrator<object, object>
+    {
+        public TestOrchestrator(ILogger<TestOrchestrator> logger)
+        {
+            this.Logger = logger;
+        }
+
+        public ILogger Logger { get; }
+
+        public override Task<object> RunAsync(TaskOrchestrationContext context, object input)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    class BadOrchestrator : TaskOrchestrator<object, object>
+    {
+        public BadOrchestrator(MyService service)
+        {
+        }
+
+        public override Task<object> RunAsync(TaskOrchestrationContext context, object input)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    class MyService { }
+}

--- a/test/Worker/Core.Tests/Logging/OrchestrationLoggerFactoryTests.cs
+++ b/test/Worker/Core.Tests/Logging/OrchestrationLoggerFactoryTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask.Tests.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.DurableTask.Worker.Logging.Tests;
+
+public sealed class OrchestrationLoggerFactoryTests : IDisposable
+{
+    readonly ILoggerFactory loggerFactory;
+
+    public OrchestrationLoggerFactoryTests(ITestOutputHelper output)
+    {
+        // Ensure not set before test.
+        TaskOrchestrationContextAccessor.Current = null;
+        this.loggerFactory = new LoggerFactory();
+        this.loggerFactory.AddProvider(new TestLogProvider(output));
+    }
+
+    public void Dispose()
+    {
+        // Ensure not set after test.
+        TaskOrchestrationContextAccessor.Current = null;
+    }
+
+    [Fact]
+    public void Ctor_Null_Throws()
+    {
+        Func<OrchestrationLoggerFactory> act = () => new OrchestrationLoggerFactory(null!);
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("innerFactory");
+    }
+
+    [Fact]
+    public void AddProvider_Throws()
+    {
+        OrchestrationLoggerFactory factory = new(this.loggerFactory);
+        Action act = () => factory.AddProvider(Mock.Of<ILoggerProvider>());
+        act.Should().ThrowExactly<NotSupportedException>();
+    }
+
+    [Fact]
+    public void CreateLogger_NoContext_Throws()
+    {
+        OrchestrationLoggerFactory factory = new(this.loggerFactory);
+        Action act = () => factory.CreateLogger("test");
+        act.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreateLogger_Context_Creates(bool isReplaying)
+    {
+        OrchestrationLoggerFactory factory = new(this.loggerFactory);
+        Mock<TaskOrchestrationContext> context = new();
+        context.Setup(x => x.IsReplaying).Returns(isReplaying);
+        TaskOrchestrationContextAccessor.Current = context.Object;
+
+        ILogger logger = factory.CreateLogger("test");
+        logger.Should().NotBeNull();
+        logger.IsEnabled(LogLevel.Debug).Should().Be(!isReplaying);
+        logger.GetType().Name.Should().Be("ReplaySafeLogger");
+    }
+}

--- a/test/Worker/Core.Tests/Worker.Tests.csproj
+++ b/test/Worker/Core.Tests/Worker.Tests.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduces restricted dependency injection for `ITaskOrchestrator`. The first supported interfaces are `ILogger<T>` and `ILoggerFactory`. The resulting services will be/provide replay-safe loggers. Attempting to resolve any other type from the `IServiceProvider` will throw.

### TODO

- [x] Unit Tests
- [ ] Integration Tests

resolves #46 