### PR TITLE
Expose ILogger creation on TaskOrchestrationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.0.0
+
+- `TaskOrchestrationContext.CreateReplaySafeLogger` now creates `ILogger` directly (as opposed to wrapping an existing `ILogger`).
+
 ## v1.0.0-rc.1
 
 ### Included Packages

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -374,21 +374,13 @@ public abstract class TaskOrchestrationContext
     public ILogger CreateReplaySafeLogger(string categoryName)
         => new ReplaySafeLogger(this, this.LoggerFactory.CreateLogger(categoryName));
 
-    /// <summary>
-    /// Returns an instance of <see cref="ILogger"/> that is replay-safe, meaning that the logger only
-    /// writes logs when the orchestrator is not replaying previous history.
-    /// </summary>
+    /// <inheritdoc cref="CreateReplaySafeLogger(string)" />
     /// <param name="type">The type to derive the category name from.</param>
-    /// <returns>An instance of <see cref="ILogger"/> that is replay-safe.</returns>
     public virtual ILogger CreateReplaySafeLogger(Type type)
         => new ReplaySafeLogger(this, this.LoggerFactory.CreateLogger(type));
 
-    /// <summary>
-    /// Returns an instance of <see cref="ILogger"/> that is replay-safe, meaning that the logger only
-    /// writes logs when the orchestrator is not replaying previous history.
-    /// </summary>
+    /// <inheritdoc cref="CreateReplaySafeLogger(string)" />
     /// <typeparam name="T">The type to derive category name from.</typeparam>
-    /// <returns>An instance of <see cref="ILogger"/> that is replay-safe.</returns>
     public virtual ILogger CreateReplaySafeLogger<T>()
         => new ReplaySafeLogger(this, this.LoggerFactory.CreateLogger<T>());
 

--- a/src/Abstractions/TaskOrchestrator.cs
+++ b/src/Abstractions/TaskOrchestrator.cs
@@ -81,9 +81,9 @@ public interface ITaskOrchestrator
 ///       input.
 ///     </item>
 ///     <item>
-///       Avoid logging directly in the orchestrator code because log messages will be duplicated on each replay.
-///       Instead, use the <see cref="TaskOrchestrationContext.CreateReplaySafeLogger"/> method to wrap an existing
-///       <see cref="ILogger"/> into a new <c>ILogger</c> that automatically filters out replay logs.
+///       When logging, ensure you use only loggers created from
+///       <see cref="TaskOrchestrationContext.CreateReplaySafeLogger(string)"/> or other overloads, as this will ensure
+///       logging is not duplicated on each replay.
 ///     </item>
 ///   </list>
 /// </para>

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -31,17 +31,15 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// </summary>
     /// <param name="innerContext">The inner orchestration context.</param>
     /// <param name="invocationContext">The invocation context.</param>
-    /// <param name="logger">The logger.</param>
     /// <param name="deserializedInput">The deserialized input.</param>
     public TaskOrchestrationContextWrapper(
         OrchestrationContext innerContext,
         OrchestrationInvocationContext invocationContext,
-        ILogger logger,
         object? deserializedInput)
     {
         this.innerContext = Check.NotNull(innerContext);
         this.invocationContext = Check.NotNull(invocationContext);
-        this.logger = this.CreateReplaySafeLogger(Check.NotNull(logger));
+        this.logger = this.CreateReplaySafeLogger("Microsoft.DurableTask");
         this.deserializedInput = deserializedInput;
     }
 
@@ -60,9 +58,10 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// <inheritdoc/>
     public override DateTime CurrentUtcDateTime => this.innerContext.CurrentUtcDateTime;
 
-    DataConverter DataConverter => this.invocationContext.Options.DataConverter;
+    /// <inheritdoc/>
+    protected override ILoggerFactory LoggerFactory => this.invocationContext.LoggerFactory;
 
-    ILoggerFactory LoggerFactory => this.invocationContext.LoggerFactory;
+    DataConverter DataConverter => this.invocationContext.Options.DataConverter;
 
     /// <inheritdoc/>
     public override T GetInput<T>() => (T)this.deserializedInput!;

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -45,8 +45,7 @@ partial class TaskOrchestrationShim : TaskOrchestration
         innerContext.ErrorDataConverter = converterShim;
 
         object? input = this.DataConverter.Deserialize(rawInput, this.implementation.InputType);
-        ILogger contextLogger = this.LoggerFactory.CreateLogger("Microsoft.DurableTask");
-        this.wrapperContext = new(innerContext, this.invocationContext, contextLogger, input);
+        this.wrapperContext = new(innerContext, this.invocationContext, input);
         object? output = await this.implementation.RunAsync(this.wrapperContext, input);
 
         // Return the output (if any) as a serialized string.


### PR DESCRIPTION
- Allows for `ILogger` creation from `TaskOrchestrationContext`
- Removes `CreateReplaySafeLogger(ILogger logger)`, as it can now be created directly.
    - In the Functions world, the `FunctionsContext.CreateLogger` methods are basically identical to the `CreateReplaySafeLogger` introduced here, so this method was now redundant.

resolves #46 