### PR TITLE
Skip log artifact if binlog disabled

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -134,5 +134,6 @@ steps:
   artifact: pkg
 
 - publish: $(log_dir)
+  condition: eq('${{ parameters.binlog }}', true)
   displayName: 'Publish logs to Artifacts'
   artifact: log

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
@@ -33,7 +33,6 @@ sealed partial class TaskOrchestrationContextWrapper
         /// <inheritdoc/>
         public Type EventType => typeof(T);
 
-
         /// <inheritdoc/>
         void IEventSource.TrySetResult(object result) => this.TrySetResult((T)result);
     }


### PR DESCRIPTION
Adds a condition to ADO step to only run it if MSBuild binlog is enabled.