### PR TITLE
Separate entity state from TaskEntityContext onto its own object

### DIFF
--- a/src/Abstractions/Entities/TaskEntityContext.cs
+++ b/src/Abstractions/Entities/TaskEntityContext.cs
@@ -51,18 +51,4 @@ public abstract class TaskEntityContext
     /// <param name="options">The options for starting the orchestration.</param>
     public abstract void StartOrchestration(
         TaskName name, object? input = null, StartOrchestrationOptions? options = null);
-
-    /// <summary>
-    /// Gets the current state for the entity this context is for. This will return <c>null</c> if no state is present,
-    /// regardless if <paramref name="type"/> is a value-type or not.
-    /// </summary>
-    /// <param name="type">The type to retrieve the state as.</param>
-    /// <returns>The entity state.</returns>
-    public abstract object? GetState(Type type);
-
-    /// <summary>
-    /// Sets the entity state. Setting of <c>null</c> will delete entity state.
-    /// </summary>
-    /// <param name="state">The state to set.</param>
-    public abstract void SetState(object? state);
 }

--- a/src/Abstractions/Entities/TaskEntityHelpers.cs
+++ b/src/Abstractions/Entities/TaskEntityHelpers.cs
@@ -13,47 +13,47 @@ static class TaskEntityHelpers
     /// <summary>
     /// Unwraps a dispatched result for a <see cref="TaskEntityOperation"/> into a <see cref="ValueTask{Object}"/>.
     /// </summary>
-    /// <param name="context">The entity context.</param>
-    /// <param name="state">Delegate to resolve new state for the entity.</param>
+    /// <param name="state">The entity state.</param>
+    /// <param name="stateCallback">Delegate to resolve new state for the entity.</param>
     /// <param name="result">The result of the operation.</param>
     /// <param name="resultType">The declared type of the result (may be different that actual type).</param>
     /// <returns>A value task which holds the result of the operation and sets state before it completes.</returns>
     public static ValueTask<object?> UnwrapAsync(
-        TaskEntityContext context, Func<object?> state, object? result, Type resultType)
+        TaskEntityState state, Func<object?> stateCallback, object? result, Type resultType)
     {
         // NOTE: Func<object?> is used for state so that we can lazily resolve it AFTER the operation has ran.
-        Check.NotNull(context);
+        Check.NotNull(state);
         Check.NotNull(resultType);
 
         if (typeof(Task).IsAssignableFrom(resultType))
         {
             // Task or Task<T>
             // We assume a declared Task return type is never null.
-            return new(UnwrapTask(context, state, (Task)result!, resultType));
+            return new(UnwrapTask(state, stateCallback, (Task)result!, resultType));
         }
 
         if (resultType == typeof(ValueTask))
         {
             // ValueTask
             // We assume a declared ValueTask return type is never null.
-            return UnwrapValueTask(context, state, (ValueTask)result!);
+            return UnwrapValueTask(state, stateCallback, (ValueTask)result!);
         }
 
         if (resultType.IsGenericType && resultType.GetGenericTypeDefinition() == typeof(ValueTask<>))
         {
             // ValueTask<T>
             // No inheritance, have to do purely via reflection.
-            return UnwrapValueTaskOfT(context, state, result!, resultType);
+            return UnwrapValueTaskOfT(state, stateCallback, result!, resultType);
         }
 
-        context.SetState(state());
+        state.SetState(stateCallback());
         return new(result);
     }
 
-    static async Task<object?> UnwrapTask(TaskEntityContext context, Func<object?> state, Task task, Type declared)
+    static async Task<object?> UnwrapTask(TaskEntityState state, Func<object?> callback, Task task, Type declared)
     {
         await task;
-        context.SetState(state());
+        state.SetState(callback());
         if (declared.IsGenericType && declared.GetGenericTypeDefinition() == typeof(Task<>))
         {
             return declared.GetProperty("Result", BindingFlags.Public | BindingFlags.Instance).GetValue(task);
@@ -62,18 +62,18 @@ static class TaskEntityHelpers
         return null;
     }
 
-    static ValueTask<object?> UnwrapValueTask(TaskEntityContext context, Func<object?> state, ValueTask t)
+    static ValueTask<object?> UnwrapValueTask(TaskEntityState state, Func<object?> callback, ValueTask t)
     {
         async Task<object?> Await(ValueTask t)
         {
             await t;
-            context.SetState(state());
+            state.SetState(callback());
             return null;
         }
 
         if (t.IsCompletedSuccessfully)
         {
-            context.SetState(state());
+            state.SetState(callback());
             return default;
         }
 
@@ -81,20 +81,20 @@ static class TaskEntityHelpers
     }
 
     static ValueTask<object?> UnwrapValueTaskOfT(
-        TaskEntityContext context, Func<object?> state, object result, Type type)
+        TaskEntityState state, Func<object?> callback, object result, Type type)
     {
         // Result and type here must be some form of ValueTask<T>.
         // TODO: can this amount of reflection be avoided?
         if ((bool)type.GetProperty("IsCompletedSuccessfully").GetValue(result))
         {
-            context.SetState(state());
+            state.SetState(callback());
             return new(type.GetProperty("Result").GetValue(result));
         }
         else
         {
             Task t = (Task)type.GetMethod("AsTask", BindingFlags.Instance | BindingFlags.Public).Invoke(result, null);
             Type taskType = typeof(Task<>).MakeGenericType(type.GetGenericArguments()[0]);
-            return new(UnwrapTask(context, state, t, taskType));
+            return new(UnwrapTask(state, callback, t, taskType));
         }
     }
 }

--- a/src/Abstractions/Entities/TaskEntityOperation.cs
+++ b/src/Abstractions/Entities/TaskEntityOperation.cs
@@ -19,6 +19,11 @@ public abstract class TaskEntityOperation
     public abstract TaskEntityContext Context { get; }
 
     /// <summary>
+    /// Gets the state of the entity.
+    /// </summary>
+    public abstract TaskEntityState State { get; }
+
+    /// <summary>
     /// Gets a value indicating whether this operation has input or not.
     /// </summary>
     public abstract bool HasInput { get; }

--- a/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
+++ b/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
@@ -47,7 +47,6 @@ public static class TaskEntityOperationExtensions
         int i = 0;
         ParameterInfo? inputResolved = null;
         ParameterInfo? contextResolved = null;
-        ParameterInfo? operationResolved = null;
         foreach (ParameterInfo parameter in parameters)
         {
             if (parameter.ParameterType == typeof(TaskEntityContext))
@@ -55,12 +54,6 @@ public static class TaskEntityOperationExtensions
                 ThrowIfDuplicateBinding(contextResolved, parameter, "context", operation);
                 inputs[i] = operation.Context;
                 contextResolved = parameter;
-            }
-            else if (parameter.ParameterType == typeof(TaskEntityOperation))
-            {
-                ThrowIfDuplicateBinding(operationResolved, parameter, "operation", operation);
-                inputs[i] = operation;
-                operationResolved = parameter;
             }
             else
             {

--- a/src/Abstractions/Entities/TaskEntityState.cs
+++ b/src/Abstractions/Entities/TaskEntityState.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Entities;
+
+/// <summary>
+/// Represents the persisted state of an entity.
+/// </summary>
+public abstract class TaskEntityState
+{
+    /// <summary>
+    /// Gets the current state for the entity this context is for. This will return <c>null</c> if no state is present,
+    /// regardless if <paramref name="type"/> is a value-type or not.
+    /// </summary>
+    /// <param name="type">The type to retrieve the state as.</param>
+    /// <returns>The entity state.</returns>
+    public abstract object? GetState(Type type);
+
+    /// <summary>
+    /// Sets the entity state. Setting of <c>null</c> will delete entity state.
+    /// </summary>
+    /// <param name="state">The state to set.</param>
+    public abstract void SetState(object? state);
+}

--- a/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
@@ -38,19 +38,19 @@ public class EntityTaskEntityTests
 
     [Theory]
     [CombinatorialData]
-    public async Task Add_Success([CombinatorialRange(0, 14)] int method, bool lowercase)
+    public async Task Add_Success([CombinatorialRange(0, 2)] int method, bool lowercase)
     {
         int start = Random.Shared.Next(0, 10);
         int toAdd = Random.Shared.Next(1, 10);
         string opName = lowercase ? "add" : "Add";
-        TestEntityContext context = new(start);
-        TestEntityOperation operation = new($"{opName}{method}", context, toAdd);
+        TestEntityState state = new(start);
+        TestEntityOperation operation = new($"{opName}{method}", state, toAdd);
         TestEntity entity = new();
 
         object? result = await entity.RunAsync(operation);
 
         int expected = start + toAdd;
-        context.GetState(typeof(int)).Should().BeOfType<int>().Which.Should().Be(expected);
+        state.GetState(typeof(int)).Should().BeOfType<int>().Which.Should().Be(expected);
         result.Should().BeOfType<int>().Which.Should().Be(expected);
     }
 
@@ -60,20 +60,20 @@ public class EntityTaskEntityTests
     {
         int expected = Random.Shared.Next(0, 10);
         string opName = lowercase ? "get" : "Get";
-        TestEntityContext context = new(expected);
-        TestEntityOperation operation = new($"{opName}{method}", context, default);
+        TestEntityState state = new(expected);
+        TestEntityOperation operation = new($"{opName}{method}", state, default);
         TestEntity entity = new();
 
         object? result = await entity.RunAsync(operation);
 
-        context.GetState(typeof(int)).Should().BeOfType<int>().Which.Should().Be(expected);
+        state.GetState(typeof(int)).Should().BeOfType<int>().Which.Should().Be(expected);
         result.Should().BeOfType<int>().Which.Should().Be(expected);
     }
 
     [Fact]
     public async Task Add_NoInput_Fails()
     {
-        TestEntityOperation operation = new("add0", new TestEntityContext(null), default);
+        TestEntityOperation operation = new("add0", new TestEntityState(null), default);
         TestEntity entity = new();
 
         Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
@@ -85,7 +85,7 @@ public class EntityTaskEntityTests
     [CombinatorialData]
     public async Task Dispatch_AmbiguousArgs_Fails([CombinatorialRange(0, 3)] int method)
     {
-        TestEntityOperation operation = new($"ambiguousArgs{method}", new TestEntityContext(null), 10);
+        TestEntityOperation operation = new($"ambiguousArgs{method}", new TestEntityState(null), 10);
         TestEntity entity = new();
 
         Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
@@ -96,7 +96,7 @@ public class EntityTaskEntityTests
     [Fact]
     public async Task Dispatch_AmbiguousMatch_Fails()
     {
-        TestEntityOperation operation = new("ambiguousMatch", new TestEntityContext(null), 10);
+        TestEntityOperation operation = new("ambiguousMatch", new TestEntityState(null), 10);
         TestEntity entity = new();
 
         Func<Task<object?>> action = () => entity.RunAsync(operation).AsTask();
@@ -106,7 +106,7 @@ public class EntityTaskEntityTests
     [Fact]
     public async Task DefaultValue_NoInput_Succeeds()
     {
-        TestEntityOperation operation = new("defaultValue", new TestEntityContext(null), default);
+        TestEntityOperation operation = new("defaultValue", new TestEntityState(null), default);
         TestEntity entity = new();
 
         object? result = await entity.RunAsync(operation);
@@ -117,7 +117,7 @@ public class EntityTaskEntityTests
     [Fact]
     public async Task DefaultValue_Input_Succeeds()
     {
-        TestEntityOperation operation = new("defaultValue", new TestEntityContext(null), "not-default");
+        TestEntityOperation operation = new("defaultValue", new TestEntityState(null), "not-default");
         TestEntity entity = new();
 
         object? result = await entity.RunAsync(operation);
@@ -131,44 +131,9 @@ public class EntityTaskEntityTests
     {
         public static string StaticMethod() => throw new NotImplementedException();
 
-        // All possible permutations of the 3 inputs we support: object, context, operation
-        // 14 via Add, 2 via Get: 16 total.
-        public int Add0(int value) => this.Add(value, default, default);
+        public int Add0(int value) => this.Add(value, default);
 
-        public int Add1(int value, TaskEntityContext context) => this.Add(value, context, default);
-
-        public int Add2(int value, TaskEntityOperation operation) => this.Add(value, default, operation);
-
-        public int Add3(int value, TaskEntityContext context, TaskEntityOperation operation)
-            => this.Add(value, context, operation);
-
-        public int Add4(int value, TaskEntityOperation operation, TaskEntityContext context)
-            => this.Add(value, context, operation);
-
-        public int Add5(TaskEntityOperation operation) => this.Add(default, default, operation);
-
-        public int Add6(TaskEntityOperation operation, int value) => this.Add(value, default, operation);
-
-        public int Add7(TaskEntityOperation operation, TaskEntityContext context)
-            => this.Add(default, context, operation);
-
-        public int Add8(TaskEntityOperation operation, int value, TaskEntityContext context)
-            => this.Add(value, context, operation);
-
-        public int Add9(TaskEntityOperation operation, TaskEntityContext context, int value)
-            => this.Add(value, context, operation);
-
-        public int Add10(TaskEntityContext context, int value)
-            => this.Add(value, context, default);
-
-        public int Add11(TaskEntityContext context, TaskEntityOperation operation)
-            => this.Add(default, context, operation);
-
-        public int Add12(TaskEntityContext context, int value, TaskEntityOperation operation)
-            => this.Add(value, context, operation);
-
-        public int Add13(TaskEntityContext context, TaskEntityOperation operation, int value)
-            => this.Add(value, context, operation);
+        public int Add1(int value, TaskEntityContext context) => this.Add(value, context);
 
         public int Get0() => this.Get(default);
 
@@ -229,21 +194,11 @@ public class EntityTaskEntityTests
             return sync ? new("success") : new(Slow());
         }
 
-        int Add(int? value, Optional<TaskEntityContext> context, Optional<TaskEntityOperation> operation)
+        int Add(int? value, Optional<TaskEntityContext> context)
         {
             if (context.HasValue)
             {
                 context.Value.Should().NotBeNull();
-            }
-
-            if (operation.HasValue)
-            {
-                operation.Value.Should().NotBeNull();
-            }
-
-            if (!value.HasValue && operation.TryGet(out TaskEntityOperation? op))
-            {
-                value = (int)op.GetInput(typeof(int))!;
             }
 
             value.HasValue.Should().BeTrue();

--- a/test/Abstractions.Tests/Entities/Mocks/TestEntityOperation.cs
+++ b/test/Abstractions.Tests/Entities/Mocks/TestEntityOperation.cs
@@ -10,25 +10,28 @@ public class TestEntityOperation : TaskEntityOperation
     readonly Optional<object?> input;
 
     public TestEntityOperation(string name, Optional<object?> input)
-        : this(name, new TestEntityContext(null), input)
+        : this(name, new TestEntityState(null), input)
     {
     }
 
     public TestEntityOperation(string name, object? state, Optional<object?> input)
-        : this(name, new TestEntityContext(state), input)
+        : this(name, new TestEntityState(state), input)
     {
     }
 
-    public TestEntityOperation(string name, TaskEntityContext context, Optional<object?> input)
+    public TestEntityOperation(string name, TaskEntityState state, Optional<object?> input)
     {
         this.Name = name;
-        this.Context = context;
+        this.State = state;
         this.input = input;
+        this.Context = Mock.Of<TaskEntityContext>();
     }
 
     public override string Name { get; }
 
     public override TaskEntityContext Context { get; }
+
+    public override TaskEntityState State { get; }
 
     public override bool HasInput => this.input.HasValue;
 

--- a/test/Abstractions.Tests/Entities/Mocks/TestEntityState.cs
+++ b/test/Abstractions.Tests/Entities/Mocks/TestEntityState.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.DurableTask.Entities.Tests;
 
-public class TestEntityContext : TaskEntityContext
+public class TestEntityState : TaskEntityState
 {
-    public TestEntityContext(object? state)
+    public TestEntityState(object? state)
     {
         this.State = state;
     }
 
     public object? State { get; private set; }
-
-    public override EntityInstanceId Id { get; }
 
     public override object? GetState(Type type)
     {
@@ -27,17 +25,5 @@ public class TestEntityContext : TaskEntityContext
     public override void SetState(object? state)
     {
         this.State = state;
-    }
-
-    public override void SignalEntity(
-        EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null)
-    {
-        throw new NotImplementedException();
-    }
-
-    public override void StartOrchestration(
-        TaskName name, object? input = null, StartOrchestrationOptions? options = null)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/test/Abstractions.Tests/Entities/TaskEntityHelpersTests.cs
+++ b/test/Abstractions.Tests/Entities/TaskEntityHelpersTests.cs
@@ -9,12 +9,12 @@ public class TaskEntityHelpersTests
     public async Task UnwrapAsync_Void()
     {
         int state = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
-        object? result = await TaskEntityHelpers.UnwrapAsync(context, () => state, null, typeof(void));
+        object? result = await TaskEntityHelpers.UnwrapAsync(entityState, () => state, null, typeof(void));
 
         result.Should().BeNull();
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Fact]
@@ -22,12 +22,12 @@ public class TaskEntityHelpersTests
     {
         int state = Random.Shared.Next(1, 10);
         int value = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
-        object? result = await TaskEntityHelpers.UnwrapAsync(context, () => state, value, typeof(int));
+        object? result = await TaskEntityHelpers.UnwrapAsync(entityState, () => state, value, typeof(int));
 
         result.Should().BeOfType<int>().Which.Should().Be(value);
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Theory]
@@ -36,14 +36,14 @@ public class TaskEntityHelpersTests
     {
         TaskCompletionSource tcs = new();
         int state = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
             tcs.TrySetResult();
         }
 
-        ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(context, () => state, tcs.Task, typeof(Task));
+        ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(entityState, () => state, tcs.Task, typeof(Task));
 
         if (async)
         {
@@ -54,7 +54,7 @@ public class TaskEntityHelpersTests
         object? result = await task;
 
         result.Should().BeNull();
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Theory]
@@ -62,14 +62,14 @@ public class TaskEntityHelpersTests
     public async Task UnwrapAsync_Task_Throws(bool async)
     {
         TaskCompletionSource tcs = new();
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
             tcs.SetException(new OperationCanceledException());
         }
 
-        Func<Task> throws = async () => await TaskEntityHelpers.UnwrapAsync(context, () => 0, tcs.Task, typeof(Task));
+        Func<Task> throws = async () => await TaskEntityHelpers.UnwrapAsync(entityState, () => 0, tcs.Task, typeof(Task));
         
         if (async)
         {
@@ -87,14 +87,14 @@ public class TaskEntityHelpersTests
 
         int state = Random.Shared.Next(1, 10);
         int value = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
             tcs.TrySetResult(value);
         }
 
-        ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(context, () => state, tcs.Task, typeof(Task<int>));
+        ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(entityState, () => state, tcs.Task, typeof(Task<int>));
 
         if (async)
         {
@@ -105,7 +105,7 @@ public class TaskEntityHelpersTests
         object? result = await task;
 
         result.Should().BeOfType<int>().Which.Should().Be(value);
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Theory]
@@ -113,7 +113,7 @@ public class TaskEntityHelpersTests
     public async Task UnwrapAsync_TaskOfInt_Throws(bool async)
     {
         TaskCompletionSource<int> tcs = new();
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
@@ -121,7 +121,7 @@ public class TaskEntityHelpersTests
         }
 
         Func<Task> throws = async () => await TaskEntityHelpers.UnwrapAsync(
-            context, () => 0, tcs.Task, typeof(Task<int>));
+            entityState, () => 0, tcs.Task, typeof(Task<int>));
 
         if (async)
         {
@@ -139,7 +139,7 @@ public class TaskEntityHelpersTests
         TaskCompletionSource tcs = new();
 
         int state = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
@@ -147,7 +147,7 @@ public class TaskEntityHelpersTests
         }
 
         ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(
-            context, () => state, new ValueTask(tcs.Task), typeof(ValueTask));
+            entityState, () => state, new ValueTask(tcs.Task), typeof(ValueTask));
 
         if (async)
         {
@@ -157,7 +157,7 @@ public class TaskEntityHelpersTests
 
         object? result = await task;
         result.Should().BeNull();
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Theory]
@@ -165,7 +165,7 @@ public class TaskEntityHelpersTests
     public async Task UnwrapAsync_ValueTask_Throws(bool async)
     {
         TaskCompletionSource tcs = new();
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
@@ -173,7 +173,7 @@ public class TaskEntityHelpersTests
         }
 
         Func<Task> throws = async () => await TaskEntityHelpers.UnwrapAsync(
-            context, () => 0, new ValueTask(tcs.Task), typeof(ValueTask));
+            entityState, () => 0, new ValueTask(tcs.Task), typeof(ValueTask));
 
         if (async)
         {
@@ -191,7 +191,7 @@ public class TaskEntityHelpersTests
         TaskCompletionSource<int> tcs = new();
         int state = Random.Shared.Next(1, 10);
         int value = Random.Shared.Next(1, 10);
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
@@ -199,7 +199,7 @@ public class TaskEntityHelpersTests
         }
 
         ValueTask<object?> task = TaskEntityHelpers.UnwrapAsync(
-            context, () => state, new ValueTask<int>(tcs.Task), typeof(ValueTask<int>));
+            entityState, () => state, new ValueTask<int>(tcs.Task), typeof(ValueTask<int>));
 
         if (async)
         {
@@ -210,7 +210,7 @@ public class TaskEntityHelpersTests
         object? result = await task;
 
         result.Should().BeOfType<int>().Which.Should().Be(value);
-        context.State.Should().BeOfType<int>().Which.Should().Be(state);
+        entityState.State.Should().BeOfType<int>().Which.Should().Be(state);
     }
 
     [Theory]
@@ -218,7 +218,7 @@ public class TaskEntityHelpersTests
     public async Task UnwrapAsync_ValueTaskOfInt_Throws(bool async)
     {
         TaskCompletionSource<int> tcs = new();
-        TestEntityContext context = new(null);
+        TestEntityState entityState = new(null);
 
         if (!async)
         {
@@ -226,7 +226,7 @@ public class TaskEntityHelpersTests
         }
 
         Func<Task> throws = async () => await TaskEntityHelpers.UnwrapAsync(
-            context, () => 0, new ValueTask<int>(tcs.Task), typeof(ValueTask<int>));
+            entityState, () => 0, new ValueTask<int>(tcs.Task), typeof(ValueTask<int>));
 
         if (async)
         {


### PR DESCRIPTION
This PR separates entity state from `TaskEntityContext` into `TaskEntityState`, which is available off of `TaskEntityOperation`. The PR also removes binding of `TaskEntityOperation` from `TaskEntity<TState>`. The end result is that when using `TaskEntity<TState>`, users have no direct access to the operation or state. This is to prevent confusing behavior when trying to use direct entity state interactions within `TaskEntity<TState>`. If a user wants direct operation access, they should derive from `ITaskEntity`.