### PR TITLE
Fix SBOM inclusion in Client & Worker packages

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER
+      run: dotnet build $solution --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
     - name: Test
       run: dotnet test $solution --configuration $config --no-build --verbosity normal

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -73,7 +73,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Manifest Generator'
   inputs:
-    BuildDropPath: '$(System.DefaultWorkingDirectory)/out/pkg'
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
 
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -7,10 +7,20 @@ pool:
   demands:
     - ImageOverride -equals MMS2022TLS
 
+parameters:
+- name: binlog
+  displayName: MSBuild binary log
+  type: boolean
+  default: false
+
 variables:
   project: 'src/dirs.proj'
   log_dir: 'out/log'
   pkg_dir: 'out/pkg'
+  build_args: -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
+  ${{ if parameters.binlog }}:
+    build_binlog: -bl:$(log_dir)/build.binlog
+    pack_binlog: -bl:$(log_dir)/pack.binlog
 
 steps:
 - checkout: self
@@ -35,7 +45,7 @@ steps:
   displayName: 'Build'
   inputs:
     command: build
-    arguments: --no-restore -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true -bl:$(log_dir)/build.binlog
+    arguments: --no-restore $(build_args) $(build_binlog)
     projects: $(project)
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
@@ -83,9 +93,9 @@ steps:
   displayName: Generate nuget packages
   inputs:
     command: custom
-    custom: Pack
-    arguments: --no-build -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true -bl:$(log_dir)/pack.binlog
-    packagesToPack: $(project)
+    custom: pack
+    arguments: --no-build $(build_args) $(pack_binlog)
+    projects: $(project)
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -73,7 +73,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Manifest Generator'
   inputs:
-    BuildDropPath: '$(System.DefaultWorkingDirectory)out/pkg'
+    BuildDropPath: '$(System.DefaultWorkingDirectory)/out/pkg'
 
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -9,6 +9,8 @@ pool:
 
 variables:
   project: 'src/dirs.proj'
+  log_dir: 'out/log'
+  pkg_dir: 'out/pkg'
 
 steps:
 - checkout: self
@@ -33,7 +35,7 @@ steps:
   displayName: 'Build'
   inputs:
     command: build
-    arguments: --no-restore -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
+    arguments: --no-restore -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true -bl:$(log_dir)/build.binlog
     projects: $(project)
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
@@ -80,11 +82,9 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: Generate nuget packages
   inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
+    command: custom
+    custom: Pack
+    arguments: --no-build -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true -bl:$(log_dir)/pack.binlog
     packagesToPack: $(project)
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
@@ -115,6 +115,10 @@ steps:
       ]
 
 # Make the nuget packages available for download in the ADO portal UI
-- publish: $(build.artifactStagingDirectory)
-  displayName: 'Publish nuget packages to Artifacts'
-  artifact: PackageOutput
+- publish: $(pkg_dir)
+  displayName: 'Publish packages to Artifacts'
+  artifact: pkg
+
+- publish: $(log_dir)
+  displayName: 'Publish logs to Artifacts'
+  artifact: log

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -15,6 +15,7 @@ parameters:
 
 variables:
   project: 'src/dirs.proj'
+  bin_dir: 'out/bin'
   log_dir: 'out/log'
   pkg_dir: 'out/pkg'
   build_args: -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
@@ -34,7 +35,7 @@ steps:
 
 # Start by restoring all the dependencies. This needs to be its own task.
 - task: DotNetCoreCLI@2
-  displayName: 'Restore'
+  displayName: Restore
   inputs:
     command: restore
     verbosityRestore: Minimal
@@ -42,7 +43,7 @@ steps:
 
 # Build source directory
 - task: DotNetCoreCLI@2
-  displayName: 'Build'
+  displayName: Build
   inputs:
     command: build
     arguments: --no-restore $(build_args) $(build_binlog)
@@ -54,7 +55,7 @@ steps:
   displayName: 'ESRP CodeSigning: Authenticode'
   inputs:
     ConnectedServiceName: 'ESRP Service'
-    FolderPath: 'out/bin'
+    FolderPath: $(bin_dir)
     Pattern: 'Microsoft.DurableTask.*.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
@@ -90,7 +91,7 @@ steps:
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.
 - task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
+  displayName: Pack
   inputs:
     command: custom
     custom: pack
@@ -103,7 +104,7 @@ steps:
   displayName: 'ESRP CodeSigning: Nupkg'
   inputs:
     ConnectedServiceName: 'ESRP Service'
-    FolderPath: $(build.artifactStagingDirectory)
+    FolderPath: $(pkg_dir)
     Pattern: '*.nupkg'
     signConfigType: inlineSignParams
     inlineOperation: |

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -73,7 +73,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Manifest Generator'
   inputs:
-    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+    BuildDropPath: '$(System.DefaultWorkingDirectory)out/pkg'
 
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.

--- a/eng/targets/Release.targets
+++ b/eng/targets/Release.targets
@@ -14,7 +14,7 @@
 
   <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <Content Include="$(PackageOutputPath)_manifest/**" Pack="true" PackagePath="content/SBOM">
+    <Content Include="$(RepoRoot)_manifest/**" Pack="true" PackagePath="content/SBOM">
       <Pack>true</Pack>
       <PackagePath>content/SBOM</PackagePath>
     </Content>

--- a/eng/targets/Release.targets
+++ b/eng/targets/Release.targets
@@ -14,7 +14,7 @@
 
   <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <Content Include="..\..\_manifest\**" Pack="true" PackagePath="content/SBOM">
+    <Content Include="$(PackageOutputPath)_manifest/**" Pack="true" PackagePath="content/SBOM">
       <Pack>true</Pack>
       <PackagePath>content/SBOM</PackagePath>
     </Content>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableStyleCop)' == 'true'">


### PR DESCRIPTION
This PR does the following:

1. Fix SBOM inclusion in Client & Worker packages (path offset was incorrect)
2. Allows for generating msbuild binary logs as part of the release build (check of "MSBuild binary log" when enqueueing build).