### PR TITLE
Preserve trailing zeroes in entity tests

### DIFF
--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -57,8 +57,9 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata, settings);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\"}}");
     }
 
@@ -75,8 +76,9 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata,settings);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{state}}}");
     }
 
@@ -93,8 +95,9 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata, settings);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{{\"Number\":{state.Number}}}}}");
     }
     
@@ -108,8 +111,9 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata, settings);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"State\":"
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"State\":"
             + $"{{\"Number\":{state.Number}}}}}");
     }
 
@@ -123,8 +127,9 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata, settings);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\"}}");
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\"}}");
     }
 
 
@@ -138,8 +143,9 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata, settings);
-        json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":""{now:O}"",""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
+        string nowStr = JsonSerializer.Serialize(now);
+        string json = JsonSerializer.Serialize(metadata);
+        json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":""{nowStr}"",""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
     }
 
     record class State(int Number)

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DurableTask.Entities;
 
 namespace Microsoft.DurableTask.Client.Entities.Tests;

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -9,10 +9,18 @@ namespace Microsoft.DurableTask.Client.Entities.Tests;
 public class EntityMetadataTests
 {
     readonly EntityInstanceId id = new("test", Random.Shared.Next(0, 100).ToString());
-    readonly IsoDateTimeConverter dateConverter = new IsoDateTimeConverter
+
+    // create customize convert class
+    public class DateTimeConverter : JsonConverter<DateTime>
     {
-        DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffzzz"
-    };
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffzzz"));
+        }
+    }
+
+    JsonSerializerOptions defaultSettings = new JsonSerializerOptions();
+    defaultSettings.Converters.Add(new DateTimeConverter());
 
     [Fact]
     public void GetState_NotIncluded_Throws()

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -9,6 +9,10 @@ namespace Microsoft.DurableTask.Client.Entities.Tests;
 public class EntityMetadataTests
 {
     readonly EntityInstanceId id = new("test", Random.Shared.Next(0, 100).ToString());
+    readonly IsoDateTimeConverter dateConverter = new IsoDateTimeConverter
+    {
+        DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffzzz"
+    };
 
     [Fact]
     public void GetState_NotIncluded_Throws()

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -59,7 +59,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\"}}");
     }
 
@@ -78,7 +78,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{state}}}");
     }
 
@@ -97,7 +97,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"BacklogQueueSize\":10,\"LockedBy\""
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{{\"Number\":{state.Number}}}}}");
     }
     
@@ -113,7 +113,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\",\"State\":"
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"State\":"
             + $"{{\"Number\":{state.Number}}}}}");
     }
 
@@ -129,7 +129,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{nowStr}\"}}");
+        json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr}}}");
     }
 
 

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -11,24 +11,6 @@ public class EntityMetadataTests
 {
     readonly EntityInstanceId id = new("test", Random.Shared.Next(0, 100).ToString());
 
-    // create customize convert class
-    public class DateTimeConverter : JsonConverter<DateTimeOffset>
-    {
-        public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return DateTimeOffset.Parse(reader.GetString());
-        }
-
-        public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue("test!");
-        }
-    }
-
-    readonly JsonSerializerOptions settings = new JsonSerializerOptions() {
-        Converters = { new DateTimeConverter() }
-    };
-
     [Fact]
     public void GetState_NotIncluded_Throws()
     {

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -25,7 +25,7 @@ public class EntityMetadataTests
         }
     }
 
-    readonly JsonSerializerOptions defaultSettings = new JsonSerializerOptions() {
+    readonly JsonSerializerOptions settings = new JsonSerializerOptions() {
         Converters = { new DateTimeConverter() }
     };
 
@@ -57,7 +57,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata, settings);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\"}}");
     }
@@ -75,7 +75,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata,settings);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{state}}}");
     }
@@ -93,7 +93,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata, settings);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{{\"Number\":{state.Number}}}}}");
     }
@@ -108,7 +108,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata, settings);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\",\"State\":"
             + $"{{\"Number\":{state.Number}}}}}");
     }
@@ -123,7 +123,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata, settings);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":\"{now:O}\"}}");
     }
 
@@ -138,7 +138,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string json = JsonSerializer.Serialize(metadata);
+        string json = JsonSerializer.Serialize(metadata, settings);
         json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":""{now:O}"",""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
     }
 

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -19,8 +19,9 @@ public class EntityMetadataTests
         }
     }
 
-    JsonSerializerOptions defaultSettings = new JsonSerializerOptions();
-    defaultSettings.Converters.Add(new DateTimeConverter());
+    readonly JsonSerializerOptions defaultSettings = new JsonSerializerOptions() {
+        Converters = { new DateTimeConverter() }
+    };
 
     [Fact]
     public void GetState_NotIncluded_Throws()

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -14,6 +14,11 @@ public class EntityMetadataTests
     // create customize convert class
     public class DateTimeConverter : JsonConverter<DateTime>
     {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return DateTime.Parse(reader.GetString());
+        }
+
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffzzz"));

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -21,7 +21,7 @@ public class EntityMetadataTests
 
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffzzz"));
+            writer.WriteStringValue(value.ToString("dd/MM/yyyy"));
         }
     }
 

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -12,14 +12,14 @@ public class EntityMetadataTests
     readonly EntityInstanceId id = new("test", Random.Shared.Next(0, 100).ToString());
 
     // create customize convert class
-    public class DateTimeConverter : JsonConverter<DateTime>
+    public class DateTimeConverter : JsonConverter<DateTimeOffset>
     {
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateTime.Parse(reader.GetString());
+            return DateTimeOffset.Parse(reader.GetString());
         }
 
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.ToString("dd/MM/yyyy"));
         }

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -145,7 +145,7 @@ public class EntityMetadataTests
 
         string nowStr = JsonSerializer.Serialize(now);
         string json = JsonSerializer.Serialize(metadata);
-        json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":""{nowStr}"",""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
+        json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":{nowStr},""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
     }
 
     record class State(int Number)

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -21,7 +21,7 @@ public class EntityMetadataTests
 
         public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString("dd/MM/yyyy"));
+            writer.WriteStringValue("test!");
         }
     }
 

--- a/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
+++ b/test/Client/Core.Tests/Entities/EntityMetadataTests.cs
@@ -39,7 +39,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\"}}");
@@ -58,7 +58,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{state}}}");
@@ -77,7 +77,7 @@ public class EntityMetadataTests
             LockedBy = lockedBy,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"BacklogQueueSize\":10,\"LockedBy\""
             + $":\"{lockedBy}\",\"State\":{{\"Number\":{state.Number}}}}}");
@@ -93,7 +93,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr},\"State\":"
             + $"{{\"Number\":{state.Number}}}}}");
@@ -109,7 +109,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($"{{\"Id\":\"{this.id}\",\"LastModifiedTime\":{nowStr}}}");
     }
@@ -125,7 +125,7 @@ public class EntityMetadataTests
             LastModifiedTime = now,
         };
 
-        string nowStr = JsonSerializer.Serialize(now);
+        string nowStr = JsonSerializer.Serialize(now); // STJ drops trailing zeroes from dates. see: https://github.com/microsoft/durabletask-dotnet/pull/239
         string json = JsonSerializer.Serialize(metadata);
         json.Should().Be($@"{{""Id"":""{this.id}"",""LastModifiedTime"":{nowStr},""State"":""{{\u0022Number\u0022:{state.Number}}}""}}");
     }


### PR DESCRIPTION
STJ's serialization of dates drops the trailing zeroes from the "round trip" format (i.e the "O" format). See below for a technical explanation from the [docs](https://learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support#support-for-formatting):

> If the [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) representation of a [DateTime](https://learn.microsoft.com/en-us/dotnet/api/system.datetime) or [DateTimeOffset](https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset) instance has trailing zeros in its fractional seconds, then [JsonSerializer](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer) and [Utf8JsonWriter](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.utf8jsonwriter) will format a representation of the instance without trailing zeros. For example, a [DateTime](https://learn.microsoft.com/en-us/dotnet/api/system.datetime) instance whose [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) representation is 2019-04-24T14:50:17.1010000Z, will be formatted as 2019-04-24T14:50:17.101Z by [JsonSerializer](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer) and [Utf8JsonWriter](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.utf8jsonwriter).

This means is that STJ serialization of dates will not match the result of "stringifying" the date as STJ may drop zeroes to save space.

As a result, some of the recently added Entity serialization tests (https://github.com/microsoft/durabletask-dotnet/pull/229) for Entities intermittently fail when the `DateTimeOffset` variable `now` contains trailing zeroes.

This PR aims to get rid of that flakiness by ensuring our expected outputs also drop the trailing zeroes, which we do by calling STJ directly.