### PR TITLE
Use ActivatorUtilities.GetServiceOrCreateInstance for TaskActivity in Azure Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.0.0
+
+- Durable Functions class-based syntax now resolves `ITaskActivity` instances from `IServiceProvider`, if available there.
+
 ## v1.0.0-rc.1
 
 ### Included Packages

--- a/src/Generators/DurableTaskSourceGenerator.cs
+++ b/src/Generators/DurableTaskSourceGenerator.cs
@@ -212,7 +212,7 @@ namespace Microsoft.DurableTask
         [Function(nameof({activity.TaskName}))]
         public static async Task<{activity.OutputType}> {activity.TaskName}([ActivityTrigger] {activity.InputParameter}, string instanceId, FunctionContext executionContext)
         {{
-            ITaskActivity activity = ActivatorUtilities.CreateInstance<{activity.TypeName}>(executionContext.InstanceServices);
+            ITaskActivity activity = ActivatorUtilities.GetServiceOrCreateInstance<{activity.TypeName}>(executionContext.InstanceServices);
             TaskActivityContext context = new GeneratedActivityContext(""{activity.TaskName}"", instanceId);
             object? result = await activity.RunAsync(context, input);
             return ({activity.OutputType})result!;


### PR DESCRIPTION
Changes `ActiviatorUtilities.CreateInstance<T>` to `ActivatorUtilities.GetServiceOrCreateInstance<T>` inside the source generated code for Azure Functions.

resolves #88 