### PR TITLE
Fixes to entity implementation

### DIFF
--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using DurableTask.Core;
 using DurableTask.Core.Command;
+using DurableTask.Core.Entities;
 using DurableTask.Core.Entities.OperationFormat;
 using DurableTask.Core.History;
 using Google.Protobuf;
@@ -629,6 +630,25 @@ static class ProtoUtils
         }
 
         return batchResult;
+    }
+
+    /// <summary>
+    /// Converts the gRPC representation of orchestrator entity parameters to the DT.Core representation.
+    /// </summary>
+    /// <param name="parameters">The DT.Core representation.</param>
+    /// <returns>The gRPC representation.</returns>
+    [return: NotNullIfNotNull("parameters")]
+    internal static TaskOrchestrationEntityParameters? ToCore(this P.OrchestratorEntityParameters? parameters)
+    {
+        if (parameters == null)
+        {
+            return null;
+        }
+
+        return new TaskOrchestrationEntityParameters()
+        {
+            EntityMessageReorderWindow = parameters.EntityMessageReorderWindow.ToTimeSpan(),
+        };
     }
 
     /// <summary>

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -202,11 +202,6 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// <inheritdoc/>
     public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
     {
-        if (typeof(T) == typeof(OperationResult))
-        {
-            throw new ArgumentException($"the type {nameof(OperationResult)} cannot be used for application-defined events", nameof(T));
-        }
-
         // Return immediately if this external event has already arrived.
         if (this.externalEventBuffer.TryTake(eventName, out string? bufferedEventPayload))
         {

--- a/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
@@ -76,7 +76,7 @@ sealed partial class TaskOrchestrationContextWrapper
                 //    entityMessageEvent.ToString());
             }
 
-            this.wrapper.innerContext.SendEvent(entityMessageEvent.TargetInstance, entityMessageEvent.EventName, entityMessageEvent.ContentAsObject());
+            this.wrapper.innerContext.SendEvent(entityMessageEvent.TargetInstance, entityMessageEvent.EventName, entityMessageEvent);
 
             OperationResult result = await this.wrapper.WaitForExternalEvent<OperationResult>(criticalSectionId.ToString());
 
@@ -155,7 +155,7 @@ sealed partial class TaskOrchestrationContextWrapper
                         //    releaseMessage.EventContent);
                     }
 
-                    this.wrapper.innerContext.SendEvent(releaseMessage.TargetInstance, releaseMessage.EventName, releaseMessage.ContentAsObject());
+                    this.wrapper.innerContext.SendEvent(releaseMessage.TargetInstance, releaseMessage.EventName, releaseMessage);
                 }
             }
         }
@@ -212,7 +212,7 @@ sealed partial class TaskOrchestrationContextWrapper
                 //    entityMessageEvent.ToString());
             }
 
-            this.wrapper.innerContext.SendEvent(entityMessageEvent.TargetInstance, entityMessageEvent.EventName, entityMessageEvent.ContentAsObject());
+            this.wrapper.innerContext.SendEvent(entityMessageEvent.TargetInstance, entityMessageEvent.EventName, entityMessageEvent);
 
             return guid;
         }

--- a/src/Worker/Grpc/GrpcOrchestrationRunner.cs
+++ b/src/Worker/Grpc/GrpcOrchestrationRunner.cs
@@ -113,7 +113,7 @@ public static class GrpcOrchestrationRunner
             ? DurableTaskShimFactory.Default
             : ActivatorUtilities.GetServiceOrCreateInstance<DurableTaskShimFactory>(services);
         TaskOrchestration shim = factory.CreateOrchestration(orchestratorName, implementation, parent);
-        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover);
+        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover, request.EntityParameters.ToCore());
         OrchestratorExecutionResult result = executor.Execute();
 
         P.OrchestratorResponse response = ProtoUtils.ConstructOrchestratorResponse(


### PR DESCRIPTION
Three changes in this PR:

- pass entity parameters to the orchestration executors (depends on https://github.com/Azure/durabletask/pull/971)
- remove a check that was meant to catch corner invalid useage case but it actually fires on our own path
- fix issue with serialization of EntityMessageEvent (depends on https://github.com/Azure/durabletask/pull/972)