### PR TITLE
Add TaskOrchestrationContext entity abstractions

### DIFF
--- a/src/Abstractions/Entities/CallEntityOptions.cs
+++ b/src/Abstractions/Entities/CallEntityOptions.cs
@@ -8,21 +8,8 @@ namespace Microsoft.DurableTask.Entities;
 /// </summary>
 public record CallEntityOptions
 {
-    /// <summary>
-    /// Gets options indicating whether to signal the entity or not.
-    /// </summary>
-    /// <remarks>
-    /// Setting this to non-<c>null</c> will signal the entity without waiting for a response.
-    /// </remarks>
-    /// <example>
-    /// Signal without start time:
-    /// <code>new CallEntityOptions { Signal = true };</code>
-    /// </example>
-    /// <example>
-    /// Signal with start time:
-    /// <code>new CallEntityOptions { Signal = DateTimeOffset };</code>
-    /// </example>
-    public SignalEntityOptions? Signal { get; init; }
+    // No call options at the moment. Keeping this class so we can ship with options in the API. This will
+    // allow us to easily add them later without adjusting API surface.
 }
 
 /// <summary>

--- a/src/Abstractions/Entities/TaskOrchestrationEntityFeature.cs
+++ b/src/Abstractions/Entities/TaskOrchestrationEntityFeature.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Entities;
+
+/// <summary>
+/// Feature for interacting with durable entities from an orchestration.
+/// </summary>
+public abstract class TaskOrchestrationEntityFeature
+{
+    /// <summary>
+    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
+    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The result of the entity operation.</typeparam>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="input">The operation input.</param>
+    /// <param name="options">The call options.</param>
+    /// <returns>
+    /// The result of the entity operation, or default(<typeparamref name="TResult"/>) in the signal-only case.
+    /// </returns>
+    public abstract Task<TResult> CallEntityAsync<TResult>(
+        EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null);
+
+    /// <summary>
+    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
+    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The result of the entity operation.</typeparam>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="options">The call options.</param>
+    /// <returns>
+    /// The result of the entity operation, or default(<typeparamref name="TResult"/>) in the signal-only case.
+    /// </returns>
+    public virtual Task<TResult> CallEntityAsync<TResult>(
+        EntityInstanceId id, string operationName, CallEntityOptions? options)
+        => this.CallEntityAsync<TResult>(id, operationName, null, options);
+
+    /// <summary>
+    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
+    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// </summary>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="input">The operation input.</param>
+    /// <param name="options">The call options.</param>
+    /// <returns>
+    /// A task that completes when the operation has been completed. Or in the signal-only case, a task that is either
+    /// already complete or completes when the operation has been enqueued.
+    /// </returns>
+    public abstract Task CallEntityAsync(
+        EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null);
+
+    /// <summary>
+    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
+    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// </summary>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="options">The call options.</param>
+    /// <returns>
+    /// A task that completes when the operation has been completed. Or in the signal-only case, a task that is either
+    /// already complete or completes when the operation has been enqueued.
+    /// </returns>
+    public virtual Task CallEntityAsync(EntityInstanceId id, string operationName, CallEntityOptions? options)
+        => this.CallEntityAsync(id, operationName, null, options);
+
+    /// <summary>
+    /// Acquires one or more entity locks.
+    /// </summary>
+    /// <param name="entityIds">The entity IDs to lock.</param>
+    /// <returns>An async-disposable which can be disposed to release the lock.</returns>
+    public abstract Task<IAsyncDisposable> LockEntitiesAsync(IEnumerable<EntityInstanceId> entityIds);
+
+    /// <summary>
+    /// Acquires one or more entity locks.
+    /// </summary>
+    /// <param name="entityIds">The entity IDs to lock.</param>
+    /// <returns>An async-disposable which can be disposed to release the lock.</returns>
+    public virtual Task<IAsyncDisposable> LockEntitiesAsync(params EntityInstanceId[] entityIds)
+        => this.LockEntitiesAsync((IEnumerable<EntityInstanceId>)entityIds); // let the implementation decide how to handle nulls.
+
+    /// <summary>
+    /// Gets a value indicating whether any entity locks are owned by this instance.
+    /// </summary>
+    /// <param name="entityIds">The list of locked entities.</param>
+    /// <returns>True if any locks are owned, false otherwise.</returns>
+    public abstract bool HasEntityLocks(out IReadOnlyList<EntityInstanceId> entityIds);
+
+    /// <summary>
+    /// Gets a value indicating whether any entity locks are owned by this instance.
+    /// </summary>
+    /// <returns>True if any locks are owned, false otherwise.</returns>
+    public virtual bool HasEntityLocks() => this.HasEntityLocks(out _);
+}

--- a/src/Abstractions/Entities/TaskOrchestrationEntityFeature.cs
+++ b/src/Abstractions/Entities/TaskOrchestrationEntityFeature.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.DurableTask.Entities;
 
 /// <summary>
@@ -9,63 +11,77 @@ namespace Microsoft.DurableTask.Entities;
 public abstract class TaskOrchestrationEntityFeature
 {
     /// <summary>
-    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
-    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// Calls an operation on an entity and waits for it to complete.
     /// </summary>
-    /// <typeparam name="TResult">The result of the entity operation.</typeparam>
+    /// <typeparam name="TResult">The result type of the entity operation.</typeparam>
     /// <param name="id">The target entity.</param>
     /// <param name="operationName">The name of the operation.</param>
     /// <param name="input">The operation input.</param>
     /// <param name="options">The call options.</param>
-    /// <returns>
-    /// The result of the entity operation, or default(<typeparamref name="TResult"/>) in the signal-only case.
-    /// </returns>
+    /// <returns>The result of the entity operation.</returns>
     public abstract Task<TResult> CallEntityAsync<TResult>(
         EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null);
 
     /// <summary>
-    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
-    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// Calls an operation on an entity and waits for it to complete.
     /// </summary>
-    /// <typeparam name="TResult">The result of the entity operation.</typeparam>
+    /// <typeparam name="TResult">The result type of the entity operation.</typeparam>
     /// <param name="id">The target entity.</param>
     /// <param name="operationName">The name of the operation.</param>
     /// <param name="options">The call options.</param>
-    /// <returns>
-    /// The result of the entity operation, or default(<typeparamref name="TResult"/>) in the signal-only case.
-    /// </returns>
+    /// <returns>The result of the entity operation.</returns>
     public virtual Task<TResult> CallEntityAsync<TResult>(
         EntityInstanceId id, string operationName, CallEntityOptions? options)
         => this.CallEntityAsync<TResult>(id, operationName, null, options);
 
     /// <summary>
-    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
-    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// Calls an operation on an entity and waits for it to complete.
     /// </summary>
     /// <param name="id">The target entity.</param>
     /// <param name="operationName">The name of the operation.</param>
     /// <param name="input">The operation input.</param>
     /// <param name="options">The call options.</param>
-    /// <returns>
-    /// A task that completes when the operation has been completed. Or in the signal-only case, a task that is either
-    /// already complete or completes when the operation has been enqueued.
-    /// </returns>
+    /// <returns>A task that completes when the operation has been completed.</returns>
     public abstract Task CallEntityAsync(
         EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null);
 
     /// <summary>
-    /// Calls an operation on an entity and waits for it to complete. Does not wait for completion if
-    /// <see cref="CallEntityOptions.Signal"/> is set on <paramref name="options"/>.
+    /// Calls an operation on an entity and waits for it to complete.
     /// </summary>
     /// <param name="id">The target entity.</param>
     /// <param name="operationName">The name of the operation.</param>
     /// <param name="options">The call options.</param>
-    /// <returns>
-    /// A task that completes when the operation has been completed. Or in the signal-only case, a task that is either
-    /// already complete or completes when the operation has been enqueued.
-    /// </returns>
+    /// <returns>A task that completes when the operation has been completed.</returns>
     public virtual Task CallEntityAsync(EntityInstanceId id, string operationName, CallEntityOptions? options)
         => this.CallEntityAsync(id, operationName, null, options);
+
+    /// <summary>
+    /// Calls an operation on an entity, but does not wait for completion.
+    /// </summary>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="input">The operation input.</param>
+    /// <param name="options">The signal options.</param>
+    /// <returns>
+    /// A task that represents scheduling of the signal operation. Dependening on implementation, this may complete
+    /// either when the operation has been signalled, or when the signal action has been enqueued by the context.
+    /// </returns>
+    public abstract Task SignalEntityAsync(
+        EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null);
+
+    /// <summary>
+    /// Calls an operation on an entity, but does not wait for completion.
+    /// </summary>
+    /// <param name="id">The target entity.</param>
+    /// <param name="operationName">The name of the operation.</param>
+    /// <param name="options">The signal options.</param>
+    /// <returns>
+    /// A task that represents scheduling of the signal operation. Dependening on implementation, this may complete
+    /// either when the operation has been signalled, or when the signal action has been enqueued by the context.
+    /// </returns>
+    public virtual Task SignalEntityAsync(
+        EntityInstanceId id, string operationName, SignalEntityOptions? options)
+        => this.SignalEntityAsync(id, operationName, null, options);
 
     /// <summary>
     /// Acquires one or more entity locks.
@@ -83,15 +99,16 @@ public abstract class TaskOrchestrationEntityFeature
         => this.LockEntitiesAsync((IEnumerable<EntityInstanceId>)entityIds); // let the implementation decide how to handle nulls.
 
     /// <summary>
-    /// Gets a value indicating whether any entity locks are owned by this instance.
+    /// Gets a value indicating whether this orchestration is in a critical section, and if true, any entity locks are
+    /// owned by this instance.
     /// </summary>
     /// <param name="entityIds">The list of locked entities.</param>
     /// <returns>True if any locks are owned, false otherwise.</returns>
-    public abstract bool HasEntityLocks(out IReadOnlyList<EntityInstanceId> entityIds);
+    public abstract bool InCriticalSection([NotNullWhen(true)] out IReadOnlyList<EntityInstanceId>? entityIds);
 
     /// <summary>
-    /// Gets a value indicating whether any entity locks are owned by this instance.
+    /// Gets a value indicating whether this orchestration is in a critical section.
     /// </summary>
     /// <returns>True if any locks are owned, false otherwise.</returns>
-    public virtual bool HasEntityLocks() => this.HasEntityLocks(out _);
+    public virtual bool InCriticalSection() => this.InCriticalSection(out _);
 }

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DurableTask;
@@ -57,6 +58,12 @@ public abstract class TaskOrchestrationContext
     /// <c>true</c> if the orchestrator is currently replaying a previous execution; otherwise <c>false</c>.
     /// </value>
     public abstract bool IsReplaying { get; }
+
+    /// <summary>
+    /// Gets the entity feature, for interacting with entities.
+    /// </summary>
+    public virtual TaskOrchestrationEntityFeature Entities =>
+        throw new NotSupportedException($"Durable entities are not supported by {this.GetType()}.");
 
     /// <summary>
     /// Gets the logger factory for this context.


### PR DESCRIPTION
resolves #167 

This PR adds abstractions for interacting with entities from an orchestration.

## Supported scenarios:

1. Call entity
2. Signal entity (this is done via `CallEntityAsync`, but passing in an `CallEntityOptions` with `Signal` set on it).
3. Lock entities
4. Check for and retrieve current entity locks