### PR TITLE
Add nuget.config to ADO yml

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -43,6 +43,8 @@ steps:
     command: restore
     verbosityRestore: Minimal
     projects: $(project)
+    selectOrConfig: config
+    nugetConfigPath: 'nuget.config'
 
 # Build source directory
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
We are now depending on some packages from other ADO feeds as we stage our releases. This change unblocks the release build for those packages.