### PR TITLE
Rev durabletask-dotnet pkg to 1.1.0-preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.1.0-preview.2
+
+- Microsoft.Azure.DurableTask.Core dependency increased to `2.16.0-preview.2`
+
 ## v1.1.0-preview.1
 
 Adds support for durable entities. Learn more [here](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-entities?tabs=csharp).

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Abstractions/RELEASENOTES.md
+++ b/src/Abstractions/RELEASENOTES.md
@@ -1,2 +1,2 @@
 - Add support for durable entities
-- Microsoft.Azure.DurableTask.Core dependency increased to `2.16.0-preview.1`
+- Microsoft.Azure.DurableTask.Core dependency increased to `2.16.0-preview.2`


### PR DESCRIPTION
Follow up to: https://github.com/microsoft/durabletask-dotnet/pull/226/files
Rev'ing version to 1.1.0-preview.2 so that we can make a release referencing DTFx.Core 2.16.0-preview.2