### PR TITLE
Add gRPC CallInvoker to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## v1.0.3
+
+### Microsoft.DurableTask.Worker.Grpc
+
+- Add `GrpcDurableTaskWorkerOptions.CallInvoker` as an alternative to `GrpcDurableTaskWorkerOptions.Channel`
+
+### Microsoft.DurableTask.Client.Grpc
+
+- Add `GrpcDurableTaskClientOptions.CallInvoker` as an alternative to `GrpcDurableTaskClientOptions.Channel`
+
 ## v1.0.2
 
 ### Microsoft.DurableTask.Worker

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -338,7 +338,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
         c = GetChannel(options.Address);
         callInvoker = c.CreateCallInvoker();
-        return new AsyncDisposable(async () => await c.ShutdownAsync());
+        return new AsyncDisposable(() => new(c.ShutdownAsync()));
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Google.Protobuf.WellKnownTypes;
-using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -46,8 +45,8 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     {
         this.logger = Check.NotNull(logger);
         this.options = Check.NotNull(options);
-        this.asyncDisposable = BuildChannel(options, out GrpcChannel channel);
-        this.sidecarClient = new TaskHubSidecarServiceClient(channel);
+        this.asyncDisposable = GetCallInvoker(options, out CallInvoker callInvoker);
+        this.sidecarClient = new TaskHubSidecarServiceClient(callInvoker);
     }
 
     DataConverter DataConverter => this.options.DataConverter;
@@ -323,16 +322,22 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         return this.PurgeInstancesCoreAsync(request, cancellation);
     }
 
-    static AsyncDisposable BuildChannel(GrpcDurableTaskClientOptions options, out GrpcChannel channel)
+    static AsyncDisposable GetCallInvoker(GrpcDurableTaskClientOptions options, out CallInvoker callInvoker)
     {
         if (options.Channel is GrpcChannel c)
         {
-            channel = c;
+            callInvoker = c.CreateCallInvoker();
+            return default;
+        }
+
+        if (options.CallInvoker is CallInvoker invoker)
+        {
+            callInvoker = invoker;
             return default;
         }
 
         c = GetChannel(options.Address);
-        channel = c;
+        callInvoker = c.CreateCallInvoker();
         return new AsyncDisposable(async () => await c.ShutdownAsync());
     }
 

--- a/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClientOptions.cs
@@ -14,7 +14,12 @@ public sealed class GrpcDurableTaskClientOptions : DurableTaskClientOptions
     public string? Address { get; set; }
 
     /// <summary>
-    /// Gets or sets the gRPC channel to use. Will supersede <see cref="Address" /> when provided.
+    /// Gets or sets the gRPC channel to use. Will supersede <see cref="CallInvoker" /> when provided.
     /// </summary>
     public GrpcChannel? Channel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the gRPC call invoker to use. Will supersede <see cref="Address" /> when provided.
+    /// </summary>
+    public CallInvoker? CallInvoker { get; set; }
 }

--- a/src/Client/Grpc/RELEASENOTES.md
+++ b/src/Client/Grpc/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- Add `GrpcDurableTaskClientOptions.CallInvoker` as an alternative to `GrpcDurableTaskClientOptions.Channel`

--- a/src/Grpc/RELEASENOTES.md
+++ b/src/Grpc/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- Add `GrpcDurableTaskClient.CallInvoker` as an alternative to `GrpcDurableTaskClient.Channel`

--- a/src/Grpc/RELEASENOTES.md
+++ b/src/Grpc/RELEASENOTES.md
@@ -1,1 +1,0 @@
-- Add `GrpcDurableTaskClient.CallInvoker` as an alternative to `GrpcDurableTaskClient.Channel`

--- a/src/Shared/Grpc/Usings.cs
+++ b/src/Shared/Grpc/Usings.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+global using Grpc.Core;
+
 #if NET6_0_OR_GREATER
 global using Grpc.Net.Client;
 #endif
 
 #if NETSTANDARD2_0
-global using Grpc.Core;
 global using GrpcChannel = Grpc.Core.Channel;
 #endif

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -35,7 +35,7 @@ sealed partial class GrpcDurableTaskWorker
 
         ILogger Logger => this.worker.logger;
 
-        public async Task ExecuteAsync(string target, CancellationToken cancellation)
+        public async Task ExecuteAsync(CancellationToken cancellation)
         {
             while (!cancellation.IsCancellationRequested)
             {
@@ -52,12 +52,12 @@ sealed partial class GrpcDurableTaskWorker
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
                 {
                     // Sidecar is shutting down - retry
-                    this.Logger.SidecarDisconnected(target);
+                    this.Logger.SidecarDisconnected();
                 }
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
                 {
                     // Sidecar is down - keep retrying
-                    this.Logger.SidecarUnavailable(target);
+                    this.Logger.SidecarUnavailable();
                 }
                 catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                 {

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -42,9 +42,9 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await using AsyncDisposable disposable = this.BuildChannel(out GrpcChannel channel);
-        this.logger.StartingTaskHubWorker(channel.Target);
-        await new Processor(this, new(channel)).ExecuteAsync(channel.Target, stoppingToken);
+        await using AsyncDisposable disposable = this.GetCallInvoker(out CallInvoker callInvoker);
+        this.logger.StartingTaskHubWorker();
+        await new Processor(this, new(callInvoker)).ExecuteAsync(stoppingToken);
     }
 
 #if NET6_0_OR_GREATER
@@ -71,16 +71,22 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
     }
 #endif
 
-    AsyncDisposable BuildChannel(out GrpcChannel channel)
+    AsyncDisposable GetCallInvoker(out CallInvoker callInvoker)
     {
         if (this.options.Channel is GrpcChannel c)
         {
-            channel = c;
+            callInvoker = c.CreateCallInvoker();
+            return default;
+        }
+
+        if (this.options.CallInvoker is CallInvoker invoker)
+        {
+            callInvoker = invoker;
             return default;
         }
 
         c = GetChannel(this.options.Address);
-        channel = c;
+        callInvoker = c.CreateCallInvoker();
         return new AsyncDisposable(async () => await c.ShutdownAsync());
     }
 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -87,6 +87,6 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
 
         c = GetChannel(this.options.Address);
         callInvoker = c.CreateCallInvoker();
-        return new AsyncDisposable(async () => await c.ShutdownAsync());
+        return new AsyncDisposable(() => new(c.ShutdownAsync()));
     }
 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -14,7 +14,12 @@ public sealed class GrpcDurableTaskWorkerOptions : DurableTaskWorkerOptions
     public string? Address { get; set; }
 
     /// <summary>
-    /// Gets or sets the gRPC channel to use. Will supersede <see cref="Address" /> when provided.
+    /// Gets or sets the gRPC channel to use. Will supersede <see cref="CallInvoker" /> when provided.
     /// </summary>
     public GrpcChannel? Channel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the gRPC call invoker to use. Will supersede <see cref="Address" /> when provided.
+    /// </summary>
+    public CallInvoker? CallInvoker { get; set; }
 }

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -13,14 +13,14 @@ namespace Microsoft.DurableTask.Worker.Grpc
     /// </remarks>
     static partial class Logs
     {
-        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Durable Task worker is connecting to sidecar at {address}.")]
-        public static partial void StartingTaskHubWorker(this ILogger logger, string address);
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Durable Task gRPC worker starting.")]
+        public static partial void StartingTaskHubWorker(this ILogger logger);
 
-        [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Durable Task worker has disconnected from {address}.")]
-        public static partial void SidecarDisconnected(this ILogger logger, string address);
+        [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Durable Task gRPC worker has disconnected from gRPC server.")]
+        public static partial void SidecarDisconnected(this ILogger logger);
 
-        [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "The sidecar at address {address} is unavailable. Will continue retrying.")]
-        public static partial void SidecarUnavailable(this ILogger logger, string address);
+        [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "The gRPC server for Durable Task gRPC worker is unavailable. Will continue retrying.")]
+        public static partial void SidecarUnavailable(this ILogger logger);
 
         [LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "Sidecar work-item streaming connection established.")]
         public static partial void EstablishedWorkItemConnection(this ILogger logger);

--- a/src/Worker/Grpc/RELEASENOTES.md
+++ b/src/Worker/Grpc/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- Add `GrpcDurableTaskWorkerOptions.CallInvoker` as an alternative to `GrpcDurableTaskWorkerOptions.Channel`


### PR DESCRIPTION
Part of #154

This PR sets up our options to allow for a `Grpc.Core.CallInvoker` to be provided, which is the type the functions dotnet worker will be making available to us. `GrpcChannel` is still accepted, this is just an alternative option to use. The order of precedence is `GrpcChannel` > `CallInvoker` > `Address`.