### PR TITLE
Add HasState and default value to GetState<T>

### DIFF
--- a/samples/AzureFunctionsApp/Entities/counters.http
+++ b/samples/AzureFunctionsApp/Entities/counters.http
@@ -6,6 +6,7 @@
 // mode=0 or mode=entity (default) - dispatch to "counter" entity
 // mode=1 or mode=state - dispatch to "counter_state" entity
 // mode=2 or mode=static - dispatch to "counter_alt" entity
+// mode=3 or mode=manual - dispatch to "counter_manual" entity
 //
 // "counter" and "counter_alt" are the same entities, however they use
 // two different functions to dispatch, and thus are different entities when

--- a/src/Abstractions/Entities/TaskEntityState.cs
+++ b/src/Abstractions/Entities/TaskEntityState.cs
@@ -9,12 +9,31 @@ namespace Microsoft.DurableTask.Entities;
 public abstract class TaskEntityState
 {
     /// <summary>
+    /// Gets a value indicating whether this entity has state or not yet.
+    /// </summary>
+    public abstract bool HasState { get; }
+
+    /// <summary>
     /// Gets the current state of the entity. This will return <c>null</c> if no state is present, regardless if
     /// <typeparamref name="T"/> is a value-type or not.
     /// </summary>
     /// <typeparam name="T">The type to retrieve.</typeparam>
+    /// <param name="defaultValue">The default value to return if no state is present.</param>
     /// <returns>The entity state.</returns>
-    public virtual T? GetState<T>() => (T?)this.GetState(typeof(T));
+    /// <remarks>
+    /// If no state is present, then <paramref see="defaultValue"/> will be returned but it will <b>not</b> be persisted
+    /// to <see cref="SetState"/>. This must be manually called.
+    /// </remarks>
+    public virtual T? GetState<T>(T? defaultValue = default)
+    {
+        object? state = this.GetState(typeof(T));
+        if (state is T typedState)
+        {
+            return typedState;
+        }
+
+        return defaultValue;
+    }
 
     /// <summary>
     /// Gets the current state of the entity. This will return <c>null</c> if no state is present, regardless if

--- a/src/Abstractions/Entities/TaskEntityState.cs
+++ b/src/Abstractions/Entities/TaskEntityState.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DurableTask.Entities;
 public abstract class TaskEntityState
 {
     /// <summary>
-    /// Gets a value indicating whether this entity has state or not yet.
+    /// Gets a value indicating whether this entity has state or not yet / anymore.
     /// </summary>
     public abstract bool HasState { get; }
 

--- a/test/Abstractions.Tests/Entities/Mocks/TestEntityState.cs
+++ b/test/Abstractions.Tests/Entities/Mocks/TestEntityState.cs
@@ -10,6 +10,8 @@ public class TestEntityState : TaskEntityState
         this.State = state;
     }
 
+    public override bool HasState => this.State != null;
+
     public object? State { get; private set; }
 
     public override object? GetState(Type type)


### PR DESCRIPTION
This PR does the following:

1. Adds another sample on how to implement the `Counter` entity.
2. Adds `bool HasState` to `TaskEntityState`, so there is a quick way to know if an entity has any serialized state or not.
3. Adds a `T? defaultValue` to `.GetState<T>` to make the new entity scenario easier (won't have any state).
4. Reworks `TaskEntityShim.StateShim` a bit to be more robust with multiple state fetches, particularly when/if they change type.