### PR TITLE
Add delete implicit operation

### DIFF
--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -198,7 +198,7 @@ public abstract class TaskEntity<TState> : ITaskEntity
     bool TryGetState(
         TaskEntityOperation operation, [NotNullWhen(true)] out TState? state, out ValueTask<object?> result)
     {
-        object? stateObj = null;
+        object? stateObj;
         try
         {
             stateObj = operation.State.GetState(typeof(TState));

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -198,7 +198,7 @@ public abstract class TaskEntity<TState> : ITaskEntity
     bool TryGetState(
         TaskEntityOperation operation, [NotNullWhen(true)] out TState? state, out ValueTask<object?> result)
     {
-        object? stateObj;
+        object? stateObj = null;
         try
         {
             stateObj = operation.State.GetState(typeof(TState));

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -128,7 +128,7 @@ public abstract class TaskEntity<TState> : ITaskEntity
         if (!operation.TryDispatch(this, out object? result, out Type returnType)
             && !this.TryDispatchState(operation, out result, out returnType))
         {
-            if (this.TryDispatchImplicit(out ValueTask<object?> task))
+            if (this.TryDispatchImplicit(operation, out ValueTask<object?> task))
             {
                 // We do not go into UnwrapAsync for implicit tasks
                 return task;
@@ -175,14 +175,14 @@ public abstract class TaskEntity<TState> : ITaskEntity
         return operation.TryDispatch(this.State, out result, out returnType);
     }
 
-    bool TryDispatchImplicit(out ValueTask<object?> result)
+    bool TryDispatchImplicit(TaskEntityOperation operation, out ValueTask<object?> result)
     {
         // We do not implement implicit operations via methods because then they would supersede state-dispatching.
         // As such, implicit operations are manually implemented here.
         result = default;
-        if (string.Equals(this.Operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
         {
-            this.Context.SetState(null);
+            operation.State.SetState(null);
             return true;
         }
 

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DurableTask.Entities;
 
@@ -123,12 +125,16 @@ public abstract class TaskEntity<TState> : ITaskEntity
     {
         Check.NotNull(operation);
         this.Context = operation.Context;
-        object? state = operation.State.GetState(typeof(TState));
-        this.State = state is null ? this.InitializeState() : (TState)state;
+        if (!this.TryGetState(operation, out TState? state, out ValueTask<object?> task))
+        {
+            return task;
+        }
+
+        this.State = state;
         if (!operation.TryDispatch(this, out object? result, out Type returnType)
             && !this.TryDispatchState(operation, out result, out returnType))
         {
-            if (this.TryDispatchImplicit(operation, out ValueTask<object?> task))
+            if (TryDispatchImplicit(operation, out task))
             {
                 // We do not go into UnwrapAsync for implicit tasks
                 return task;
@@ -158,6 +164,20 @@ public abstract class TaskEntity<TState> : ITaskEntity
         return Activator.CreateInstance<TState>();
     }
 
+    static bool TryDispatchImplicit(TaskEntityOperation operation, out ValueTask<object?> result)
+    {
+        // We do not implement implicit operations via methods because then they would supersede state-dispatching.
+        // As such, implicit operations are manually implemented here.
+        result = default;
+        if (string.Equals(operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
+        {
+            operation.State.SetState(null);
+            return true;
+        }
+
+        return false;
+    }
+
     bool TryDispatchState(TaskEntityOperation operation, out object? result, out Type returnType)
     {
         if (!this.AllowStateDispatch)
@@ -175,17 +195,28 @@ public abstract class TaskEntity<TState> : ITaskEntity
         return operation.TryDispatch(this.State, out result, out returnType);
     }
 
-    bool TryDispatchImplicit(TaskEntityOperation operation, out ValueTask<object?> result)
+    bool TryGetState(
+        TaskEntityOperation operation, [NotNullWhen(true)] out TState? state, out ValueTask<object?> result)
     {
-        // We do not implement implicit operations via methods because then they would supersede state-dispatching.
-        // As such, implicit operations are manually implemented here.
-        result = default;
-        if (string.Equals(operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
+        object? stateObj = null;
+        try
         {
-            operation.State.SetState(null);
-            return true;
+            stateObj = operation.State.GetState(typeof(TState));
+        }
+        catch
+        {
+            // State might be corrupt, check if this is an implicit operation (such as delete).
+            if (TryDispatchImplicit(operation, out result))
+            {
+                state = default;
+                return false;
+            }
+
+            throw;
         }
 
-        return false;
+        result = default;
+        state = stateObj is null ? this.InitializeState()! : (TState)stateObj;
+        return true;
     }
 }

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -128,7 +128,7 @@ public abstract class TaskEntity<TState> : ITaskEntity
         if (!operation.TryDispatch(this, out object? result, out Type returnType)
             && !this.TryDispatchState(operation, out result, out returnType))
         {
-            if (this.TryDispatchImplicit(operation, out ValueTask<object?> task))
+            if (TryDispatchImplicit(operation, out ValueTask<object?> task))
             {
                 // We do not go into UnwrapAsync for implicit tasks
                 return task;
@@ -158,6 +158,20 @@ public abstract class TaskEntity<TState> : ITaskEntity
         return Activator.CreateInstance<TState>();
     }
 
+    static bool TryDispatchImplicit(TaskEntityOperation operation, out ValueTask<object?> result)
+    {
+        // We do not implement implicit operations via methods because then they would supersede state-dispatching.
+        // As such, implicit operations are manually implemented here.
+        result = default;
+        if (string.Equals(operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
+        {
+            operation.State.SetState(null);
+            return true;
+        }
+
+        return false;
+    }
+
     bool TryDispatchState(TaskEntityOperation operation, out object? result, out Type returnType)
     {
         if (!this.AllowStateDispatch)
@@ -173,19 +187,5 @@ public abstract class TaskEntity<TState> : ITaskEntity
         }
 
         return operation.TryDispatch(this.State, out result, out returnType);
-    }
-
-    bool TryDispatchImplicit(TaskEntityOperation operation, out ValueTask<object?> result)
-    {
-        // We do not implement implicit operations via methods because then they would supersede state-dispatching.
-        // As such, implicit operations are manually implemented here.
-        result = default;
-        if (string.Equals(operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
-        {
-            operation.State.SetState(null);
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -72,6 +72,14 @@ public interface ITaskEntity
 /// Entity state will be hydrated into the <see cref="TaskEntity{TState}.State"/> property. See <see cref="State"/> for
 /// more information.
 /// </para>
+///
+/// <para><b>Implicit Operations</b></para>
+/// <para>
+/// This class supports some operations implicitly. Implicit operations have the lowest priority, after entity and state
+/// method dispatching. To override an implicit operation, implement a public method of the same name. Throw
+/// <see cref="NotSupportedException"/> from the method to indicate the implicit operation is not supported at all.
+/// </para>
+/// <para><c>delete</c>: deletes the entity state from storage.</para>
 /// </remarks>
 public abstract class TaskEntity<TState> : ITaskEntity
 {
@@ -124,6 +132,12 @@ public abstract class TaskEntity<TState> : ITaskEntity
         if (!operation.TryDispatch(this, out object? result, out Type returnType)
             && !this.TryDispatchState(out result, out returnType))
         {
+            if (this.TryDispatchImplicit(out ValueTask<object?> task))
+            {
+                // We do not go into UnwrapAsync for implicit tasks
+                return task;
+            }
+
             throw new NotSupportedException($"No suitable method found for entity operation '{operation}'.");
         }
 
@@ -163,5 +177,19 @@ public abstract class TaskEntity<TState> : ITaskEntity
         }
 
         return this.Operation.TryDispatch(this.State, out result, out returnType);
+    }
+
+    bool TryDispatchImplicit(out ValueTask<object?> result)
+    {
+        // We do not implement implicit operations via methods because then they would supersede state-dispatching.
+        // As such, implicit operations are manually implemented here.
+        result = default;
+        if (string.Equals(this.Operation.Name, "delete", StringComparison.OrdinalIgnoreCase))
+        {
+            this.Context.SetState(null);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
@@ -125,6 +125,34 @@ public class EntityTaskEntityTests
         result.Should().BeOfType<string>().Which.Should().Be("not-default");
     }
 
+    [Theory]
+    [InlineData("delete")]
+    [InlineData("Delete")]
+    public async Task ImplicitDelete_ClearsState(string op)
+    {
+        TestEntityOperation operation = new(op, 10, default);
+        TestEntity entity = new();
+
+        object? result = await entity.RunAsync(operation);
+
+        result.Should().BeNull();
+        operation.Context.GetState(typeof(object)).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("delete")]
+    [InlineData("Delete")]
+    public async Task ExplicitDelete_Overridden(string op)
+    {
+        TestEntityOperation operation = new(op, 10, default);
+        DeleteEntity entity = new();
+
+        object? result = await entity.RunAsync(operation);
+
+        result.Should().BeNull();
+        operation.Context.GetState(typeof(int)).Should().Be(0);
+    }
+
 #pragma warning disable CA1822 // Mark members as static
 #pragma warning disable IDE0060 // Remove unused parameter
     class TestEntity : TaskEntity<int>
@@ -259,6 +287,11 @@ public class EntityTaskEntityTests
 
             return this.State;
         }
+    }
+
+    class DeleteEntity : TaskEntity<int>
+    {
+        public void Delete() => this.State = 0;
     }
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1822 // Mark members as static

--- a/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
@@ -136,7 +136,7 @@ public class EntityTaskEntityTests
         object? result = await entity.RunAsync(operation);
 
         result.Should().BeNull();
-        operation.Context.GetState(typeof(object)).Should().BeNull();
+        operation.State.GetState(typeof(object)).Should().BeNull();
     }
 
     [Theory]
@@ -150,7 +150,7 @@ public class EntityTaskEntityTests
         object? result = await entity.RunAsync(operation);
 
         result.Should().BeNull();
-        operation.Context.GetState(typeof(int)).Should().Be(0);
+        operation.State.GetState(typeof(int)).Should().Be(0);
     }
 
 #pragma warning disable CA1822 // Mark members as static

--- a/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
@@ -158,6 +158,20 @@ public class StateTaskEntityTests
         result.Should().BeOfType<string>().Which.Should().Be("not-default");
     }
 
+    [Theory]
+    [InlineData("delete")]
+    [InlineData("Delete")]
+    public async Task ExplicitDelete_Overridden(string op)
+    {
+        TestEntityOperation operation = new(op, State(10), default);
+        TestEntity entity = new();
+
+        object? result = await entity.RunAsync(operation);
+
+        result.Should().BeNull();
+        operation.Context.GetState(typeof(TestState)).Should().BeOfType<TestState>().Which.Value.Should().Be(0);
+    }
+
     static TestState State(int value) => new() { Value = value };
 
     class NullStateEntity : TestEntity
@@ -186,6 +200,8 @@ public class StateTaskEntityTests
         public int Value { get; set; }
 
         public static string StaticMethod() => throw new NotImplementedException();
+
+        public void Delete() => this.Value = 0;
 
         public int Precedence() => 10;
 

--- a/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
@@ -169,7 +169,7 @@ public class StateTaskEntityTests
         object? result = await entity.RunAsync(operation);
 
         result.Should().BeNull();
-        operation.Context.GetState(typeof(TestState)).Should().BeOfType<TestState>().Which.Value.Should().Be(0);
+        operation.State.GetState(typeof(TestState)).Should().BeOfType<TestState>().Which.Value.Should().Be(0);
     }
 
     static TestState State(int value) => new() { Value = value };


### PR DESCRIPTION
This PR introduces an implicit `delete` operation when deriving from `TaskEntity<TState>`. This operation will null out the entities state, effectively deleting the entity.