### PR TITLE
Unwrap original exception when dispatching entity

### DIFF
--- a/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
+++ b/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
@@ -81,7 +81,7 @@ public static class TaskEntityOperationExtensions
             returnType = method.ReturnType;
             return true;
         }
-        catch (TargetInvocationException ex)
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
             // Re-throw the inner exception so that the stack trace is preserved.
             ExceptionDispatchInfo.Capture(ex.InnerException).Throw();

--- a/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
+++ b/src/Abstractions/Entities/TaskEntityOperationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace Microsoft.DurableTask.Entities;
 
@@ -74,9 +75,18 @@ public static class TaskEntityOperationExtensions
             i++;
         }
 
-        result = method.Invoke(target, inputs);
-        returnType = method.ReturnType;
-        return true;
+        try
+        {
+            result = method.Invoke(target, inputs);
+            returnType = method.ReturnType;
+            return true;
+        }
+        catch (TargetInvocationException ex)
+        {
+            // Re-throw the inner exception so that the stack trace is preserved.
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // Unreachable.
+        }
 
         static void ThrowIfDuplicateBinding(
             ParameterInfo? existing, ParameterInfo parameter, string bindingConcept, TaskEntityOperation operation)

--- a/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
+++ b/test/Abstractions.Tests/Entities/EntityTaskEntityTests.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using DotNext;
-using FluentAssertions.Specialized;
 
 namespace Microsoft.DurableTask.Entities.Tests;
 
@@ -163,7 +162,7 @@ public class EntityTaskEntityTests
 
         Func<Task> act = async () => await entity.RunAsync(operation);
 
-        ExceptionAssertions<InvalidOperationException> ex = await act.Should()
+        await act.Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage(error)
             .Where(x => x.StackTrace!.StartsWith("   at Microsoft.DurableTask.Entities.Tests.EntityTaskEntityTests.TestEntity.Throws(String message)"));


### PR DESCRIPTION
Unwrap and rethrow the original exception from a failed entity operation.