### PR TITLE
Revise queries

### DIFF
--- a/src/Abstractions/Entities/TaskEntityContext.cs
+++ b/src/Abstractions/Entities/TaskEntityContext.cs
@@ -40,8 +40,9 @@ public abstract class TaskEntityContext
     /// </summary>
     /// <param name="name">The name of the orchestration to start.</param>
     /// <param name="options">The options for starting the orchestration.</param>
-    public virtual void StartOrchestration(TaskName name, StartOrchestrationOptions options)
-        => this.StartOrchestration(name, null, options);
+    /// <returns>The instance id for the new orchestration.</returns>
+    public virtual string ScheduleNewOrchestration(TaskName name, StartOrchestrationOptions options)
+        => this.ScheduleNewOrchestration(name, null, options);
 
     /// <summary>
     /// Starts an orchestration.
@@ -49,6 +50,7 @@ public abstract class TaskEntityContext
     /// <param name="name">The name of the orchestration to start.</param>
     /// <param name="input">The input for the orchestration.</param>
     /// <param name="options">The options for starting the orchestration.</param>
-    public abstract void StartOrchestration(
+    /// <returns>The instance id for the new orchestration.</returns>
+    public abstract string ScheduleNewOrchestration(
         TaskName name, object? input = null, StartOrchestrationOptions? options = null);
 }

--- a/src/Client/Core/Entities/CleanEntityStorage.cs
+++ b/src/Client/Core/Entities/CleanEntityStorage.cs
@@ -6,18 +6,18 @@ namespace Microsoft.DurableTask.Client.Entities;
 /// <summary>
 /// Request struct for <see cref="DurableEntityClient.CleanEntityStorageAsync"/>.
 /// </summary>
-public readonly record struct CleanEntityStorageRequest
+public record CleanEntityStorageRequest
 {
     /// <summary>
-    /// Gets a value indicating whether to remove empty entities.
+    /// Gets a value indicating whether to remove empty entities. Defaults to true.
     /// </summary>
     /// <remarks>
     /// An entity is considered empty, and is removed, if it has no state, is not locked.
     /// </remarks>
-    public bool RemoveEmptyEntities { get; init; }
+    public bool RemoveEmptyEntities { get; init; } = true;
 
     /// <summary>
-    /// Gets a value indicating whether to release orphaned locks or not.
+    /// Gets a value indicating whether to release orphaned locks or not. Defaults to true.
     /// </summary>
     /// <remarks>
     /// Locks are considered orphaned, and are released, and if the orchestration that holds them is not in state
@@ -25,10 +25,10 @@ public readonly record struct CleanEntityStorageRequest
     /// occur if the orchestration instance holding the lock exhibits replay nondeterminism failures, or if it is
     /// explicitly purged.
     /// </remarks>
-    public bool ReleaseOrphanedLocks { get; init; }
+    public bool ReleaseOrphanedLocks { get; init; } = true;
 
     /// <summary>
-    /// Gets the continuation token to resume a previous <see cref="CleanEntityStorageRequest"/>.
+    /// Gets the continuation token to resume a previous <see cref="CleanEntityStorageRequest"/>. Defaults to null.
     /// </summary>
     public string? ContinuationToken { get; init; }
 }

--- a/src/Client/Core/Entities/CleanEntityStorage.cs
+++ b/src/Client/Core/Entities/CleanEntityStorage.cs
@@ -6,15 +6,26 @@ namespace Microsoft.DurableTask.Client.Entities;
 /// <summary>
 /// Request struct for <see cref="DurableEntityClient.CleanEntityStorageAsync"/>.
 /// </summary>
-public record CleanEntityStorageRequest
+public readonly record struct CleanEntityStorageRequest
 {
+    /// <summary>
+    /// Gets the default request parameters. The default is meant to represent
+    /// "maximal" cleaning that is safe to call at all times.
+    /// </summary>
+    public static CleanEntityStorageRequest Default => new()
+    {
+        RemoveEmptyEntities = true,
+        ReleaseOrphanedLocks = true,
+        ContinuationToken = null,
+    };
+
     /// <summary>
     /// Gets a value indicating whether to remove empty entities. Defaults to true.
     /// </summary>
     /// <remarks>
     /// An entity is considered empty, and is removed, if it has no state, is not locked.
     /// </remarks>
-    public bool RemoveEmptyEntities { get; init; } = true;
+    public bool RemoveEmptyEntities { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether to release orphaned locks or not. Defaults to true.
@@ -25,7 +36,7 @@ public record CleanEntityStorageRequest
     /// occur if the orchestration instance holding the lock exhibits replay nondeterminism failures, or if it is
     /// explicitly purged.
     /// </remarks>
-    public bool ReleaseOrphanedLocks { get; init; } = true;
+    public bool ReleaseOrphanedLocks { get; init; }
 
     /// <summary>
     /// Gets the continuation token to resume a previous <see cref="CleanEntityStorageRequest"/>. Defaults to null.

--- a/src/Client/Core/Entities/DurableEntityClient.cs
+++ b/src/Client/Core/Entities/DurableEntityClient.cs
@@ -138,7 +138,7 @@ public abstract class DurableEntityClient
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
     /// <returns>A task that completes when the operation is finished.</returns>
     public abstract Task<CleanEntityStorageResult> CleanEntityStorageAsync(
-        CleanEntityStorageRequest request,
+        CleanEntityStorageRequest? request = null,
         bool continueUntilComplete = true,
         CancellationToken cancellation = default);
 }

--- a/src/Client/Core/Entities/DurableEntityClient.cs
+++ b/src/Client/Core/Entities/DurableEntityClient.cs
@@ -138,7 +138,7 @@ public abstract class DurableEntityClient
     /// <param name="cancellation">The cancellation token to cancel the operation.</param>
     /// <returns>A task that completes when the operation is finished.</returns>
     public abstract Task<CleanEntityStorageResult> CleanEntityStorageAsync(
-        CleanEntityStorageRequest request = default,
+        CleanEntityStorageRequest request,
         bool continueUntilComplete = true,
         CancellationToken cancellation = default);
 }

--- a/src/Client/Core/Entities/EntityMetadata.cs
+++ b/src/Client/Core/Entities/EntityMetadata.cs
@@ -47,6 +47,16 @@ public class EntityMetadata<TState>
     public DateTimeOffset LastModifiedTime { get; init; }
 
     /// <summary>
+    /// Gets the size of the backlog queue, if there is a backlog, and if that metric is supported by the backend.
+    /// </summary>
+    public int BacklogQueueSize { get; init; }
+
+    /// <summary>
+    /// Gets the instance id of the orchestration that has locked this entity, or null if the entity is not locked.
+    /// </summary>
+    public string? LockedBy { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether this metadata response includes the entity state.
     /// </summary>
     /// <remarks>

--- a/src/Client/Core/Entities/EntityQuery.cs
+++ b/src/Client/Core/Entities/EntityQuery.cs
@@ -61,15 +61,18 @@ public record EntityQuery
     public bool IncludeState { get; init; } = true;
 
     /// <summary>
-    /// Gets the size of each page to return.
+    /// Gets a value indicating whether to include metadata about entities that have no user-defined state. Defaults to false.
     /// </summary>
-    public int PageSize { get; init; } = DefaultPageSize;
     /// <remarks> Stateless entities occur when the storage provider is tracking metadata about an entity for synchronization purposes
     /// even though the entity does not "logically" exist, in the sense that it has no application-defined state.
     /// Stateless entities are usually transient. For example, they may be in the process of being created or deleted, or they may have been locked by a critical section.
     /// </remarks>
     public bool IncludeStateless { get; init; }
 
+    /// <summary>
+    /// Gets the size of each page to return. If null, the page size is determined by the backend.
+    /// </summary>
+    public int? PageSize { get; init; }
 
     /// <summary>
     /// Gets the continuation token to resume a previous query.

--- a/src/Client/Core/Entities/EntityQuery.cs
+++ b/src/Client/Core/Entities/EntityQuery.cs
@@ -64,6 +64,12 @@ public record EntityQuery
     /// Gets the size of each page to return.
     /// </summary>
     public int PageSize { get; init; } = DefaultPageSize;
+    /// <remarks> Stateless entities occur when the storage provider is tracking metadata about an entity for synchronization purposes
+    /// even though the entity does not "logically" exist, in the sense that it has no application-defined state.
+    /// Stateless entities are usually transient. For example, they may be in the process of being created or deleted, or they may have been locked by a critical section.
+    /// </remarks>
+    public bool IncludeStateless { get; init; }
+
 
     /// <summary>
     /// Gets the continuation token to resume a previous query.

--- a/src/Client/Core/Entities/EntityQuery.cs
+++ b/src/Client/Core/Entities/EntityQuery.cs
@@ -61,13 +61,15 @@ public record EntityQuery
     public bool IncludeState { get; init; } = true;
 
     /// <summary>
-    /// Gets a value indicating whether to include metadata about entities that have no user-defined state. Defaults to false.
+    /// Gets a value indicating whether to include metadata about transient entities. Defaults to false.
     /// </summary>
-    /// <remarks> Stateless entities occur when the storage provider is tracking metadata about an entity for synchronization purposes
-    /// even though the entity does not "logically" exist, in the sense that it has no application-defined state.
-    /// Stateless entities are usually transient. For example, they may be in the process of being created or deleted, or they may have been locked by a critical section.
+    /// <remarks> Transient entities are entities that do not have an application-defined state, but for which the storage provider is
+    /// tracking metadata for synchronization purposes.
+    /// For example, a transient entity may be observed when the entity is in the process of being created or deleted, or
+    /// when the entity has been locked by a critical section. By default, transient entities are not included in queries since they are
+    /// considered to "not exist" from the perspective of the user application.
     /// </remarks>
-    public bool IncludeStateless { get; init; }
+    public bool IncludeTransient { get; init; }
 
     /// <summary>
     /// Gets the size of each page to return. If null, the page size is determined by the backend.

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -166,7 +166,7 @@ class GrpcDurableEntityClient : DurableEntityClient
         where TMetadata : class
     {
         bool includeState = filter?.IncludeState ?? true;
-        bool includeStateless = filter?.IncludeStateless ?? false;
+        bool includeTransient = filter?.IncludeTransient ?? false;
         string startsWith = filter?.InstanceIdStartsWith ?? string.Empty;
         DateTimeOffset? lastModifiedFrom = filter?.LastModifiedFrom;
         DateTimeOffset? lastModifiedTo = filter?.LastModifiedTo;
@@ -186,7 +186,7 @@ class GrpcDurableEntityClient : DurableEntityClient
                             LastModifiedFrom = lastModifiedFrom?.ToTimestamp(),
                             LastModifiedTo = lastModifiedTo?.ToTimestamp(),
                             IncludeState = includeState,
-                            IncludeStateless = includeStateless,
+                            IncludeTransient = includeTransient,
                             PageSize = pageSize,
                             ContinuationToken = continuation ?? filter?.ContinuationToken,
                         },

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -89,10 +89,11 @@ class GrpcDurableEntityClient : DurableEntityClient
 
     /// <inheritdoc/>
     public override async Task<CleanEntityStorageResult> CleanEntityStorageAsync(
-        CleanEntityStorageRequest request = default,
+        CleanEntityStorageRequest request,
         bool continueUntilComplete = true,
         CancellationToken cancellation = default)
     {
+        request ??= new CleanEntityStorageRequest(); // establishes default values to use
         string? continuationToken = request.ContinuationToken;
         int emptyEntitiesRemoved = 0;
         int orphanedLocksReleased = 0;

--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -89,12 +89,12 @@ class GrpcDurableEntityClient : DurableEntityClient
 
     /// <inheritdoc/>
     public override async Task<CleanEntityStorageResult> CleanEntityStorageAsync(
-        CleanEntityStorageRequest request,
+        CleanEntityStorageRequest? request = null,
         bool continueUntilComplete = true,
         CancellationToken cancellation = default)
     {
-        request ??= new CleanEntityStorageRequest(); // establishes default values to use
-        string? continuationToken = request.ContinuationToken;
+        CleanEntityStorageRequest req = request ?? CleanEntityStorageRequest.Default;
+        string? continuationToken = req.ContinuationToken;
         int emptyEntitiesRemoved = 0;
         int orphanedLocksReleased = 0;
 
@@ -105,8 +105,8 @@ class GrpcDurableEntityClient : DurableEntityClient
                 P.CleanEntityStorageResponse response = await this.sidecarClient.CleanEntityStorageAsync(
                     new P.CleanEntityStorageRequest
                     {
-                        RemoveEmptyEntities = request.RemoveEmptyEntities,
-                        ReleaseOrphanedLocks = request.ReleaseOrphanedLocks,
+                        RemoveEmptyEntities = req.RemoveEmptyEntities,
+                        ReleaseOrphanedLocks = req.ReleaseOrphanedLocks,
                         ContinuationToken = continuationToken,
                     },
                     cancellationToken: cancellation);

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -529,6 +529,7 @@ static class ProtoUtils
                     Input = operationAction.StartNewOrchestration.Input,
                     InstanceId = operationAction.StartNewOrchestration.InstanceId,
                     Version = operationAction.StartNewOrchestration.Version,
+                    ScheduledStartTime = operationAction.StartNewOrchestration.ScheduledTime?.ToDateTime(),
                 };
             default:
                 throw new NotSupportedException($"Deserialization of {operationAction.OperationActionTypeCase} is not supported.");
@@ -571,6 +572,7 @@ static class ProtoUtils
                     Input = startNewOrchestrationAction.Input,
                     Version = startNewOrchestrationAction.Version,
                     InstanceId = startNewOrchestrationAction.InstanceId,
+                    ScheduledTime = startNewOrchestrationAction.ScheduledStartTime?.ToTimestamp(),
                 };
                 break;
         }

--- a/src/Worker/Core/Shims/TaskEntityShim.cs
+++ b/src/Worker/Core/Shims/TaskEntityShim.cs
@@ -207,15 +207,18 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
             });
         }
 
-        public override void StartOrchestration(TaskName name, object? input = null, StartOrchestrationOptions? options = null)
+        public override string ScheduleNewOrchestration(TaskName name, object? input = null, StartOrchestrationOptions? options = null)
         {
+            string instanceId = options?.InstanceId ?? Guid.NewGuid().ToString("N");
             this.operationActions.Add(new StartNewOrchestrationOperationAction()
             {
                 Name = name.Name,
                 Version = name.Version,
-                InstanceId = Guid.NewGuid().ToString("N"),
+                InstanceId = instanceId,
                 Input = this.dataConverter.Serialize(input),
+                ScheduledStartTime = options?.StartAt?.UtcDateTime,
             });
+            return instanceId;
         }
     }
 


### PR DESCRIPTION
Several changes (they are separated by commits):

- rename StartOrchestration to ScheduleNewOrchestration
- specify different defaults for clean entity storage (should clean everything by default)
- support queries to (optionally) return stateless entities, and add more metadata to the returned entity metadata
- make the page size a nullable int and keep it null if not specified (allows backend to choose an appropriate page size instead of using an arbitrary default)