### PR TITLE
Add write-only serializer for EntityMetadata

### DIFF
--- a/src/Client/Core/Entities/EntityMetadata.cs
+++ b/src/Client/Core/Entities/EntityMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Microsoft.DurableTask.Entities;
 
 namespace Microsoft.DurableTask.Client.Entities;
@@ -10,6 +11,7 @@ namespace Microsoft.DurableTask.Client.Entities;
 /// Represents entity metadata.
 /// </summary>
 /// <typeparam name="TState">The type of state held by the metadata.</typeparam>
+[JsonConverter(typeof(EntityMetadataConverter))]
 public class EntityMetadata<TState>
 {
     readonly TState? state;
@@ -94,6 +96,7 @@ public class EntityMetadata<TState>
 /// <summary>
 /// Represents the metadata for a durable entity instance.
 /// </summary>
+[JsonConverter(typeof(EntityMetadataConverter))]
 public sealed class EntityMetadata : EntityMetadata<SerializedData>
 {
     /// <summary>

--- a/src/Client/Core/Entities/EntityMetadataConverter.cs
+++ b/src/Client/Core/Entities/EntityMetadataConverter.cs
@@ -49,34 +49,6 @@ class EntityMetadataConverter : JsonConverterFactory
             culture: null)!;
     }
 
-    class Converter<TState> : JsonConverter<EntityMetadata<TState>>
-    {
-        public override EntityMetadata<TState>? Read(
-            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            throw new NotSupportedException("EntityMetadata cannot be deserialized");
-        }
-
-        public override void Write(Utf8JsonWriter writer, EntityMetadata<TState> value, JsonSerializerOptions options)
-        {
-            EntityMetadataConverter.Write(writer, value, options);
-        }
-    }
-    
-    class Converter : JsonConverter<EntityMetadata>
-    {
-        public override EntityMetadata? Read(
-            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            throw new NotSupportedException("EntityMetadata cannot be deserialized");
-        }
-
-        public override void Write(Utf8JsonWriter writer, EntityMetadata value, JsonSerializerOptions options)
-        {
-            EntityMetadataConverter.Write(writer, value, options);
-        }
-    }
-
     static void Write<TState>(Utf8JsonWriter writer, EntityMetadata<TState> value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
@@ -113,5 +85,33 @@ class EntityMetadataConverter : JsonConverterFactory
         }
 
         writer.WriteEndObject();
+    }
+
+    class Converter<TState> : JsonConverter<EntityMetadata<TState>>
+    {
+        public override EntityMetadata<TState>? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("EntityMetadata cannot be deserialized");
+        }
+
+        public override void Write(Utf8JsonWriter writer, EntityMetadata<TState> value, JsonSerializerOptions options)
+        {
+            EntityMetadataConverter.Write(writer, value, options);
+        }
+    }
+
+    class Converter : JsonConverter<EntityMetadata>
+    {
+        public override EntityMetadata? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("EntityMetadata cannot be deserialized");
+        }
+
+        public override void Write(Utf8JsonWriter writer, EntityMetadata value, JsonSerializerOptions options)
+        {
+            EntityMetadataConverter.Write(writer, value, options);
+        }
     }
 }

--- a/src/Client/Core/Entities/EntityMetadataConverter.cs
+++ b/src/Client/Core/Entities/EntityMetadataConverter.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DurableTask.Client.Entities;
+
+/// <summary>
+/// Json converter factory for <see cref="EntityMetadata{TState}"/> .
+/// </summary>
+class EntityMetadataConverter : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (typeToConvert.IsGenericType)
+        {
+            Type genericType = typeToConvert.GetGenericTypeDefinition();
+            if (genericType == typeof(EntityMetadata<>))
+            {
+                return true;
+            }
+        }
+
+        if (typeToConvert == typeof(EntityMetadata))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (typeToConvert == typeof(EntityMetadata))
+        {
+            return new Converter();
+        }
+
+        Type stateType = typeToConvert.GetGenericArguments()[0];
+        return (JsonConverter)Activator.CreateInstance(
+            typeof(Converter<>).MakeGenericType(stateType),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            args: null,
+            culture: null)!;
+    }
+
+    class Converter<TState> : JsonConverter<EntityMetadata<TState>>
+    {
+        public override EntityMetadata<TState>? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("EntityMetadata cannot be deserialized");
+        }
+
+        public override void Write(Utf8JsonWriter writer, EntityMetadata<TState> value, JsonSerializerOptions options)
+        {
+            EntityMetadataConverter.Write(writer, value, options);
+        }
+    }
+    
+    class Converter : JsonConverter<EntityMetadata>
+    {
+        public override EntityMetadata? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("EntityMetadata cannot be deserialized");
+        }
+
+        public override void Write(Utf8JsonWriter writer, EntityMetadata value, JsonSerializerOptions options)
+        {
+            EntityMetadataConverter.Write(writer, value, options);
+        }
+    }
+
+    static void Write<TState>(Utf8JsonWriter writer, EntityMetadata<TState> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        static string ConvertName(string name, JsonSerializerOptions options)
+        {
+            return options.PropertyNamingPolicy?.ConvertName(name) ?? name;
+        }
+
+        writer.WriteString(ConvertName(nameof(value.Id), options), value.Id.ToString());
+        writer.WriteString(ConvertName(nameof(value.LastModifiedTime), options), value.LastModifiedTime);
+
+        if (value.BacklogQueueSize > 0)
+        {
+            writer.WriteNumber(ConvertName(nameof(value.BacklogQueueSize), options), value.BacklogQueueSize);
+        }
+
+        if (value.LockedBy is string s)
+        {
+            writer.WriteString(ConvertName(nameof(value.LockedBy), options), value.LockedBy);
+        }
+
+        if (value.IncludesState)
+        {
+            if (value is EntityMetadata<SerializedData> serializedData)
+            {
+                writer.WriteString(ConvertName(nameof(value.State), options), serializedData.State.Value);
+            }
+            else
+            {
+                writer.WritePropertyName(ConvertName(nameof(value.State), options));
+                JsonSerializer.Serialize(writer, value.State, options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Client/Core/SerializedData.cs
+++ b/src/Client/Core/SerializedData.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.DurableTask.Converters;
+
 namespace Microsoft.DurableTask.Client;
 
 /// <summary>
@@ -13,10 +15,10 @@ public sealed class SerializedData
     /// </summary>
     /// <param name="data">The serialized data.</param>
     /// <param name="converter">The data converter.</param>
-    public SerializedData(string data, DataConverter converter)
+    public SerializedData(string data, DataConverter? converter = null)
     {
         this.Value = Check.NotNull(data);
-        this.Converter = Check.NotNull(converter);
+        this.Converter = converter ?? JsonDataConverter.Default;
     }
 
     /// <summary>
@@ -35,4 +37,16 @@ public sealed class SerializedData
     /// <typeparam name="T">The type to deserialize into.</typeparam>
     /// <returns>The deserialized type.</returns>
     public T ReadAs<T>() => this.Converter.Deserialize<T>(this.Value);
+
+    /// <summary>
+    /// Creates a new instance of <see cref="SerializedData"/> from the specified data.
+    /// </summary>
+    /// <param name="data">The data to serialize.</param>
+    /// <param name="converter">The data converter.</param>
+    /// <returns>Serialized data.</returns>
+    internal static SerializedData Create(object data, DataConverter? converter = null)
+    {
+        converter ??= JsonDataConverter.Default;
+        return new SerializedData(converter.Serialize(data), converter);
+    }
 }

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.DurableTask.Client.Entities.Tests;
+
+public class EntityMetadataTests
+{
+    readonly EntityInstanceId id = new("test", Random.Shared.Next(0, 100).ToString());
+
+    [Fact]
+    public void GetState_NotIncluded_Throws()
+    {
+        EntityMetadata<int> metadata = new(this.id);
+        Func<int> act = () => metadata.State;
+        act.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetState_Included_DoesNotThrow()
+    {
+        int state = Random.Shared.Next(0, 100);
+        EntityMetadata<int> metadata = new(this.id, state);
+        metadata.State.Should().Be(state);
+    }
+
+    [Fact]
+    public void Serialize_StateNotIncluded()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        string lockedBy = Guid.NewGuid().ToString("N");
+        EntityMetadata<int> metadata = new(this.id)
+        {
+            LastModifiedTime = now,
+            BacklogQueueSize = 10,
+            LockedBy = lockedBy,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+            + $":\"{lockedBy}\"}}");
+    }
+
+    [Fact]
+    public void Serialize_StateIncluded_Int()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        string lockedBy = Guid.NewGuid().ToString("N");
+        int state = Random.Shared.Next(0, 100);
+        EntityMetadata<int> metadata = new(this.id, state)
+        {
+            LastModifiedTime = now,
+            BacklogQueueSize = 10,
+            LockedBy = lockedBy,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+            + $":\"{lockedBy}\",\"State\":{state}}}");
+    }
+
+    [Fact]
+    public void Serialize_StateIncluded_Object()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        string lockedBy = Guid.NewGuid().ToString("N");
+        State state = State.GetRandom();
+        EntityMetadata<State> metadata = new(this.id, state)
+        {
+            LastModifiedTime = now,
+            BacklogQueueSize = 10,
+            LockedBy = lockedBy,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+            + $":\"{lockedBy}\",\"State\":{{\"Number\":{state.Number}}}}}");
+    }
+    
+    [Fact]
+    public void Serialize_StateIncluded_Object2()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        State state = State.GetRandom();
+        EntityMetadata<State> metadata = new(this.id, state)
+        {
+            LastModifiedTime = now,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"State\":"
+            + $"{{\"Number\":{state.Number}}}}}");
+    }
+
+    [Fact]
+    public void Serialize_StateNotIncluded_NonGeneric()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        State state = State.GetRandom();
+        EntityMetadata metadata = new(this.id)
+        {
+            LastModifiedTime = now,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\"}}");
+    }
+
+
+    [Fact]
+    public void Serialize_StateIncluded_NonGeneric()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        State state = State.GetRandom();
+        EntityMetadata metadata = new(this.id, SerializedData.Create(state))
+        {
+            LastModifiedTime = now,
+        };
+
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":""{now:O}"",""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
+    }
+
+    record class State(int Number)
+    {
+        public static State GetRandom() => new(Random.Shared.Next(0, 100));
+    }
+}


### PR DESCRIPTION
Adds a custom write-only System.Text.Json  `JsonConverter` for `EntityMetadata<TState>` to allow for serializing this type in responses. This is write-only at the time as we do not see value in reading this type, especially since the `EntityMetadata` derived type needs the `DataConverter` supplied to it. Supporting write has value as without a custom converter, accessing `.State` could throw depending on the value of `IncludesState`.