### PR TITLE
Several fixes to entity implementation

### DIFF
--- a/src/Abstractions/Entities/EntityOperationFailedException.cs
+++ b/src/Abstractions/Entities/EntityOperationFailedException.cs
@@ -17,10 +17,9 @@ public sealed class EntityOperationFailedException : Exception
     /// </summary>
     /// <param name="operationName">The operation name.</param>
     /// <param name="entityId">The entity ID.</param>
-    /// <param name="errorContext">The context in which the error was caught.</param>
     /// <param name="failureDetails">The failure details.</param>
-    public EntityOperationFailedException(EntityInstanceId entityId, string operationName, string errorContext, TaskFailureDetails failureDetails)
-        : base(GetExceptionMessage(operationName, entityId, errorContext, failureDetails))
+    public EntityOperationFailedException(EntityInstanceId entityId, string operationName, TaskFailureDetails failureDetails)
+        : base(GetExceptionMessage(operationName, entityId, failureDetails))
     {
         this.EntityId = entityId;
         this.OperationName = operationName;
@@ -42,8 +41,8 @@ public sealed class EntityOperationFailedException : Exception
     /// </summary>
     public TaskFailureDetails FailureDetails { get; }
 
-    static string GetExceptionMessage(string operationName, EntityInstanceId entityId, string errorContext, TaskFailureDetails failureDetails)
+    static string GetExceptionMessage(string operationName, EntityInstanceId entityId, TaskFailureDetails failureDetails)
     {
-        return $"Operation '{operationName}' of entity '{entityId}' failed: {errorContext}: {failureDetails.ErrorMessage}";
+        return $"Operation '{operationName}' of entity '{entityId}' failed: {failureDetails.ErrorMessage}";
     }
 }

--- a/src/Abstractions/Entities/TaskEntity.cs
+++ b/src/Abstractions/Entities/TaskEntity.cs
@@ -124,7 +124,7 @@ public abstract class TaskEntity<TState> : ITaskEntity
         Check.NotNull(operation);
         this.Context = operation.Context;
         object? state = operation.State.GetState(typeof(TState));
-        this.State = state is null ? this.InitializeState() : (TState)state;
+        this.State = state is null ? this.InitializeState(operation) : (TState)state;
         if (!operation.TryDispatch(this, out object? result, out Type returnType)
             && !this.TryDispatchState(operation, out result, out returnType))
         {
@@ -143,9 +143,10 @@ public abstract class TaskEntity<TState> : ITaskEntity
     /// <summary>
     /// Initializes the entity state. This is only called when there is no current state for this entity.
     /// </summary>
+    /// <param name="entityOperation">The entity operation to be executed.</param>
     /// <returns>The entity state.</returns>
     /// <remarks>The default implementation uses <see cref="Activator.CreateInstance()"/>.</remarks>
-    protected virtual TState InitializeState()
+    protected virtual TState InitializeState(TaskEntityOperation entityOperation)
     {
         if (Nullable.GetUnderlyingType(typeof(TState)) is Type t)
         {

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -43,6 +43,8 @@ class GrpcDurableEntityClient : DurableEntityClient
         SignalEntityOptions? options = null,
         CancellationToken cancellation = default)
     {
+        Check.NotNullOrEmpty(id.Name);
+        Check.NotNull(id.Key);
         Guid requestId = Guid.NewGuid();
         DateTimeOffset? scheduledTime = options?.SignalTime;
 
@@ -135,6 +137,9 @@ class GrpcDurableEntityClient : DurableEntityClient
         CancellationToken cancellation)
         where TMetadata : class
     {
+        Check.NotNullOrEmpty(id.Name);
+        Check.NotNull(id.Key);
+
         P.GetEntityRequest request = new()
         {
             InstanceId = id.ToString(),

--- a/src/Worker/Core/Shims/TaskEntityShim.cs
+++ b/src/Worker/Core/Shims/TaskEntityShim.cs
@@ -195,6 +195,9 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
 
         public override void SignalEntity(EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null)
         {
+            Check.NotNullOrEmpty(id.Name);
+            Check.NotNull(id.Key);
+
             this.operationActions.Add(new SendSignalOperationAction()
             {
                 InstanceId = id.ToString(),

--- a/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
@@ -89,6 +89,9 @@ sealed partial class TaskOrchestrationContextWrapper
         /// <inheritdoc/>
         public override async Task<TResult> CallEntityAsync<TResult>(EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
         {
+            Check.NotNullOrEmpty(id.Name);
+            Check.NotNull(id.Key);
+
             OperationResult operationResult = await this.CallEntityInternalAsync(id, operationName, input);
 
             if (operationResult.IsError)
@@ -104,6 +107,9 @@ sealed partial class TaskOrchestrationContextWrapper
         /// <inheritdoc/>
         public override async Task CallEntityAsync(EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
         {
+            Check.NotNullOrEmpty(id.Name);
+            Check.NotNull(id.Key);
+
             OperationResult operationResult = await this.CallEntityInternalAsync(id, operationName, input);
 
             if (operationResult.IsError)
@@ -115,6 +121,9 @@ sealed partial class TaskOrchestrationContextWrapper
         /// <inheritdoc/>
         public override Task SignalEntityAsync(EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null)
         {
+            Check.NotNullOrEmpty(id.Name);
+            Check.NotNull(id.Key);
+
             this.SendOperationMessage(id.ToString(), operationName, input, oneWay: true, scheduledTime: options?.SignalTime);
             return Task.CompletedTask;
         }

--- a/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
@@ -91,9 +91,9 @@ sealed partial class TaskOrchestrationContextWrapper
         {
             OperationResult operationResult = await this.CallEntityInternalAsync(id, operationName, input);
 
-            if (operationResult.ErrorMessage != null)
+            if (operationResult.IsError)
             {
-                throw new EntityOperationFailedException(id, operationName, operationResult.ErrorMessage, ConvertFailureDetails(operationResult.FailureDetails!));
+                throw new EntityOperationFailedException(id, operationName, ConvertFailureDetails(operationResult.FailureDetails!));
             }
             else
             {
@@ -106,9 +106,9 @@ sealed partial class TaskOrchestrationContextWrapper
         {
             OperationResult operationResult = await this.CallEntityInternalAsync(id, operationName, input);
 
-            if (operationResult.ErrorMessage != null)
+            if (operationResult.IsError)
             {
-                throw new EntityOperationFailedException(id, operationName, operationResult.ErrorMessage, ConvertFailureDetails(operationResult.FailureDetails!));
+                throw new EntityOperationFailedException(id, operationName, ConvertFailureDetails(operationResult.FailureDetails!));
             }
         }
 

--- a/src/Worker/Grpc/GrpcOrchestrationRunner.cs
+++ b/src/Worker/Grpc/GrpcOrchestrationRunner.cs
@@ -113,7 +113,7 @@ public static class GrpcOrchestrationRunner
             ? DurableTaskShimFactory.Default
             : ActivatorUtilities.GetServiceOrCreateInstance<DurableTaskShimFactory>(services);
         TaskOrchestration shim = factory.CreateOrchestration(orchestratorName, implementation, parent);
-        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover);
+        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover, request.EntityParameters.ToCore());
         OrchestratorExecutionResult result = executor.Execute();
 
         P.OrchestratorResponse response = ProtoUtils.ConstructOrchestratorResponse(

--- a/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/StateTaskEntityTests.cs
@@ -176,7 +176,7 @@ public class StateTaskEntityTests
 
     class NullStateEntity : TestEntity
     {
-        protected override TestState InitializeState() => null!;
+        protected override TestState InitializeState(TaskEntityOperation entityOperation) => null!;
     }
 
     class TestEntity : TaskEntity<TestState>


### PR DESCRIPTION
Three fixes in this PR for issues that were discovered during testing:

- some of the design changes for OperationResult were not fully reflected (was still using errorContext/ ErrorMessage)
- did not have enough parameter checking for entity ids that are passed in
- the orchestration executor was not being passed the entity backend parameters

Also, one design changes per online discussion
- add a TaskEntityOperation parameter to the InitializeState call