### PR TITLE
Use ErrorPropgationMode.FailureDetails for orchestrators

### DIFF
--- a/src/Worker/Grpc/GrpcOrchestrationRunner.cs
+++ b/src/Worker/Grpc/GrpcOrchestrationRunner.cs
@@ -113,7 +113,7 @@ public static class GrpcOrchestrationRunner
             ? DurableTaskShimFactory.Default
             : ActivatorUtilities.GetServiceOrCreateInstance<DurableTaskShimFactory>(services);
         TaskOrchestration shim = factory.CreateOrchestration(orchestratorName, implementation, parent);
-        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover);
+        TaskOrchestrationExecutor executor = new(runtimeState, shim, BehaviorOnContinueAsNew.Carryover, ErrorPropagationMode.UseFailureDetails);
         OrchestratorExecutionResult result = executor.Execute();
 
         P.OrchestratorResponse response = ProtoUtils.ConstructOrchestratorResponse(


### PR DESCRIPTION
During testing for durable entities, discovered that orchestrators are using `ErrorPropagationMode.SerializeExceptions` which appears to not have been intended (all code was supposed to use `ErrorPropagationMode.FailureDetails`). This PR adds the missing parameter to the constructor call to choose the correct error propagation mode.

**Note**: Before merging this, there needs to be some discussion/investigation about whether this change is safe to make at this point since it will change the behavior of shipped code.