### PR TITLE
Add FabricBot config for automated GitHub issue management

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,536 @@
+{
+    "version": "1.0",
+    "tasks": [
+        {
+            "taskType": "trigger",
+            "capabilityId": "IssueResponder",
+            "subCapability": "IssuesOnlyResponder",
+            "version": "1.0",
+            "config": {
+                "taskName": "Add needs triage label to new issues",
+                "conditions": {
+                    "operator": "and",
+                    "operands": [
+                        {
+                            "name": "isAction",
+                            "parameters": {
+                                "action": "opened"
+                            }
+                        },
+                        {
+                            "operator": "not",
+                            "operands": [
+                                {
+                                    "name": "isPartOfProject",
+                                    "parameters": {}
+                                }
+                            ]
+                        },
+                        {
+                            "operator": "not",
+                            "operands": [
+                                {
+                                    "name": "isAssignedToSomeone",
+                                    "parameters": {}
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "name": "addLabel",
+                        "parameters": {
+                            "label": "Needs: Triage :mag:"
+                        }
+                    }
+                ],
+                "eventType": "issue",
+                "eventNames": [
+                    "issues",
+                    "project_card"
+                ]
+            },
+            "id": "TCZqLcGIj"
+        },
+        {
+            "taskType": "trigger",
+            "capabilityId": "IssueResponder",
+            "subCapability": "IssueCommentResponder",
+            "version": "1.0",
+            "config": {
+                "taskName": "Replace needs author feedback label with needs attention label when the author comments on an issue",
+                "conditions": {
+                    "operator": "and",
+                    "operands": [
+                        {
+                            "name": "isAction",
+                            "parameters": {
+                                "action": "created"
+                            }
+                        },
+                        {
+                            "name": "isActivitySender",
+                            "parameters": {
+                                "user": {
+                                    "type": "author"
+                                }
+                            }
+                        },
+                        {
+                            "name": "hasLabel",
+                            "parameters": {
+                                "label": "Needs: Author Feedback"
+                            }
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "name": "addLabel",
+                        "parameters": {
+                            "label": "Needs: Attention :wave:"
+                        }
+                    },
+                    {
+                        "name": "removeLabel",
+                        "parameters": {
+                            "label": "Needs: Author Feedback"
+                        }
+                    }
+                ],
+                "eventType": "issue",
+                "eventNames": [
+                    "issue_comment"
+                ]
+            },
+            "id": "f8AERPzkGt"
+        },
+        {
+            "taskType": "trigger",
+            "capabilityId": "IssueResponder",
+            "subCapability": "IssuesOnlyResponder",
+            "version": "1.0",
+            "config": {
+                "taskName": "Remove no recent activity label from issues",
+                "conditions": {
+                    "operator": "and",
+                    "operands": [
+                        {
+                            "operator": "not",
+                            "operands": [
+                                {
+                                    "name": "isAction",
+                                    "parameters": {
+                                        "action": "closed"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "hasLabel",
+                            "parameters": {
+                                "label": "no-recent-activity"
+                            }
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "name": "removeLabel",
+                        "parameters": {
+                            "label": "no-recent-activity"
+                        }
+                    }
+                ],
+                "eventType": "issue",
+                "eventNames": [
+                    "issues",
+                    "project_card"
+                ]
+            },
+            "id": "iz3b4ifNMz"
+        },
+        {
+            "taskType": "scheduled",
+            "capabilityId": "ScheduledSearch",
+            "subCapability": "ScheduledSearch",
+            "version": "1.1",
+            "config": {
+                "taskName": "Close stale issues",
+                "frequency": [
+                    {
+                        "weekDay": 0,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 1,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 2,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 3,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 4,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 5,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 6,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    }
+                ],
+                "searchTerms": [
+                    {
+                        "name": "isIssue",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "isOpen",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "hasLabel",
+                        "parameters": {
+                            "label": "Needs: Author Feedback"
+                        }
+                    },
+                    {
+                        "name": "hasLabel",
+                        "parameters": {
+                            "label": "no-recent-activity"
+                        }
+                    },
+                    {
+                        "name": "noActivitySince",
+                        "parameters": {
+                            "days": 3
+                        }
+                    }
+                ],
+                "actions": [
+                    {
+                        "name": "closeIssue",
+                        "parameters": {}
+                    }
+                ]
+            },
+            "id": "cnjUEhVUAa"
+        },
+        {
+            "taskType": "scheduled",
+            "capabilityId": "ScheduledSearch",
+            "subCapability": "ScheduledSearch",
+            "version": "1.1",
+            "config": {
+                "taskName": "Add no recent activity label to issues",
+                "frequency": [
+                    {
+                        "weekDay": 0,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 1,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 2,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 3,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 4,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 5,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 6,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    }
+                ],
+                "searchTerms": [
+                    {
+                        "name": "isIssue",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "isOpen",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "hasLabel",
+                        "parameters": {
+                            "label": "Needs: Author Feedback"
+                        }
+                    },
+                    {
+                        "name": "noActivitySince",
+                        "parameters": {
+                            "days": 4
+                        }
+                    },
+                    {
+                        "name": "noLabel",
+                        "parameters": {
+                            "label": "no-recent-activity"
+                        }
+                    }
+                ],
+                "actions": [
+                    {
+                        "name": "addLabel",
+                        "parameters": {
+                            "label": "no-recent-activity"
+                        }
+                    },
+                    {
+                        "name": "addReply",
+                        "parameters": {
+                            "comment": "This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**."
+                        }
+                    }
+                ]
+            },
+            "id": "53YGS8DptJ"
+        },
+        {
+            "taskType": "scheduled",
+            "capabilityId": "ScheduledSearch",
+            "subCapability": "ScheduledSearch",
+            "version": "1.1",
+            "config": {
+                "taskName": "Close duplicate issues",
+                "frequency": [
+                    {
+                        "weekDay": 0,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 1,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 2,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 3,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 4,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 5,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    },
+                    {
+                        "weekDay": 6,
+                        "hours": [
+                            0,
+                            6,
+                            12,
+                            18
+                        ]
+                    }
+                ],
+                "searchTerms": [
+                    {
+                        "name": "isIssue",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "isOpen",
+                        "parameters": {}
+                    },
+                    {
+                        "name": "hasLabel",
+                        "parameters": {
+                            "label": "duplicate"
+                        }
+                    },
+                    {
+                        "name": "noActivitySince",
+                        "parameters": {
+                            "days": 1
+                        }
+                    }
+                ],
+                "actions": [
+                    {
+                        "name": "addReply",
+                        "parameters": {
+                            "comment": "This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes."
+                        }
+                    },
+                    {
+                        "name": "closeIssue",
+                        "parameters": {}
+                    }
+                ]
+            },
+            "id": "B3MvNRf8yD"
+        },
+        {
+            "taskType": "trigger",
+            "capabilityId": "ReleaseAnnouncement",
+            "subCapability": "ReleaseAnnouncement",
+            "version": "1.0",
+            "id": "eT3hzThQI",
+            "config": {
+                "prReply": ":loudspeaker: **${pkgName} ${version}** has been released which incorporates this pull request.\n\n* [Release notes](https://github.com/${owner}/${repo}/releases/tag/${version})\n* [Official nuget.org release](https://www.nuget.org/packages/${pkgName}/${versionNumber})",
+                "taskName": "Announce a fix has been released",
+                "issueReply": ":loudspeaker: This issue was addressed in #${prNumber}, which has now been successfully released as **${pkgName} ${version}**.\n\n* [Release notes](https://github.com/${owner}/${repo}/releases/tag/${version})\n* [Official nuget.org release](https://www.nuget.org/packages/${pkgName}/${versionNumber})"
+            }
+        },
+        {
+            "taskType": "trigger",
+            "capabilityId": "IssueResponder",
+            "subCapability": "IssueCommentResponder",
+            "version": "1.0",
+            "config": {
+                "eventType": "issue",
+                "eventNames": [
+                    "issue_comment"
+                ],
+                "conditions": {
+                    "operator": "and",
+                    "operands": [
+                        {
+                            "name": "hasLabel",
+                            "parameters": {
+                                "label": "no-recent-activity"
+                            }
+                        }
+                    ]
+                },
+                "taskName": "Remove no recent activity label when an issue is commented on",
+                "actions": [
+                    {
+                        "name": "removeLabel",
+                        "parameters": {
+                            "label": "no-recent-activity"
+                        }
+                    }
+                ]
+            },
+            "id": "ciziQmUSW"
+        }
+    ],
+    "userGroups": []
+}


### PR DESCRIPTION
This PR adds a configuration file to enable FabricBot to assist with GitHub issue management. It will enable things like adding the "needs: triage" label to new issues, automatically closing stale issues, and so on.

This issues the same configuration file as the DF Extension here: https://raw.githubusercontent.com/Azure/azure-functions-durable-extension/dev/.github/fabricbot.json

The file is a bit long and hard to parse for humans. This is because it's auto-generated. We're told that the Fabricbot team is moving to a different configuration management system that will make this file unnecessary in the future. For now though, adding this file is the fastest way to get onboarding to this automation.

Enabling Fabricbot will make it easier for larger the Durable Functions team to be engaged with this repo's issues, so it would be helpful to merge this. Thanks!