### PR TITLE
Add method dispatching TaskEntity base class

### DIFF
--- a/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
+++ b/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.13.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Reflection;
+
 namespace Microsoft.DurableTask.Entities;
 
 /// <summary>
@@ -14,4 +16,82 @@ public interface ITaskEntity
     /// <param name="operation">The operation to run.</param>
     /// <returns>The response to the caller, if any.</returns>
     ValueTask<object?> RunAsync(TaskEntityOperation operation);
+}
+
+/// <summary>
+/// A <see cref="ITaskEntity"/> which dispatches its operations to public instance methods or properties.
+/// </summary>
+public abstract class TaskEntity : ITaskEntity
+{
+    /**
+     * TODO:
+     * 1. Evaluate if Task and ValueTask support is necessary. If so, also support "Async" method name suffix.
+     * 2. Consider caching a compiled delegate for a given operation name.
+     */
+    static readonly BindingFlags InstanceBindingFlags
+            = BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
+
+    /// <inheritdoc/>
+    public ValueTask<object?> RunAsync(TaskEntityOperation operation)
+    {
+        Check.NotNull(operation);
+        if (!this.TryDispatchMethod(operation, out object? result))
+        {
+            throw new NotSupportedException($"Entity operation {operation} is not supported.");
+        }
+
+        return new(result);
+    }
+
+    bool TryDispatchMethod(TaskEntityOperation operation, out object? result)
+    {
+        Type t = this.GetType();
+        MethodInfo? method = t.GetMethod(operation.Name, InstanceBindingFlags);
+        if (method is null)
+        {
+            result = null;
+            return false;
+        }
+
+        if (method.ReturnType.IsTaskOrValueTask())
+        {
+            throw new InvalidOperationException($"{typeof(Task)} and {typeof(ValueTask)} return values are not supported");
+        }
+
+        ParameterInfo[] parameters = method.GetParameters();
+        object?[] inputs = new object[parameters.Length];
+
+        int i = 0;
+        bool inputResolved = false;
+        bool contextResolved = false;
+        bool operationResolved = false;
+        foreach (ParameterInfo parameter in parameters)
+        {
+            if (!contextResolved && parameter.ParameterType == typeof(TaskEntityContext))
+            {
+                inputs[i] = operation.Context;
+                contextResolved = true;
+            }
+            else if (!operationResolved && parameter.ParameterType == typeof(TaskEntityOperation))
+            {
+                inputs[i] = operation;
+                operationResolved = true;
+            }
+            else if (!inputResolved)
+            {
+                inputs[i] = operation.GetInput(parameter.ParameterType);
+                inputResolved = true;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Entity operation input parameter of '{parameter}' cannot be" +
+                    $" resolved. Either this input has already been resolved or is unsupported.");
+            }
+
+            i++;
+        }
+
+        result = method.Invoke(this, inputs);
+        return true;
+    }
 }

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Data.Common;
 using System.Reflection;
 
 namespace Microsoft.DurableTask.Entities;
@@ -9,6 +8,14 @@ namespace Microsoft.DurableTask.Entities;
 /// <summary>
 /// The task entity contract.
 /// </summary>
+/// <remarks>
+/// <para><b>Entity State</b></para>
+/// <para>
+/// All entity implementations are required to be serializable by the configured <see cref="DataConverter"/>. An entity
+/// will have its state deserialized before executing an operation, and then the new state will be the serialized value
+/// of the <see cref="ITaskEntity"/> implementation instance post-operation.
+/// </para>
+/// </remarks>
 public interface ITaskEntity
 {
     /// <summary>
@@ -20,8 +27,53 @@ public interface ITaskEntity
 }
 
 /// <summary>
-/// A <see cref="ITaskEntity"/> which dispatches its operations to public instance methods or properties.
+/// An <see cref="ITaskEntity"/> which dispatches its operations to public instance methods or properties.
 /// </summary>
+/// <remarks>
+/// <para><b>Method Binding</b></para>
+/// <para>
+/// When using this base class, all public methods will be considered valid entity operations.
+/// <list type="bullet">
+/// <item>Only public methods are considered (private, internal, and protected are not.)</item>
+/// <item>Properties are not considered.</item>
+/// <item>Operation matching is case insensitive.</item>
+/// <item><see cref="NotSupportedException"/> is thrown if no matching public method is found for an operation.</item>
+/// <item><see cref="AmbiguousMatchException"/> is thrown if there are multiple public overloads for an operation name.</item>
+/// </list>
+/// </para>
+///
+/// <para><b>Parameter Binding</b></para>
+/// <para>
+/// Operation methods supports parameter binding as follows:
+/// <list type="bullet">
+/// <item>Can bind to the context by adding a parameter of type <see cref="TaskEntityContext"/>.</item>
+/// <item>Can bind to the raw operation by adding a parameter of type <see cref="TaskEntityOperation"/>.</item>
+/// <item>Can bind to the operation input directly by adding any parameter which does not match a previously described
+/// binding candidate. The operation input, if available, will be deserialized to that type.</item>
+/// <item>Default parameters can be used for input to allow for an operation to execute (with the default value) without
+/// an input being provided.</item>
+/// </list>
+///
+/// <see cref="InvalidOperationException" /> will be thrown if:
+/// <list type="bullet">
+/// <item>There is a redundant parameter binding (ie: two context, operation, or input matches)</item>
+/// <item>There is an input binding, but no input was provided.</item>
+/// <item>There is another unknown type present which does not match context, operation, or input.</item>
+/// </list>
+/// </para>
+///
+/// <para><b>Return Value</b></para>
+/// <para>
+/// Any value returned by the bound method will be returned to the operation caller. Not all callers wait for a return
+/// value, such as signal-only callers. The return value is ignored in these cases.
+/// </para>
+///
+/// <para><b>Entity State</b></para>
+/// <para>
+/// Unchanged from <see cref="ITaskEntity"/>. Entity state is the serialized value of the entity after an operation
+/// completes.
+/// </para>
+/// </remarks>
 public abstract class TaskEntity : ITaskEntity
 {
     /**
@@ -38,10 +90,51 @@ public abstract class TaskEntity : ITaskEntity
         Check.NotNull(operation);
         if (!this.TryDispatchMethod(operation, out object? result))
         {
-            throw new NotSupportedException($"Entity operation {operation} is not supported.");
+            throw new NotSupportedException($"No suitable method found for entity operation '{operation}'.");
+        }
+
+        if (result is null)
+        {
+            return default;
+        }
+
+        if (result is Task task)
+        {
+            return new(task.ToGeneric<object?>());
+        }
+
+        if (result is ValueTask valueTask)
+        {
+            if (valueTask.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return valueTask.ToGeneric<object?>();
+        }
+
+        Type type = result.GetType();
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            // unwrap ValueTask via reflection.
+            return Unwrap(type, result);
         }
 
         return new(result);
+
+        static ValueTask<object?> Unwrap(Type type, object result)
+        {
+            if ((bool)type.GetProperty("IsCompleted").GetValue(result))
+            {
+                return new(type.GetProperty("Result").GetValue(result));
+            }
+            else
+            {
+                Task t = (Task)type.GetMethod("AsTask", BindingFlags.Instance | BindingFlags.Public)
+                    .Invoke(result, null);
+                return new(t.ToGeneric<object?>());
+            }
+        }
     }
 
     static bool TryGetInput(ParameterInfo parameter, TaskEntityOperation operation, out object? input)
@@ -64,31 +157,14 @@ public abstract class TaskEntity : ITaskEntity
 
     bool TryDispatchMethod(TaskEntityOperation operation, out object? result)
     {
-        static void CheckDuplicateBinding(
-            ParameterInfo? existing, ParameterInfo parameter, string bindingConcept, TaskEntityOperation operation)
-        {
-            if (existing is not null)
-            {
-                throw new InvalidOperationException($"Error dispatching {operation} to '{parameter.Member}'.\n" +
-                    $"Unable to bind {bindingConcept} to '{parameter}' because it has " +
-                    $"already been bound to parameter '{existing}'. Please remove the duplicate parameter in method " +
-                    $"'{parameter.Member}'.\nEntity operation: {operation}.");
-            }
-        }
-
         Type t = this.GetType();
+
+        // Will throw AmbiguousMatchException if more than 1 overload for the method name exists.
         MethodInfo? method = t.GetMethod(operation.Name, InstanceBindingFlags);
         if (method is null)
         {
             result = null;
             return false;
-        }
-
-        if (method.ReturnType.IsTaskOrValueTask())
-        {
-            throw new InvalidOperationException($"Error dispatching {operation} to '{method}'.\n" +
-                $"{typeof(Task)} and {typeof(ValueTask)} return values are not supported. Return type found: " +
-                $"{method.ReturnType}.");
         }
 
         ParameterInfo[] parameters = method.GetParameters();
@@ -102,27 +178,30 @@ public abstract class TaskEntity : ITaskEntity
         {
             if (parameter.ParameterType == typeof(TaskEntityContext))
             {
-                CheckDuplicateBinding(contextResolved, parameter, "context", operation);
+                ThrowIfDuplicateBinding(contextResolved, parameter, "context", operation);
                 inputs[i] = operation.Context;
                 contextResolved = parameter;
             }
             else if (parameter.ParameterType == typeof(TaskEntityOperation))
             {
-                CheckDuplicateBinding(operationResolved, parameter, "operation", operation);
+                ThrowIfDuplicateBinding(operationResolved, parameter, "operation", operation);
                 inputs[i] = operation;
                 operationResolved = parameter;
             }
-            else if (TryGetInput(parameter, operation, out object? input))
-            {
-                CheckDuplicateBinding(inputResolved, parameter, "input", operation);
-                inputs[i] = input;
-                inputResolved = parameter;
-            }
             else
             {
-                throw new InvalidOperationException($"Error dispatching {operation} to '{method}'.\n" +
-                    $"There was an error binding parameter '{parameter}'. Either the type is not supported or no " +
-                    $"input was provided for this parameter.\nInput provided: {operation.HasInput}.");
+                ThrowIfDuplicateBinding(inputResolved, parameter, "input", operation);
+                if (TryGetInput(parameter, operation, out object? input))
+                {
+                    inputs[i] = input;
+                    inputResolved = parameter;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Error dispatching {operation} to '{method}'.\n" +
+                        $"There was an error binding parameter '{parameter}'. The operation expected an input value, " +
+                        "but no input was provided by the caller.");
+                }
             }
 
             i++;
@@ -130,5 +209,17 @@ public abstract class TaskEntity : ITaskEntity
 
         result = method.Invoke(this, inputs);
         return true;
+
+        static void ThrowIfDuplicateBinding(
+            ParameterInfo? existing, ParameterInfo parameter, string bindingConcept, TaskEntityOperation operation)
+        {
+            if (existing is not null)
+            {
+                throw new InvalidOperationException($"Error dispatching {operation} to '{parameter.Member}'.\n" +
+                    $"Unable to bind {bindingConcept} to '{parameter}' because it has " +
+                    $"already been bound to parameter '{existing}'. Please remove the duplicate parameter in method " +
+                    $"'{parameter.Member}'.\nEntity operation: {operation}.");
+            }
+        }
     }
 }

--- a/src/Abstractions/Entities/TaskEntityOperation.cs
+++ b/src/Abstractions/Entities/TaskEntityOperation.cs
@@ -19,9 +19,20 @@ public abstract class TaskEntityOperation
     public abstract TaskEntityContext Context { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this operation has input or not.
+    /// </summary>
+    public abstract bool HasInput { get; }
+
+    /// <summary>
     /// Gets the input for this operation.
     /// </summary>
     /// <param name="inputType">The type to deserialize the input as.</param>
     /// <returns>The deserialized input type.</returns>
     public abstract object? GetInput(Type inputType);
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{this.Context.Id.Name}/{this.Name}";
+    }
 }

--- a/src/Shared/Core/TaskExtensions.cs
+++ b/src/Shared/Core/TaskExtensions.cs
@@ -1,43 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Net.NetworkInformation;
 using System.Reflection;
 using Microsoft.DurableTask;
 
 namespace System;
 
 /// <summary>
-/// Extensions for <see cref="Type"/>.
+/// Extensions for <see cref="Task"/> and <see cref="ValueTask" />.
 /// </summary>
-static class TypeExtensions
+static class TaskExtensions
 {
-    /// <summary>
-    /// Checks if a <paramref name="type" /> represents a <see cref="ValueTask" />, or <see cref="ValueTask{T}" />.
-    /// </summary>
-    /// <param name="type">The type to check.</param>
-    /// <returns><c>true</c> if a ValueTask, <c>false</c> otherwise.</returns>
-    public static bool IsValueTask(this Type type)
-    {
-        Check.NotNull(type);
-
-        if (type == typeof(ValueTask))
-        {
-            return true;
-        }
-
-        if (type.IsGenericType)
-        {
-            Type generic = type.GetGenericTypeDefinition();
-            if (generic == typeof(ValueTask<>))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /// <summary>
     /// Converts a <see cref="Task"/> to a generic <see cref="Task{T}"/>.
     /// </summary>

--- a/src/Shared/Core/TypeExtensions.cs
+++ b/src/Shared/Core/TypeExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask;
+
+namespace System;
+
+/// <summary>
+/// Extensions for <see cref="Type"/>.
+/// </summary>
+static class TypeExtensions
+{
+    /// <summary>
+    /// Checks if a <paramref name="type" /> represents a <see cref="Task" />, <see cref="Task{T}" />,
+    /// <see cref="ValueTask" />, or <see cref="ValueTask{T}" />.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if a Task or ValueTask, <c>false</c> otherwise.</returns>
+    public static bool IsTaskOrValueTask(this Type type)
+    {
+        Check.NotNull(type);
+
+        if (type == typeof(Task) || type == typeof(ValueTask))
+        {
+            return true;
+        }
+
+        if (type.IsGenericType)
+        {
+            Type generic = type.GetGenericTypeDefinition();
+            if (generic == typeof(Task<>) || generic == typeof(ValueTask<>))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Shared/Core/TypeExtensions.cs
+++ b/src/Shared/Core/TypeExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.NetworkInformation;
+using System.Reflection;
 using Microsoft.DurableTask;
 
 namespace System;
@@ -11,16 +13,15 @@ namespace System;
 static class TypeExtensions
 {
     /// <summary>
-    /// Checks if a <paramref name="type" /> represents a <see cref="Task" />, <see cref="Task{T}" />,
-    /// <see cref="ValueTask" />, or <see cref="ValueTask{T}" />.
+    /// Checks if a <paramref name="type" /> represents a <see cref="ValueTask" />, or <see cref="ValueTask{T}" />.
     /// </summary>
     /// <param name="type">The type to check.</param>
-    /// <returns><c>true</c> if a Task or ValueTask, <c>false</c> otherwise.</returns>
-    public static bool IsTaskOrValueTask(this Type type)
+    /// <returns><c>true</c> if a ValueTask, <c>false</c> otherwise.</returns>
+    public static bool IsValueTask(this Type type)
     {
         Check.NotNull(type);
 
-        if (type == typeof(Task) || type == typeof(ValueTask))
+        if (type == typeof(ValueTask))
         {
             return true;
         }
@@ -28,12 +29,43 @@ static class TypeExtensions
         if (type.IsGenericType)
         {
             Type generic = type.GetGenericTypeDefinition();
-            if (generic == typeof(Task<>) || generic == typeof(ValueTask<>))
+            if (generic == typeof(ValueTask<>))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Converts a <see cref="Task"/> to a generic <see cref="Task{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The generic type param to convert to.</typeparam>
+    /// <param name="task">The task to convert.</param>
+    /// <returns>The converted task.</returns>
+    public static async Task<T?> ToGeneric<T>(this Task task)
+    {
+        await Check.NotNull(task);
+
+        Type t = task.GetType();
+        if (t.IsGenericType)
+        {
+            return (T)t.GetProperty("Result", BindingFlags.Public | BindingFlags.Instance).GetValue(task);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Converts a <see cref="ValueTask"/> to a <see cref="ValueTask{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The generic type param to convert to.</typeparam>
+    /// <param name="task">The value task to convert.</param>
+    /// <returns>The converted value task.</returns>
+    public static async ValueTask<T?> ToGeneric<T>(this ValueTask task)
+    {
+        await task;
+        return default;
     }
 }

--- a/test/Abstractions.Tests/Entities/TaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/TaskEntityTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using DotNext;
+
+namespace Microsoft.DurableTask.Entities.Tests;
+
+public class TaskEntityTests
+{
+    [Theory]
+    [InlineData("doesNotExist")] // method does not exist.
+    [InlineData("add")] // private method, should not work
+    public async Task Dispatch_OperationNotSupported(string name)
+    {
+        Operation operation = new(name, Mock.Of<TaskEntityContext>(), 10);
+        TestEntity entity = new();
+
+        Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
+
+        await action.Should().ThrowAsync<NotSupportedException>();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Dispatch_Add_Success([CombinatorialRange(0, 14)] int method, bool lowercase)
+    {
+        int start = Random.Shared.Next(0, 10);
+        int toAdd = Random.Shared.Next(0, 10);
+        string opName = lowercase ? "add" : "Add";
+        Operation operation = new($"{opName}{method}", Mock.Of<TaskEntityContext>(), toAdd);
+        TestEntity entity = new() { Value = start };
+
+        object? result = await entity.RunAsync(operation);
+
+        int expected = start + toAdd;
+        entity.Value.Should().Be(expected);
+        result.Should().BeOfType<int>().Which.Should().Be(expected);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Dispatch_Get_Success([CombinatorialRange(0, 2)] int method, bool lowercase)
+    {
+        int expected = Random.Shared.Next(0, 10);
+        string opName = lowercase ? "get" : "Get";
+        Operation operation = new($"{opName}{method}", Mock.Of<TaskEntityContext>(), default);
+        TestEntity entity = new() { Value = expected };
+
+        object? result = await entity.RunAsync(operation);
+
+        entity.Value.Should().Be(expected);
+        result.Should().BeOfType<int>().Which.Should().Be(expected);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Dispatch_AddBadArgs_Fails([CombinatorialRange(0, 3)] int method, bool lowercase)
+    {
+        string opName = lowercase ? "addBadArgs" : "AddBadArgs";
+        Operation operation = new($"{opName}{method}", Mock.Of<TaskEntityContext>(), 10);
+        ErrorEntity entity = new();
+
+        Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
+
+        await action.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Dispatch_AddAmbiguous_Fails()
+    {
+        Operation operation = new("add0", Mock.Of<TaskEntityContext>(), 10);
+        ErrorEntity entity = new();
+
+        Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
+        await action.Should().ThrowAsync<AmbiguousMatchException>();
+    }
+
+    class Operation : TaskEntityOperation
+    {
+        readonly Optional<object?> input;
+
+        public Operation(string name, TaskEntityContext context, Optional<object?> input)
+        {
+            this.Name = name;
+            this.Context = context;
+            this.input = input;
+        }
+
+        public override string Name { get; }
+
+        public override TaskEntityContext Context { get; }
+
+        public override bool HasInput => this.input.IsPresent;
+
+        public override object? GetInput(Type inputType)
+        {
+            if (!this.input.IsPresent)
+            {
+                throw new InvalidOperationException("No input available.");
+            }
+
+            if (this.input.Value is null)
+            {
+                return null;
+            }
+
+            if (!inputType.IsAssignableFrom(this.input.Value.GetType()))
+            {
+                throw new InvalidCastException("Cannot convert input type.");
+            }
+
+            return this.input.Value;
+        }
+    }
+
+    class ErrorEntity : TestEntity
+    {
+        // Should be an amiguous match.
+        public int Add0(int value, TaskEntityContext context) => this.Add0(value);
+
+        public int AddBadArgs0(int value, object other) => this.Add0(value);
+
+        public int AddBadArgs1(int value, TaskEntityContext context, TaskEntityContext context2) => this.Add0(value);
+
+        public int AddBadArgs2(int value, TaskEntityOperation operation, TaskEntityOperation operation2) => this.Add0(value);
+    }
+
+    class TestEntity : TaskEntity
+    {
+        public int Value { get; set; }
+
+        // All possible permutations of the 3 inputs we support: object, context, operation
+        public int Add0(int value) => this.Add(value, default, default);
+
+        public int Add1(int value, TaskEntityContext context) => this.Add(value, context, default);
+
+        public int Add2(int value, TaskEntityOperation operation) => this.Add(value, default, operation);
+
+        public int Add3(int value, TaskEntityContext context, TaskEntityOperation operation)
+            => this.Add(value, context, operation);
+
+        public int Add4(int value, TaskEntityOperation operation, TaskEntityContext context)
+            => this.Add(value, context, operation);
+
+        public int Add5(TaskEntityOperation operation) => this.Add(default, default, operation);
+
+        public int Add6(TaskEntityOperation operation, int value) => this.Add(value, default, operation);
+
+        public int Add7(TaskEntityOperation operation, TaskEntityContext context)
+            => this.Add(default, context, operation);
+
+        public int Add8(TaskEntityOperation operation, int value, TaskEntityContext context)
+            => this.Add(value, context, operation);
+
+        public int Add9(TaskEntityOperation operation, TaskEntityContext context, int value)
+            => this.Add(value, context, operation);
+
+        public int Add10(TaskEntityContext context, int value)
+            => this.Add(value, context, default);
+
+        public int Add11(TaskEntityContext context, TaskEntityOperation operation)
+            => this.Add(default, context, operation);
+
+        public int Add12(TaskEntityContext context, int value, TaskEntityOperation operation)
+            => this.Add(value, context, operation);
+
+        public int Add13(TaskEntityContext context, TaskEntityOperation operation, int value)
+            => this.Add(value, context, operation);
+
+        public int Get0() => this.Get(default);
+
+        public int Get1(TaskEntityContext context) => this.Get(context);
+
+        int Add(int? value, Optional<TaskEntityContext> context, Optional<TaskEntityOperation> operation)
+        {
+            if (context.IsPresent)
+            {
+                context.Value.Should().NotBeNull();
+            }
+
+            if (operation.IsPresent)
+            {
+                operation.Value.Should().NotBeNull();
+            }
+
+            if (!value.HasValue && operation.TryGet(out TaskEntityOperation op))
+            {
+                value = (int)op.GetInput(typeof(int))!;
+            }
+
+            value.HasValue.Should().BeTrue();
+            return this.Value += value!.Value;
+        }
+
+        int Get(Optional<TaskEntityContext> context)
+        {
+            if (context.IsPresent)
+            {
+                context.Value.Should().NotBeNull();
+            }
+
+            return this.Value;
+        }
+    }
+}

--- a/test/Abstractions.Tests/Entities/TaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/TaskEntityTests.cs
@@ -23,6 +23,21 @@ public class TaskEntityTests
     }
 
     [Theory]
+    [InlineData("TaskOp")]
+    [InlineData("TaskOfStringOp")]
+    [InlineData("ValueTaskOp")]
+    [InlineData("ValueTaskOfStringOp")]
+    public async Task TasknNotSupported_Fails(string name)
+    {
+        Operation operation = new(name, Mock.Of<TaskEntityContext>(), default);
+        TestEntity entity = new();
+
+        Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
+
+        await action.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Theory]
     [CombinatorialData]
     public async Task Add_Success([CombinatorialRange(0, 14)] int method, bool lowercase)
     {
@@ -207,6 +222,14 @@ public class TaskEntityTests
             => this.Add0(value);
 
         public string DefaultValue(string toReturn = "default") => toReturn;
+
+        public Task TaskOp() => throw new NotImplementedException();
+
+        public Task<string> TaskOfStringOp() => throw new NotImplementedException();
+
+        public ValueTask ValueTaskOp() => throw new NotImplementedException();
+
+        public ValueTask<string> ValueTaskOfStringOp() => throw new NotImplementedException();
 
         int Add(int? value, Optional<TaskEntityContext> context, Optional<TaskEntityOperation> operation)
         {

--- a/test/Abstractions.Tests/Entities/TaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/TaskEntityTests.cs
@@ -27,7 +27,7 @@ public class TaskEntityTests
     [InlineData("TaskOfStringOp")]
     [InlineData("ValueTaskOp")]
     [InlineData("ValueTaskOfStringOp")]
-    public async Task TasknNotSupported_Fails(string name)
+    public async Task TaskNotSupported_Fails(string name)
     {
         Operation operation = new(name, Mock.Of<TaskEntityContext>(), default);
         TestEntity entity = new();
@@ -169,6 +169,7 @@ public class TaskEntityTests
         public static string StaticMethod() => throw new NotImplementedException();
 
         // All possible permutations of the 3 inputs we support: object, context, operation
+        // 14 via Add, 2 via Get: 16 total.
         public int Add0(int value) => this.Add(value, default, default);
 
         public int Add1(int value, TaskEntityContext context) => this.Add(value, context, default);

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,6 +4,7 @@
     Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, $(_DirectoryBuildTargetsFile)))' != '' " />
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageReference Include="DotNext" Value="4.13.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -13,6 +14,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
resolves #164

Adds a `TaskEntity` abstract class which can be used for implementing entities where all public methods are considered operations.


## What is supported?

Customers can derive from `TaskEntity` and add public methods to their type which will be considered operations. These public methods work as follows:

1. The return value is the response to the operation caller (if available)
2. input, entity context, and entity operation are supported as parameters.
3. Default values for the input parameter is supported.
4. The input parameter does not need to be called `input`. It is defined as any parameter which does not match `TaskEntityContext` or `TaskEntityOperation`.
5. Bound parameters cannot be duplicate, meaning a max of 3 parameters and only 1 of each can match input, context, and operation.
6. Methods cannot return `Task` or `ValueTask` (until we determine this support is needed).
    1. Added this restriction as I am unsure how an async entity would even behave, given the current implementation in DF is based on orchestrations.