### PR TITLE
Make DurableTaskClient method names consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## v1.0.0
 
 - Added `SuspendInstanceAsync` and `ResumeInstanceAsync` to `DurableTaskClient`.
+- Rename `DurableTaskClient` methods
+    - `TerminateAsync` -> `TerminateInstanceAsync`
+    - `PurgeInstances` -> `PurgeAllInstancesAsync`
+    - `PurgeInstanceMetadataAsync` -> `PurgeInstanceAsync`
+    - `GetInstanceMetadataAsync` -> `GetInstanceAsync`
+    - `GetInstances` -> `GetAllInstancesAsync`
 - `TaskOrchestrationContext.CreateReplaySafeLogger` now creates `ILogger` directly (as opposed to wrapping an existing `ILogger`).
 - Durable Functions class-based syntax now resolves `ITaskActivity` instances from `IServiceProvider`, if available there.
 - `DurableTaskClient` methods have been touched up to ensure `CancellationToken` is included, as well as is the last parameter.

--- a/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
@@ -30,7 +30,7 @@ public static class DurableTaskClientExtensions
     {
         Check.NotNull(client);
         PurgeInstancesFilter filter = new(createdFrom, createdTo, statuses);
-        return client.PurgeInstanceMetadataAsync(filter, cancellation);
+        return client.PurgeInstancesAsync(filter, cancellation);
     }
 
     /// <summary>

--- a/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
@@ -30,7 +30,7 @@ public static class DurableTaskClientExtensions
     {
         Check.NotNull(client);
         PurgeInstancesFilter filter = new(createdFrom, createdTo, statuses);
-        return client.PurgeInstancesAsync(filter, cancellation);
+        return client.PurgeAllInstancesAsync(filter, cancellation);
     }
 
     /// <summary>

--- a/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
@@ -30,7 +30,7 @@ public static class DurableTaskClientExtensions
     {
         Check.NotNull(client);
         PurgeInstancesFilter filter = new(createdFrom, createdTo, statuses);
-        return client.PurgeInstancesAsync(filter, cancellation);
+        return client.PurgeInstanceMetadataAsync(filter, cancellation);
     }
 
     /// <summary>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -140,75 +140,15 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task RaiseEventAsync(
         string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default);
 
-    /// <inheritdoc cref="TerminateAsync(string, object, CancellationToken)"/>
-    public virtual Task TerminateAsync(
-        string instanceId, CancellationToken cancellation)
-        => this.TerminateAsync(instanceId, null, cancellation);
-
-    /// <summary>
-    /// Terminates a running orchestration instance and updates its runtime status to
-    /// <see cref="OrchestrationRuntimeStatus.Terminated"/>.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method internally enqueues a "terminate" message in the task hub. When the task hub worker processes
-    /// this message, it will update the runtime status of the target instance to
-    /// <see cref="OrchestrationRuntimeStatus.Terminated"/>. You can use the
-    /// <see cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/> to wait for the instance to reach
-    /// the terminated state.
-    /// </para>
-    /// <para>
-    /// Terminating an orchestration instance has no effect on any in-flight activity function executions
-    /// or sub-orchestrations that were started by the terminated instance. Those actions will continue to run
-    /// without interruption. However, their results will be discarded. If you want to terminate sub-orchestrations,
-    /// you must issue separate terminate commands for each sub-orchestration instance.
-    /// </para><para>
-    /// At the time of writing, there is no way to terminate an in-flight activity execution.
-    /// </para><para>
-    /// Attempting to terminate a completed or non-existent orchestration instance will fail silently.
-    /// </para>
-    /// </remarks>
-    /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
-    /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
-    /// <param name="cancellation">
-    /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
-    /// termination of the orchestration once enqueued.
-    /// </param>
-    /// <returns>A task that completes when the terminate message is enqueued.</returns>
-    public abstract Task TerminateAsync(
-        string instanceId, object? output = null, CancellationToken cancellation = default);
-
     /// <inheritdoc cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/>
     public virtual Task<OrchestrationMetadata> WaitForInstanceStartAsync(
         string instanceId, CancellationToken cancellation)
         => this.WaitForInstanceStartAsync(instanceId, false, cancellation);
 
-    /// <summary>
-    /// Suspends an orchestration instance, halting processing of it until <see cref="ResumeInstanceAsync" /> is used
-    /// to resume the orchestration.
-    /// </summary>
-    /// <param name="instanceId">The instance ID of the orchestration to suspend.</param>
-    /// <param name="reason">The optional suspension reason.</param>
-    /// <param name="cancellation">
-    /// A <see cref="CancellationToken"/> that can be used to cancel the suspend operation. Note, cancelling this token
-    /// does <b>not</b> resume the orchestration if suspend was successful.
-    /// </param>
-    /// <returns>A task that completes when the suspend has been committed to the backend.</returns>
-    public abstract Task SuspendInstanceAsync(
-        string instanceId, string? reason = null, CancellationToken cancellation = default);
-
-    /// <summary>
-    /// Resumes an orchestration instance that was suspended via <see cref="SuspendInstanceAsync" />.
-    /// </summary>
-    /// <param name="instanceId">The instance ID of the orchestration to resume.</param>
-    /// <param name="reason">The optional resume reason.</param>
-    /// <param name="cancellation">
-    /// A <see cref="CancellationToken"/> that can be used to cancel the resume operation. Note, cancelling this token
-    /// does <b>not</b> re-suspend the orchestration if resume was successful.
-    /// </param>
-    /// <returns>A task that completes when the resume has been committed to the backend.</returns>
-    public abstract Task ResumeInstanceAsync(
-        string instanceId, string? reason = null, CancellationToken cancellation = default);
+    /// <inheritdoc cref="TerminateInstanceAsync(string, object, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(
+        string instanceId, CancellationToken cancellation)
+        => this.TerminateInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>
     /// Waits for an orchestration to start running and returns a <see cref="OrchestrationMetadata"/>
@@ -263,6 +203,66 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
+    /// <summary>
+    /// Terminates a running orchestration instance and updates its runtime status to
+    /// <see cref="OrchestrationRuntimeStatus.Terminated"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method internally enqueues a "terminate" message in the task hub. When the task hub worker processes
+    /// this message, it will update the runtime status of the target instance to
+    /// <see cref="OrchestrationRuntimeStatus.Terminated"/>. You can use the
+    /// <see cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/> to wait for the instance to reach
+    /// the terminated state.
+    /// </para>
+    /// <para>
+    /// Terminating an orchestration instance has no effect on any in-flight activity function executions
+    /// or sub-orchestrations that were started by the terminated instance. Those actions will continue to run
+    /// without interruption. However, their results will be discarded. If you want to terminate sub-orchestrations,
+    /// you must issue separate terminate commands for each sub-orchestration instance.
+    /// </para><para>
+    /// At the time of writing, there is no way to terminate an in-flight activity execution.
+    /// </para><para>
+    /// Attempting to terminate a completed or non-existent orchestration instance will fail silently.
+    /// </para>
+    /// </remarks>
+    /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
+    /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
+    /// <param name="cancellation">
+    /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
+    /// termination of the orchestration once enqueued.
+    /// </param>
+    /// <returns>A task that completes when the terminate message is enqueued.</returns>
+    public abstract Task TerminateInstanceAsync(
+        string instanceId, object? output = null, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Suspends an orchestration instance, halting processing of it until <see cref="ResumeInstanceAsync" /> is used
+    /// to resume the orchestration.
+    /// </summary>
+    /// <param name="instanceId">The instance ID of the orchestration to suspend.</param>
+    /// <param name="reason">The optional suspension reason.</param>
+    /// <param name="cancellation">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the suspend operation. Note, cancelling this token
+    /// does <b>not</b> resume the orchestration if suspend was successful.
+    /// </param>
+    /// <returns>A task that completes when the suspend has been committed to the backend.</returns>
+    public abstract Task SuspendInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Resumes an orchestration instance that was suspended via <see cref="SuspendInstanceAsync" />.
+    /// </summary>
+    /// <param name="instanceId">The instance ID of the orchestration to resume.</param>
+    /// <param name="reason">The optional resume reason.</param>
+    /// <param name="cancellation">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the resume operation. Note, cancelling this token
+    /// does <b>not</b> re-suspend the orchestration if resume was successful.
+    /// </param>
+    /// <returns>A task that completes when the resume has been committed to the backend.</returns>
+    public abstract Task ResumeInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default);
+
     /// <inheritdoc cref="GetInstanceMetadataAsync(string, bool, CancellationToken)"/>
     public virtual Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
         string instanceId, CancellationToken cancellation)
@@ -286,7 +286,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </summary>
     /// <param name="query">Filters down the instances included in the query.</param>
     /// <returns>An async pageable of the query results.</returns>
-    public abstract AsyncPageable<OrchestrationMetadata> GetInstances(OrchestrationQuery? query = null);
+    public abstract AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null);
 
     /// <summary>
     /// Purges orchestration instance metadata from the durable store.
@@ -328,7 +328,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstancesAsync(
+    public abstract Task<PurgeResult> PurgeInstanceMetadataAsync(
         PurgeInstancesFilter filter, CancellationToken cancellation = default);
 
     // TODO: Create task hub

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -144,12 +144,6 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public virtual Task<OrchestrationMetadata> WaitForInstanceStartAsync(
         string instanceId, CancellationToken cancellation)
         => this.WaitForInstanceStartAsync(instanceId, false, cancellation);
-
-    /// <inheritdoc cref="TerminateInstanceAsync(string, object, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(
-        string instanceId, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, null, cancellation);
-
     /// <summary>
     /// Waits for an orchestration to start running and returns a <see cref="OrchestrationMetadata"/>
     /// object that contains metadata about the started instance.
@@ -203,6 +197,10 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
+    /// <inheritdoc cref="TerminateInstanceAsync(string, object, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
+        => this.TerminateInstanceAsync(instanceId, null, cancellation);
+
     /// <summary>
     /// Terminates a running orchestration instance and updates its runtime status to
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/>.
@@ -236,6 +234,10 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task TerminateInstanceAsync(
         string instanceId, object? output = null, CancellationToken cancellation = default);
 
+    /// <inheritdoc cref="SuspendInstanceAsync(string, string, CancellationToken)"/>
+    public virtual Task SuspendInstanceAsync(string instanceId, CancellationToken cancellation)
+        => this.SuspendInstanceAsync(instanceId, null, cancellation);
+
     /// <summary>
     /// Suspends an orchestration instance, halting processing of it until <see cref="ResumeInstanceAsync" /> is used
     /// to resume the orchestration.
@@ -250,8 +252,12 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task SuspendInstanceAsync(
         string instanceId, string? reason = null, CancellationToken cancellation = default);
 
+    /// <inheritdoc cref="ResumeInstanceAsync(string, string, CancellationToken)"/>
+    public virtual Task ResumeInstanceAsync(string instanceId, CancellationToken cancellation)
+        => this.ResumeInstanceAsync(instanceId, null, cancellation);
+
     /// <summary>
-    /// Resumes an orchestration instance that was suspended via <see cref="SuspendInstanceAsync" />.
+    /// Resumes an orchestration instance that was suspended via <see cref="SuspendInstanceAsync(string, string, CancellationToken)" />.
     /// </summary>
     /// <param name="instanceId">The instance ID of the orchestration to resume.</param>
     /// <param name="reason">The optional resume reason.</param>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -144,6 +144,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public virtual Task<OrchestrationMetadata> WaitForInstanceStartAsync(
         string instanceId, CancellationToken cancellation)
         => this.WaitForInstanceStartAsync(instanceId, false, cancellation);
+
     /// <summary>
     /// Waits for an orchestration to start running and returns a <see cref="OrchestrationMetadata"/>
     /// object that contains metadata about the started instance.
@@ -239,8 +240,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
         => this.SuspendInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>
-    /// Suspends an orchestration instance, halting processing of it until <see cref="ResumeInstanceAsync" /> is used
-    /// to resume the orchestration.
+    /// Suspends an orchestration instance, halting processing of it until
+    /// <see cref="ResumeInstanceAsync(string, string, CancellationToken)" /> is used to resume the orchestration.
     /// </summary>
     /// <param name="instanceId">The instance ID of the orchestration to suspend.</param>
     /// <param name="reason">The optional suspension reason.</param>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -291,9 +291,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <summary>
     /// Queries orchestration instances.
     /// </summary>
-    /// <param name="query">Filters down the instances included in the query.</param>
+    /// <param name="filter">Filters down the instances included in the query.</param>
     /// <returns>An async pageable of the query results.</returns>
-    public abstract AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null);
+    public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
     /// <summary>
     /// Purges orchestration instance metadata from the durable store.
@@ -321,7 +321,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
     /// instance was successfully purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstancesAsync(
+    public abstract Task<PurgeResult> PurgeInstanceAsync(
         string instanceId, CancellationToken cancellation = default);
 
     /// <summary>
@@ -335,7 +335,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstancesAsync(
+    public abstract Task<PurgeResult> PurgeAllInstancesAsync(
         PurgeInstancesFilter filter, CancellationToken cancellation = default);
 
     // TODO: Create task hub

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -73,7 +73,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// and health of the backend task hub, and whether a start time was provided via <paramref name="options" />.
     /// </para><para>
     /// The task associated with this method completes after the orchestration instance was successfully scheduled. You
-    /// can use the <see cref="GetInstanceMetadataAsync(string, bool, CancellationToken)"/> to query the status of the
+    /// can use the <see cref="GetInstancesAsync(string, bool, CancellationToken)"/> to query the status of the
     /// scheduled instance, the <see cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/> method to wait
     /// for the instance to transition out of the <see cref="OrchestrationRuntimeStatus.Pending"/> status, or the
     /// <see cref="WaitForInstanceCompletionAsync(string, bool, CancellationToken)"/> method to wait for the instance to
@@ -263,10 +263,10 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task ResumeInstanceAsync(
         string instanceId, string? reason = null, CancellationToken cancellation = default);
 
-    /// <inheritdoc cref="GetInstanceMetadataAsync(string, bool, CancellationToken)"/>
-    public virtual Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+    /// <inheritdoc cref="GetInstancesAsync(string, bool, CancellationToken)"/>
+    public virtual Task<OrchestrationMetadata?> GetInstancesAsync(
         string instanceId, CancellationToken cancellation)
-        => this.GetInstanceMetadataAsync(instanceId, false, cancellation);
+        => this.GetInstancesAsync(instanceId, false, cancellation);
 
     /// <summary>
     /// Fetches orchestration instance metadata from the configured durable store.
@@ -278,7 +278,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// memory costs associated with fetching the instance metadata.
     /// </remarks>
     /// <inheritdoc cref="WaitForInstanceStartAsync(string, bool, CancellationToken)"/>
-    public abstract Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+    public abstract Task<OrchestrationMetadata?> GetInstancesAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
     /// <summary>
@@ -286,7 +286,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </summary>
     /// <param name="query">Filters down the instances included in the query.</param>
     /// <returns>An async pageable of the query results.</returns>
-    public abstract AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null);
+    public abstract AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null);
 
     /// <summary>
     /// Purges orchestration instance metadata from the durable store.
@@ -314,7 +314,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
     /// instance was successfully purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstanceMetadataAsync(
+    public abstract Task<PurgeResult> PurgeInstancesAsync(
         string instanceId, CancellationToken cancellation = default);
 
     /// <summary>
@@ -328,7 +328,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstanceMetadataAsync(
+    public abstract Task<PurgeResult> PurgeInstancesAsync(
         PurgeInstancesFilter filter, CancellationToken cancellation = default);
 
     // TODO: Create task hub

--- a/src/Client/Core/OrchestrationMetadata.cs
+++ b/src/Client/Core/OrchestrationMetadata.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DurableTask.Client;
 /// </summary>
 /// <remarks>
 /// Instances of this class are produced by methods in the <see cref="DurableTaskClient"/> class, such as
-/// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/>,
+/// <see cref="DurableTaskClient.GetInstancesAsync(string, CancellationToken)"/>,
 /// <see cref="DurableTaskClient.WaitForInstanceStartAsync(string, CancellationToken)"/> and
 /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/>.
 /// </remarks>
@@ -117,7 +117,7 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.GetInstancesAsync(string, CancellationToken)"/> or
     /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
     /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>
@@ -143,7 +143,7 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.GetInstancesAsync(string, CancellationToken)"/> or
     /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
     /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>
@@ -169,7 +169,7 @@ public sealed class OrchestrationMetadata
     /// </summary>
     /// <remarks>
     /// This method can only be used when inputs and outputs are explicitly requested from the
-    /// <see cref="DurableTaskClient.GetInstanceMetadataAsync(string, CancellationToken)"/> or
+    /// <see cref="DurableTaskClient.GetInstancesAsync(string, CancellationToken)"/> or
     /// <see cref="DurableTaskClient.WaitForInstanceCompletionAsync(string, CancellationToken)"/> method that produced
     /// this <see cref="OrchestrationMetadata"/> object.
     /// </remarks>

--- a/src/Client/Core/PurgeInstancesFilter.cs
+++ b/src/Client/Core/PurgeInstancesFilter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.DurableTask.Client;
 /// <param name="CreatedTo">Date created to.</param>
 /// <param name="Statuses">The statuses.</param>
 public record PurgeInstancesFilter(
-    DateTimeOffset? CreatedFrom, DateTimeOffset? CreatedTo, IEnumerable<OrchestrationRuntimeStatus>? Statuses)
+    DateTimeOffset? CreatedFrom = null,
+    DateTimeOffset? CreatedTo = null,
+    IEnumerable<OrchestrationRuntimeStatus>? Statuses = null)
 {
 }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -181,7 +181,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override async Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+    public override async Task<OrchestrationMetadata?> GetInstancesAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(instanceId))
@@ -207,7 +207,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
+    public override AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null)
     {
         return Pageable.Create(async (continuation, pageSize, cancellation) =>
         {
@@ -249,7 +249,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
             {
                 throw new OperationCanceledException(
-                    $"The {nameof(this.GetInstanceMetadataAsync)} operation was canceled.", e, cancellation);
+                    $"The {nameof(this.GetInstancesAsync)} operation was canceled.", e, cancellation);
             }
         });
     }
@@ -305,7 +305,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+    public override Task<PurgeResult> PurgeInstancesAsync(
         string instanceId, CancellationToken cancellation = default)
     {
         this.logger.PurgingInstanceMetadata(instanceId);
@@ -315,7 +315,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+    public override Task<PurgeResult> PurgeInstancesAsync(
         PurgeInstancesFilter filter, CancellationToken cancellation = default)
     {
         this.logger.PurgingInstances(filter);
@@ -385,7 +385,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
         {
             throw new OperationCanceledException(
-                $"The {nameof(this.PurgeInstanceMetadataAsync)} operation was canceled.", e, cancellation);
+                $"The {nameof(this.PurgeInstancesAsync)} operation was canceled.", e, cancellation);
         }
     }
 

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -116,7 +116,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override async Task TerminateAsync(
+    public override async Task TerminateInstanceAsync(
         string instanceId, object? output = null, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(instanceId))
@@ -207,7 +207,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override AsyncPageable<OrchestrationMetadata> GetInstances(OrchestrationQuery? query = null)
+    public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
     {
         return Pageable.Create(async (continuation, pageSize, cancellation) =>
         {
@@ -249,7 +249,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
             {
                 throw new OperationCanceledException(
-                    $"The {nameof(this.GetInstances)} operation was canceled.", e, cancellation);
+                    $"The {nameof(this.GetInstanceMetadataAsync)} operation was canceled.", e, cancellation);
             }
         });
     }
@@ -315,7 +315,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
-    public override Task<PurgeResult> PurgeInstancesAsync(
+    public override Task<PurgeResult> PurgeInstanceMetadataAsync(
         PurgeInstancesFilter filter, CancellationToken cancellation = default)
     {
         this.logger.PurgingInstances(filter);
@@ -385,7 +385,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
         {
             throw new OperationCanceledException(
-                $"The {nameof(this.PurgeInstancesAsync)} operation was canceled.", e, cancellation);
+                $"The {nameof(this.PurgeInstanceMetadataAsync)} operation was canceled.", e, cancellation);
         }
     }
 

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -83,7 +83,7 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstances(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
         {
             throw new NotImplementedException();
         }
@@ -94,7 +94,7 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
@@ -127,7 +127,7 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
-        public override Task TerminateAsync(
+        public override Task TerminateInstanceAsync(
             string instanceId, object? output = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -83,18 +83,18 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeInstanceAsync(
             string instanceId, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeAllInstancesAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -77,24 +77,24 @@ public class DefaultDurableTaskClientBuilderTests
             throw new NotImplementedException();
         }
 
-        public override Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+        public override Task<OrchestrationMetadata?> GetInstancesAsync(
             string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+        public override Task<PurgeResult> PurgeInstancesAsync(
             string instanceId, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+        public override Task<PurgeResult> PurgeInstancesAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -113,18 +113,18 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeInstanceAsync(
             string instanceId, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeAllInstancesAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -113,7 +113,7 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstances(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
         {
             throw new NotImplementedException();
         }
@@ -124,7 +124,7 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstancesAsync(
+        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
@@ -157,7 +157,7 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
-        public override Task TerminateAsync(
+        public override Task TerminateInstanceAsync(
             string instanceId, object? output = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -107,24 +107,24 @@ public class DurableTaskClientBuilderExtensionsTests
             throw new NotImplementedException();
         }
 
-        public override Task<OrchestrationMetadata?> GetInstanceMetadataAsync(
+        public override Task<OrchestrationMetadata?> GetInstancesAsync(
             string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override AsyncPageable<OrchestrationMetadata> GetInstanceMetadataAsync(OrchestrationQuery? query = null)
+        public override AsyncPageable<OrchestrationMetadata> GetInstancesAsync(OrchestrationQuery? query = null)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+        public override Task<PurgeResult> PurgeInstancesAsync(
             string instanceId, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<PurgeResult> PurgeInstanceMetadataAsync(
+        public override Task<PurgeResult> PurgeInstancesAsync(
             PurgeInstancesFilter filter, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -44,12 +44,12 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
             OrchestrationName, input: shouldThrow);
 
         await server.Client.WaitForInstanceStartAsync(instanceId, default);
-        OrchestrationMetadata? metadata = await server.Client.GetInstanceMetadataAsync(instanceId, false);
+        OrchestrationMetadata? metadata = await server.Client.GetInstancesAsync(instanceId, false);
         AssertMetadata(metadata!, instanceId, OrchestrationRuntimeStatus.Running);
 
         await server.Client.RaiseEventAsync(instanceId, "event", default);
         await server.Client.WaitForInstanceCompletionAsync(instanceId, default);
-        metadata = await server.Client.GetInstanceMetadataAsync(instanceId, false);
+        metadata = await server.Client.GetInstancesAsync(instanceId, false);
         AssertMetadata(
             metadata!,
             instanceId,
@@ -101,7 +101,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         await ForEachOrchestrationAsync(
             x => server.Client.ScheduleNewOrchestrationInstanceAsync(
                 OrchestrationName, input: false, new StartOrchestrationOptions(x)));
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstanceMetadataAsync(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstancesAsync(query);
 
         await ForEachOrchestrationAsync(x => server.Client.WaitForInstanceStartAsync(x, default));
         List<OrchestrationMetadata> metadata = await pageable.ToListAsync();
@@ -129,7 +129,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
                 OrchestrationName, input: false, new StartOrchestrationOptions($"GetInstances_AsPages_EndToEnd-{i}"));
         }
 
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstanceMetadataAsync(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstancesAsync(query);
         List<Page<OrchestrationMetadata>> pages = await pageable.AsPages(pageSizeHint: 5).ToListAsync();
         pages.Should().HaveCount(5);
         pages.ForEach(p => p.Values.Should().HaveCount(p.ContinuationToken is null ? 1 : 5));

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -101,7 +101,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         await ForEachOrchestrationAsync(
             x => server.Client.ScheduleNewOrchestrationInstanceAsync(
                 OrchestrationName, input: false, new StartOrchestrationOptions(x)));
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstancesAsync(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetAllInstancesAsync(query);
 
         await ForEachOrchestrationAsync(x => server.Client.WaitForInstanceStartAsync(x, default));
         List<OrchestrationMetadata> metadata = await pageable.ToListAsync();
@@ -129,7 +129,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
                 OrchestrationName, input: false, new StartOrchestrationOptions($"GetInstances_AsPages_EndToEnd-{i}"));
         }
 
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstancesAsync(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetAllInstancesAsync(query);
         List<Page<OrchestrationMetadata>> pages = await pageable.AsPages(pageSizeHint: 5).ToListAsync();
         pages.Should().HaveCount(5);
         pages.ForEach(p => p.Values.Should().HaveCount(p.ContinuationToken is null ? 1 : 5));

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -101,7 +101,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         await ForEachOrchestrationAsync(
             x => server.Client.ScheduleNewOrchestrationInstanceAsync(
                 OrchestrationName, input: false, new StartOrchestrationOptions(x)));
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstanceMetadataAsync(query);
 
         await ForEachOrchestrationAsync(x => server.Client.WaitForInstanceStartAsync(x, default));
         List<OrchestrationMetadata> metadata = await pageable.ToListAsync();
@@ -129,7 +129,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
                 OrchestrationName, input: false, new StartOrchestrationOptions($"GetInstances_AsPages_EndToEnd-{i}"));
         }
 
-        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstances(query);
+        AsyncPageable<OrchestrationMetadata> pageable = server.Client.GetInstanceMetadataAsync(query);
         List<Page<OrchestrationMetadata>> pages = await pageable.AsPages(pageSizeHint: 5).ToListAsync();
         pages.Should().HaveCount(5);
         pages.ForEach(p => p.Values.Should().HaveCount(p.ContinuationToken is null ? 1 : 5));

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -325,7 +325,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         OrchestrationMetadata metadata = await server.Client.WaitForInstanceStartAsync(instanceId, this.TimeoutToken);
 
         var expectedOutput = new { quote = "I'll be back." };
-        await server.Client.TerminateAsync(instanceId, expectedOutput);
+        await server.Client.TerminateInstanceAsync(instanceId, expectedOutput);
 
         metadata = await server.Client.WaitForInstanceCompletionAsync(
             instanceId, getInputsAndOutputs: true, this.TimeoutToken);


### PR DESCRIPTION
This PR does the following:

1. Makes `PurgeInstancesFilter` parameters optional since they were already nullable.
2. Add some overloads for `Suspend` and `Resume`
3. Makes method names in `DurableTaskClient` more consistent.
    - `TerminateAsync` -> `TerminateInstanceAsync`
    - `GetInstances` -> `GetAllInstancesAsync`
    - `GetInstanceMetadataAsync` -> `GetInstanceAsync`
    - `PurgeInstances` -> `PurgeAllInstancesAsync`
    - `PurgInstanceMetadataAsync` -> `PurgeInstanceAsync`
