### PR TITLE
Add new TaskOption overload for skipping input param

### DIFF
--- a/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
+++ b/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
@@ -9,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.0-rc.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />

--- a/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
+++ b/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
@@ -10,8 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.0-rc.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />

--- a/src/Abstractions/TaskActivity.cs
+++ b/src/Abstractions/TaskActivity.cs
@@ -51,7 +51,8 @@ public interface ITaskActivity
 /// Because activities only guarantee at least once execution, it's recommended that activity logic be implemented as
 /// idempotent whenever possible.
 /// </para><para>
-/// Activities are invoked by orchestrators using one of the <see cref="TaskOrchestrationContext.CallActivityAsync"/>
+/// Activities are invoked by orchestrators using one of the
+/// <see cref="TaskOrchestrationContext.CallActivityAsync(TaskName, object?, TaskOptions?)"/>
 /// method overloads. Activities that derive from <see cref="TaskActivity{TInput, TOutput}"/> can also be invoked
 /// using generated extension methods. To participate in code generation, an activity class must be decorated with the
 /// <see cref="DurableTaskAttribute"/> attribute. The source generator will then generate a <c>CallMyActivityAsync()</c>

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -108,15 +108,30 @@ public abstract class TaskOrchestrationContext
     /// <see cref="TaskFailedException.FailureDetails"/> property.
     /// </exception>
     public virtual Task CallActivityAsync(TaskName name, object? input = null, TaskOptions? options = null)
-    {
-        return this.CallActivityAsync<object>(name, input, options);
-    }
+        => this.CallActivityAsync<object>(name, input, options);
 
     /// <returns>
     /// A task that completes when the activity completes or fails. The result of the task is the activity's return value.
     /// </returns>
-    /// <inheritdoc cref="CallActivityAsync"/>
-    public abstract Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null);
+    /// <inheritdoc cref="CallActivityAsync(TaskName, object?, TaskOptions?)"/>
+    public virtual Task CallActivityAsync(TaskName name, TaskOptions options)
+        => this.CallActivityAsync(name, null, options);
+
+    /// <returns>
+    /// A task that completes when the activity completes or fails. The result of the task is the activity's return value.
+    /// </returns>
+    /// <typeparam name="TResult">The type into which to deserialize the activity's output.</typeparam>
+    /// <inheritdoc cref="CallActivityAsync(TaskName, object?, TaskOptions?)"/>
+    public virtual Task<TResult> CallActivityAsync<TResult>(TaskName name, TaskOptions options)
+        => this.CallActivityAsync<TResult>(name, null, options);
+
+    /// <returns>
+    /// A task that completes when the activity completes or fails. The result of the task is the activity's return value.
+    /// </returns>
+    /// <typeparam name="TResult">The type into which to deserialize the activity's output.</typeparam>
+    /// <inheritdoc cref="CallActivityAsync(TaskName, object?, TaskOptions?)"/>
+    public abstract Task<TResult> CallActivityAsync<TResult>(
+        TaskName name, object? input = null, TaskOptions? options = null);
 
     /// <summary>
     /// Creates a durable timer that expires after the specified delay.
@@ -247,12 +262,25 @@ public abstract class TaskOrchestrationContext
     /// <summary>
     /// Executes a named sub-orchestrator and returns the result.
     /// </summary>
-    /// <typeparam name="TResult">
-    /// The type into which to deserialize the sub-orchestrator's output.
-    /// </typeparam>
+    /// <typeparam name="TResult">The type into which to deserialize the sub-orchestrator's output.</typeparam>
     /// <inheritdoc cref="CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)"/>
     public abstract Task<TResult> CallSubOrchestratorAsync<TResult>(
         TaskName orchestratorName, object? input = null, TaskOptions? options = null);
+
+    /// <summary>
+    /// Executes a named sub-orchestrator and returns the result.
+    /// </summary>
+    /// <typeparam name="TResult">The type into which to deserialize the sub-orchestrator's output.</typeparam>
+    /// <inheritdoc cref="CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)"/>
+    public virtual Task<TResult> CallSubOrchestratorAsync<TResult>(TaskName orchestratorName, TaskOptions options)
+        => this.CallSubOrchestratorAsync<TResult>(orchestratorName, null, options);
+
+    /// <summary>
+    /// Executes a named sub-orchestrator and returns the result.
+    /// </summary>
+    /// <inheritdoc cref="CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)"/>
+    public virtual Task CallSubOrchestratorAsync(TaskName orchestratorName, TaskOptions options)
+        => this.CallSubOrchestratorAsync(orchestratorName, null, options);
 
     /// <summary>
     /// Executes a named sub-orchestrator.
@@ -296,11 +324,9 @@ public abstract class TaskOrchestrationContext
     /// The sub-orchestration failed with an unhandled exception. The details of the failure can be found in the
     /// <see cref="TaskFailedException.FailureDetails"/> property.
     /// </exception>
-    public Task CallSubOrchestratorAsync(
+    public virtual Task CallSubOrchestratorAsync(
         TaskName orchestratorName, object? input = null, TaskOptions? options = null)
-    {
-        return this.CallSubOrchestratorAsync<object>(orchestratorName, input, options);
-    }
+        => this.CallSubOrchestratorAsync<object>(orchestratorName, input, options);
 
     /// <summary>
     /// Restarts the orchestration with a new input and clears its history.

--- a/src/Abstractions/TaskOrchestrator.cs
+++ b/src/Abstractions/TaskOrchestrator.cs
@@ -45,7 +45,8 @@ public interface ITaskOrchestrator
 /// </para>
 /// <para>
 ///   Orchestrators can be scheduled using an external client (see Microsoft.DurableTask.Client). Orchestrators can
-///   also invoke child orchestrators using the <see cref="TaskOrchestrationContext.CallSubOrchestratorAsync"/> method.
+///   also invoke child orchestrators using the
+///   <see cref="TaskOrchestrationContext.CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)"/> method.
 ///   Orchestrators that derive from <see cref="TaskOrchestrator{TInput, TOutput}"/> can also be invoked using
 ///   generated extension methods. To participate in code generation, an orchestrator class must be decorated with the
 ///   <see cref="DurableTaskAttribute"/> attribute. The source generator will then generate a

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -50,6 +50,11 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
         TaskName orchestratorName, object? input, CancellationToken cancellation)
         => this.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input, null, cancellation);
 
+    /// <inheritdoc cref="ScheduleNewOrchestrationInstanceAsync(TaskName, object, StartOrchestrationOptions, CancellationToken)"/>
+    public virtual Task<string> ScheduleNewOrchestrationInstanceAsync(
+        TaskName orchestratorName, StartOrchestrationOptions options, CancellationToken cancellation = default)
+        => this.ScheduleNewOrchestrationInstanceAsync(orchestratorName, null, options, cancellation);
+
     /// <summary>
     /// Schedules a new orchestration instance for execution.
     /// </summary>


### PR DESCRIPTION
Adds some overloads to protect against accidentally supplying `TaskOptions` as `input`.