### PR TITLE
Fix ADO build when binlog=false

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -22,6 +22,9 @@ variables:
   ${{ if parameters.binlog }}:
     build_binlog: -bl:$(log_dir)/build.binlog
     pack_binlog: -bl:$(log_dir)/pack.binlog
+  ${{ else }}:
+    build_binlog: ''
+    pack_binlog: ''
 
 steps:
 - checkout: self


### PR DESCRIPTION
Ensures `$(build_binlog)` and `$(pkg_binlog)` are set to empty string when the build is enqueued with `binlog == false`. If we leave them unset then ADO does not replace them and places the raw value of "$(build_binlog)" when it is used, which fails the build due to unknown args.