### PR TITLE
Refactor EntityMetadata to improve state consumption

### DIFF
--- a/src/Client/Core/Entities/DurableEntityClient.cs
+++ b/src/Client/Core/Entities/DurableEntityClient.cs
@@ -77,7 +77,7 @@ public abstract class DurableEntityClient
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="includeState"><c>true</c> to include entity state in the response, <c>false</c> to not.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>A response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity, or null if the entity does not exist.</returns>
     public abstract Task<EntityMetadata?> GetEntityAsync(
         EntityInstanceId id, bool includeState = true, CancellationToken cancellation = default);
 
@@ -86,7 +86,7 @@ public abstract class DurableEntityClient
     /// </summary>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>A response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity, or null if the entity does not exist.</returns>
     public virtual Task<EntityMetadata?> GetEntityAsync(
         EntityInstanceId id, CancellationToken cancellation)
             => this.GetEntityAsync(id, includeState: true, cancellation);
@@ -98,7 +98,7 @@ public abstract class DurableEntityClient
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="includeState"><c>true</c> to include entity state in the response, <c>false</c> to not.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>A response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity, or null if the entity does not exist.</returns>
     public abstract Task<EntityMetadata<T>?> GetEntityAsync<T>(
         EntityInstanceId id, bool includeState = true, CancellationToken cancellation = default);
 
@@ -108,7 +108,7 @@ public abstract class DurableEntityClient
     /// <typeparam name="T">The type of the entity state.</typeparam>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>A response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity, or null if the entity does not exist.</returns>
     public virtual Task<EntityMetadata<T>?> GetEntityAsync<T>(
         EntityInstanceId id, CancellationToken cancellation)
             => this.GetEntityAsync<T>(id, includeState: true, cancellation);

--- a/src/Client/Core/Entities/DurableEntityClient.cs
+++ b/src/Client/Core/Entities/DurableEntityClient.cs
@@ -72,24 +72,46 @@ public abstract class DurableEntityClient
         => this.SignalEntityAsync(id, operationName, null, null, cancellation);
 
     /// <summary>
-    /// Tries to get the entity with ID of <paramref name="id"/>.
+    /// Tries to get the entity with ID of <paramref name="id"/>. Includes entity state by default.
     /// </summary>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="includeState"><c>true</c> to include entity state in the response, <c>false</c> to not.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>a response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity.</returns>
     public abstract Task<EntityMetadata?> GetEntityAsync(
-        EntityInstanceId id, bool includeState = false, CancellationToken cancellation = default);
+        EntityInstanceId id, bool includeState = true, CancellationToken cancellation = default);
 
     /// <summary>
-    /// Tries to get the entity with ID of <paramref name="id"/>.
+    /// Tries to get the entity with ID of <paramref name="id"/>. Includes entity state.
     /// </summary>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
-    /// <returns>a response containing metadata describing the entity.</returns>
+    /// <returns>A response containing metadata describing the entity.</returns>
     public virtual Task<EntityMetadata?> GetEntityAsync(
         EntityInstanceId id, CancellationToken cancellation)
-            => this.GetEntityAsync(id, includeState: false, cancellation);
+            => this.GetEntityAsync(id, includeState: true, cancellation);
+
+    /// <summary>
+    /// Tries to get the entity with ID of <paramref name="id"/>. Includes entity state by default.
+    /// </summary>
+    /// <typeparam name="T">The type of the entity state.</typeparam>
+    /// <param name="id">The ID of the entity to get.</param>
+    /// <param name="includeState"><c>true</c> to include entity state in the response, <c>false</c> to not.</param>
+    /// <param name="cancellation">The cancellation token to cancel the operation.</param>
+    /// <returns>A response containing metadata describing the entity.</returns>
+    public abstract Task<EntityMetadata<T>?> GetEntityAsync<T>(
+        EntityInstanceId id, bool includeState = true, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Tries to get the entity with ID of <paramref name="id"/>. Includes entity state.
+    /// </summary>
+    /// <typeparam name="T">The type of the entity state.</typeparam>
+    /// <param name="id">The ID of the entity to get.</param>
+    /// <param name="cancellation">The cancellation token to cancel the operation.</param>
+    /// <returns>A response containing metadata describing the entity.</returns>
+    public virtual Task<EntityMetadata<T>?> GetEntityAsync<T>(
+        EntityInstanceId id, CancellationToken cancellation)
+            => this.GetEntityAsync<T>(id, includeState: true, cancellation);
 
     /// <summary>
     /// Queries entity instances, optionally filtering results with <paramref name="filter"/>.
@@ -99,12 +121,24 @@ public abstract class DurableEntityClient
     public abstract AsyncPageable<EntityMetadata> GetAllEntitiesAsync(EntityQuery? filter = null);
 
     /// <summary>
+    /// Queries entity instances, optionally filtering results with <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the entity state.</typeparam>
+    /// <param name="filter">The optional query filter.</param>
+    /// <returns>An async pageable of the query results.</returns>
+    public abstract AsyncPageable<EntityMetadata<T>> GetAllEntitiesAsync<T>(EntityQuery? filter = null);
+
+    /// <summary>
     /// Cleans entity storage. See <see cref="CleanEntityStorageRequest"/> for the different forms of cleaning available.
     /// </summary>
     /// <param name="request">The request which describes what to clean.</param>
-    /// <param name="continueUntilComplete">whether to keep going until the cleaning is complete, or to return intermediate results with a continuation token.</param>
+    /// <param name="continueUntilComplete">
+    /// Whether to keep going until the cleaning is complete, or to return intermediate results with a continuation token.
+    /// </param>
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
     /// <returns>A task that completes when the operation is finished.</returns>
     public abstract Task<CleanEntityStorageResult> CleanEntityStorageAsync(
-        CleanEntityStorageRequest request = default, bool continueUntilComplete = true, CancellationToken cancellation = default);
+        CleanEntityStorageRequest request = default,
+        bool continueUntilComplete = true,
+        CancellationToken cancellation = default);
 }

--- a/src/Client/Core/Entities/EntityMetadata.cs
+++ b/src/Client/Core/Entities/EntityMetadata.cs
@@ -47,8 +47,11 @@ public class EntityMetadata<TState>
     public DateTimeOffset LastModifiedTime { get; init; }
 
     /// <summary>
-    /// Gets a value indicating if entity metadata 
+    /// Gets a value indicating whether this metadata response includes the entity state.
     /// </summary>
+    /// <remarks>
+    /// Queries can exclude the state of the entity from the metadata that is retrieved.
+    /// </remarks>
     [MemberNotNullWhen(true, "State")]
     [MemberNotNullWhen(true, "state")]
     public bool IncludesState { get; }
@@ -56,7 +59,14 @@ public class EntityMetadata<TState>
     /// <summary>
     /// Gets the state for this entity.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="IncludesState"/> is <c>false</c>.</exception>
+    /// <remarks>
+    /// This method can only be used when <see cref="IncludesState"/> = <c>true</c>, meaning  that the entity state was
+    /// included in the response returned by the query.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if this metadata object was fetched without including the entity state. In which case,
+    /// <see cref="IncludesState" /> will be <c>false</c>.
+    /// </exception>
     public TState State
     {
         get

--- a/src/Client/Core/Entities/EntityMetadata.cs
+++ b/src/Client/Core/Entities/EntityMetadata.cs
@@ -56,6 +56,7 @@ public class EntityMetadata<TState>
     /// <summary>
     /// Gets the state for this entity.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="IncludesState"/> is <c>false</c>.</exception>
     public TState State
     {
         get

--- a/src/Client/Core/Entities/EntityQuery.cs
+++ b/src/Client/Core/Entities/EntityQuery.cs
@@ -56,9 +56,9 @@ public record EntityQuery
     public DateTimeOffset? LastModifiedTo { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether to include state in the query results or not.
+    /// Gets a value indicating whether to include state in the query results or not. Defaults to true.
     /// </summary>
-    public bool IncludeState { get; init; }
+    public bool IncludeState { get; init; } = true;
 
     /// <summary>
     /// Gets the size of each page to return.

--- a/src/Client/Core/SerializedData.cs
+++ b/src/Client/Core/SerializedData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Client;
+
+/// <summary>
+/// Gets a type representing serialized data.
+/// </summary>
+public sealed class SerializedData
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializedData"/> class.
+    /// </summary>
+    /// <param name="data">The serialized data.</param>
+    /// <param name="converter">The data converter.</param>
+    public SerializedData(string data, DataConverter converter)
+    {
+        this.Value = Check.NotNull(data);
+        this.Converter = Check.NotNull(converter);
+    }
+
+    /// <summary>
+    /// Gets the serialized value.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets the data converter.
+    /// </summary>
+    public DataConverter Converter { get; }
+
+    /// <summary>
+    /// Deserializes the data into <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize into.</typeparam>
+    /// <returns>The deserialized type.</returns>
+    public T ReadAs<T>() => this.Converter.Deserialize<T>(this.Value);
+}

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Net.NetworkInformation;
-using System.Text;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.DurableTask.Client.Entities;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
@@ -165,7 +160,7 @@ class GrpcDurableEntityClient : DurableEntityClient
         EntityQuery? filter, Func<P.EntityMetadata, bool, TMetadata> select)
         where TMetadata : class
     {
-        bool includeState = filter?.IncludeState ?? false;
+        bool includeState = filter?.IncludeState ?? true;
         string startsWith = filter?.InstanceIdStartsWith ?? string.Empty;
         DateTimeOffset? lastModifiedFrom = filter?.LastModifiedFrom;
         DateTimeOffset? lastModifiedTo = filter?.LastModifiedTo;

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.NetworkInformation;
 using System.Text;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.DurableTask.Client.Entities;
@@ -30,7 +31,8 @@ class GrpcDurableEntityClient : DurableEntityClient
     /// <param name="dataConverter">The data converter.</param>
     /// <param name="sidecarClient">The client for the GRPC connection to the sidecar.</param>
     /// <param name="logger">The logger for logging client requests.</param>
-    public GrpcDurableEntityClient(string name, DataConverter dataConverter, TaskHubSidecarServiceClient sidecarClient, ILogger logger)
+    public GrpcDurableEntityClient(
+        string name, DataConverter dataConverter, TaskHubSidecarServiceClient sidecarClient, ILogger logger)
         : base(name)
     {
         this.dataConverter = dataConverter;
@@ -39,7 +41,12 @@ class GrpcDurableEntityClient : DurableEntityClient
     }
 
     /// <inheritdoc/>
-    public override async Task SignalEntityAsync(EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null, CancellationToken cancellation = default)
+    public override async Task SignalEntityAsync(
+        EntityInstanceId id,
+        string operationName,
+        object? input = null,
+        SignalEntityOptions? options = null,
+        CancellationToken cancellation = default)
     {
         Guid requestId = Guid.NewGuid();
         DateTimeOffset? scheduledTime = options?.SignalTime;
@@ -67,72 +74,28 @@ class GrpcDurableEntityClient : DurableEntityClient
     }
 
     /// <inheritdoc/>
-    public override async Task<EntityMetadata?> GetEntityAsync(EntityInstanceId id, bool includeState = false, CancellationToken cancellation = default)
-    {
-        P.GetEntityRequest request = new()
-        {
-            InstanceId = id.ToString(),
-            IncludeState = includeState,
-        };
+    public override Task<EntityMetadata?> GetEntityAsync(
+        EntityInstanceId id, bool includeState = false, CancellationToken cancellation = default)
+        => this.GetEntityCoreAsync(id, includeState, (e, s) => this.ToEntityMetadata(e, s), cancellation);
 
-        try
-        {
-            P.GetEntityResponse response = await this.sidecarClient.GetEntityAsync(request, cancellationToken: cancellation);
-
-            return response.Exists ? this.ToEntityMetadata(response.Entity, includeState) : null;
-        }
-        catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
-        {
-            throw new OperationCanceledException(
-                $"The {nameof(this.GetEntityAsync)} operation was canceled.", e, cancellation);
-        }
-    }
+    /// <inheritdoc/>
+    public override Task<EntityMetadata<TState>?> GetEntityAsync<TState>(
+        EntityInstanceId id, bool includeState = false, CancellationToken cancellation = default)
+        => this.GetEntityCoreAsync(id, includeState, (e, s) => this.ToEntityMetadata<TState>(e, s), cancellation);
 
     /// <inheritdoc/>
     public override AsyncPageable<EntityMetadata> GetAllEntitiesAsync(EntityQuery? filter = null)
-    {
-        bool includeState = filter?.IncludeState ?? false;
-        string startsWith = filter?.InstanceIdStartsWith ?? string.Empty;
-        DateTimeOffset? lastModifiedFrom = filter?.LastModifiedFrom;
-        DateTimeOffset? lastModifiedTo = filter?.LastModifiedTo;
-
-        return Pageable.Create(async (continuation, pageSize, cancellation) =>
-        {
-            pageSize ??= filter?.PageSize;
-
-            try
-            {
-                P.QueryEntitiesResponse response = await this.sidecarClient.QueryEntitiesAsync(
-                    new P.QueryEntitiesRequest
-                    {
-                        Query = new P.EntityQuery
-                        {
-                            InstanceIdStartsWith = startsWith,
-                            LastModifiedFrom = lastModifiedFrom?.ToTimestamp(),
-                            LastModifiedTo = lastModifiedTo?.ToTimestamp(),
-                            IncludeState = includeState,
-                            PageSize = pageSize,
-                            ContinuationToken = continuation ?? filter?.ContinuationToken,
-                        },
-                    },
-                    cancellationToken: cancellation);
-
-                IReadOnlyList<EntityMetadata> values = response.Entities
-                    .Select(x => this.ToEntityMetadata(x, includeState))
-                    .ToList();
-
-                return new Page<EntityMetadata>(values, response.ContinuationToken);
-            }
-            catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
-            {
-                throw new OperationCanceledException(
-                    $"The {nameof(this.GetAllEntitiesAsync)} operation was canceled.", e, cancellation);
-            }
-        });
-    }
+        => this.GetAllEntitiesCoreAsync(filter, (x, s) => this.ToEntityMetadata(x, s));
 
     /// <inheritdoc/>
-    public override async Task<CleanEntityStorageResult> CleanEntityStorageAsync(CleanEntityStorageRequest request = default, bool continueUntilComplete = true, CancellationToken cancellation = default)
+    public override AsyncPageable<EntityMetadata<TState>> GetAllEntitiesAsync<TState>(EntityQuery? filter = null)
+        => this.GetAllEntitiesCoreAsync(filter, (x, s) => this.ToEntityMetadata<TState>(x, s));
+
+    /// <inheritdoc/>
+    public override async Task<CleanEntityStorageResult> CleanEntityStorageAsync(
+        CleanEntityStorageRequest request = default,
+        bool continueUntilComplete = true,
+        CancellationToken cancellation = default)
     {
         string? continuationToken = request.ContinuationToken;
         int emptyEntitiesRemoved = 0;
@@ -170,17 +133,101 @@ class GrpcDurableEntityClient : DurableEntityClient
                 $"The {nameof(this.CleanEntityStorageAsync)} operation was canceled.", e, cancellation);
         }
     }
+    
+    async Task<TMetadata?> GetEntityCoreAsync<TMetadata>(
+        EntityInstanceId id,
+        bool includeState,
+        Func<P.EntityMetadata, bool, TMetadata> select,
+        CancellationToken cancellation)
+        where TMetadata : class
+    {
+        P.GetEntityRequest request = new()
+        {
+            InstanceId = id.ToString(),
+            IncludeState = includeState,
+        };
+
+        try
+        {
+            P.GetEntityResponse response = await this.sidecarClient
+                .GetEntityAsync(request, cancellationToken: cancellation);
+
+            return response.Exists ? select(response.Entity, includeState) : null;
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException(
+                $"The {nameof(this.GetEntityAsync)} operation was canceled.", e, cancellation);
+        }
+    }
+
+    AsyncPageable<TMetadata> GetAllEntitiesCoreAsync<TMetadata>(
+        EntityQuery? filter, Func<P.EntityMetadata, bool, TMetadata> select)
+        where TMetadata : class
+    {
+        bool includeState = filter?.IncludeState ?? false;
+        string startsWith = filter?.InstanceIdStartsWith ?? string.Empty;
+        DateTimeOffset? lastModifiedFrom = filter?.LastModifiedFrom;
+        DateTimeOffset? lastModifiedTo = filter?.LastModifiedTo;
+
+        return Pageable.Create(async (continuation, pageSize, cancellation) =>
+        {
+            pageSize ??= filter?.PageSize;
+
+            try
+            {
+                P.QueryEntitiesResponse response = await this.sidecarClient.QueryEntitiesAsync(
+                    new P.QueryEntitiesRequest
+                    {
+                        Query = new P.EntityQuery
+                        {
+                            InstanceIdStartsWith = startsWith,
+                            LastModifiedFrom = lastModifiedFrom?.ToTimestamp(),
+                            LastModifiedTo = lastModifiedTo?.ToTimestamp(),
+                            IncludeState = includeState,
+                            PageSize = pageSize,
+                            ContinuationToken = continuation ?? filter?.ContinuationToken,
+                        },
+                    },
+                    cancellationToken: cancellation);
+
+                IReadOnlyList<TMetadata> values = response.Entities
+                    .Select(x => select(x, includeState))
+                    .ToList();
+
+                return new Page<TMetadata>(values, response.ContinuationToken);
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+            {
+                throw new OperationCanceledException(
+                    $"The {nameof(this.GetAllEntitiesAsync)} operation was canceled.", e, cancellation);
+            }
+        });
+    }
 
     EntityMetadata ToEntityMetadata(P.EntityMetadata metadata, bool includeState)
     {
         var coreEntityId = DTCore.Entities.EntityId.FromString(metadata.InstanceId);
         EntityInstanceId entityId = new(coreEntityId.Name, coreEntityId.Key);
 
-        return new EntityMetadata(entityId)
+        SerializedData? data = includeState ? new(metadata.SerializedState, this.dataConverter) : null;
+        return new EntityMetadata(entityId, data)
         {
-            DataConverter = includeState ? this.dataConverter : null,
             LastModifiedTime = metadata.LastModifiedTime.ToDateTimeOffset(),
-            SerializedState = includeState ? metadata.SerializedState : null,
         };
+    }
+
+    EntityMetadata<T> ToEntityMetadata<T>(P.EntityMetadata metadata, bool includeState)
+    {
+        var coreEntityId = DTCore.Entities.EntityId.FromString(metadata.InstanceId);
+        EntityInstanceId entityId = new(coreEntityId.Name, coreEntityId.Key);
+
+        T? data = includeState ? this.dataConverter.Deserialize<T>(metadata.SerializedState) : default;
+        DateTimeOffset lastModified = metadata.LastModifiedTime.ToDateTimeOffset();
+
+        // Use separate constructors to ensure default structs get correct state inclusion value.
+        return includeState
+            ? new EntityMetadata<T>(entityId, data) { LastModifiedTime = lastModified }
+            : new EntityMetadata<T>(entityId) { LastModifiedTime = lastModified };
     }
 }


### PR DESCRIPTION
This PR changes to following:

1. `includeState` is `true` by default for all get entity methods (including get all)
2. Added `EntityMetadata<TState>`, which has a strongly typed deserialized `TState State` property.
3. Extracted un-typed state into `SerializedData`, which has a `ReadAs<T>()` method.
4. `EntityMetadata` now implements `EntityMetadata<SerializedData>`
5. `EntityMetadata<TState>` now has a `bool IncludesState` which indicates if state was retrieved or not.
6. `EntityMetadata<TState>.State` now throws if `IncludeState==false`
7. Added `GetEntityAsync<T>` and `GetAllEntitiesAsync<T>` overloads to get `EntityMetadata<T>`