### PR TITLE
Cascade terminate/purge support in GrpcDurableTaskClient

### DIFF
--- a/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
@@ -15,6 +15,33 @@ public static class DurableTaskClientExtensions
     /// <param name="createdFrom">Filter purging to orchestrations after this date.</param>
     /// <param name="createdTo">Filter purging to orchestrations before this date.</param>
     /// <param name="statuses">Filter purging to orchestrations with these statuses.</param>
+    /// <param name="options">The optional options for purging the orchestration.</param>
+    /// <param name="cancellation">The cancellation token.</param>
+    /// <returns>
+    /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
+    /// instance was successfully purged.
+    /// </returns>
+    public static Task<PurgeResult> PurgeInstancesAsync(
+        this DurableTaskClient client,
+        DateTimeOffset? createdFrom,
+        DateTimeOffset? createdTo,
+        IEnumerable<OrchestrationRuntimeStatus>? statuses,
+        PurgeInstanceOptons? options,
+        CancellationToken cancellation = default)
+    {
+        Check.NotNull(client);
+        PurgeInstancesFilter filter = new(createdFrom, createdTo, statuses);
+        return client.PurgeAllInstancesAsync(filter, options, cancellation);
+    }
+
+    /// <summary>
+    /// Purges orchestration instances metadata from the durable store.
+    /// </summary>
+    /// <param name="client">The DurableTask client.</param>
+    /// <param name="createdFrom">Filter purging to orchestrations after this date.</param>
+    /// <param name="createdTo">Filter purging to orchestrations before this date.</param>
+    /// <param name="statuses">Filter purging to orchestrations with these statuses.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
@@ -27,11 +54,28 @@ public static class DurableTaskClientExtensions
         DateTimeOffset? createdTo,
         IEnumerable<OrchestrationRuntimeStatus>? statuses,
         CancellationToken cancellation = default)
-    {
-        Check.NotNull(client);
-        PurgeInstancesFilter filter = new(createdFrom, createdTo, statuses);
-        return client.PurgeAllInstancesAsync(filter, cancellation);
-    }
+        => PurgeInstancesAsync(client, createdFrom, createdTo, statuses, null, cancellation);
+
+    /// <summary>
+    /// Purges orchestration instances metadata from the durable store.
+    /// </summary>
+    /// <param name="client">The DurableTask client.</param>
+    /// <param name="createdFrom">Filter purging to orchestrations after this date.</param>
+    /// <param name="createdTo">Filter purging to orchestrations before this date.</param>
+    /// <param name="options">The optional options for purging the orchestration.</param>
+    /// <param name="cancellation">The cancellation token.</param>
+    /// <returns>
+    /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
+    /// instance was successfully purged.
+    /// </returns>
+    public static Task<PurgeResult> PurgeInstancesAsync(
+        this DurableTaskClient client,
+        DateTimeOffset? createdFrom,
+        DateTimeOffset? createdTo,
+        PurgeInstanceOptions? options,
+        CancellationToken cancellation = default)
+        => PurgeInstancesAsync(client, createdFrom, createdTo, null, options, cancellation);
 
     /// <summary>
     /// Purges orchestration instances metadata from the durable store.
@@ -50,5 +94,5 @@ public static class DurableTaskClientExtensions
         DateTimeOffset? createdFrom,
         DateTimeOffset? createdTo,
         CancellationToken cancellation = default)
-        => PurgeInstancesAsync(client, createdFrom, createdTo, null, cancellation);
+        => PurgeInstancesAsync(client, createdFrom, createdTo, null, null, cancellation);
 }

--- a/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientExtensions.cs
@@ -19,15 +19,15 @@ public static class DurableTaskClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
-    /// instance was successfully purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public static Task<PurgeResult> PurgeInstancesAsync(
         this DurableTaskClient client,
         DateTimeOffset? createdFrom,
         DateTimeOffset? createdTo,
         IEnumerable<OrchestrationRuntimeStatus>? statuses,
-        PurgeInstanceOptons? options,
+        PurgeInstanceOptions? options,
         CancellationToken cancellation = default)
     {
         Check.NotNull(client);
@@ -45,8 +45,8 @@ public static class DurableTaskClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
-    /// instance was successfully purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public static Task<PurgeResult> PurgeInstancesAsync(
         this DurableTaskClient client,
@@ -66,8 +66,8 @@ public static class DurableTaskClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
-    /// instance was successfully purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public static Task<PurgeResult> PurgeInstancesAsync(
         this DurableTaskClient client,
@@ -86,8 +86,8 @@ public static class DurableTaskClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
-    /// instance was successfully purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public static Task<PurgeResult> PurgeInstancesAsync(
         this DurableTaskClient client,

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -391,8 +391,11 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
     /// instance was successfully purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, bool recursive = true, CancellationToken cancellation = default);
+    public virtual Task<PurgeResult> PurgeInstanceAsync(
+        string instanceId, bool recursive = true, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
+    }
 
     /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, bool, CancellationToken)"/>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
@@ -410,8 +413,11 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
-    public abstract Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default);
+    public virtual Task<PurgeResult> PurgeAllInstancesAsync(
+        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
+    }
 
     // TODO: Create task hub
 

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -214,30 +214,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
         => this.TerminateInstanceAsync(instanceId, null, cancellation);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, object? output)
+    public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation = default)
     {
         TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
-        return this.TerminateInstanceAsync(instanceId, options);
-    }
-
-    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation)
-    {
-        TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
-        return this.TerminateInstanceAsync(instanceId, options, cancellation);
-    }
-
-    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, bool recursive)
-    {
-        TerminateInstanceOptions options = new() { Recursive = recursive };
-        return this.TerminateInstanceAsync(instanceId, options);
-    }
-
-    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, bool recursive, CancellationToken cancellation)
-    {
-        TerminateInstanceOptions options = new() { Recursive = recursive };
         return this.TerminateInstanceAsync(instanceId, options, cancellation);
     }
 
@@ -378,7 +357,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// If <paramref name="instanceId"/> is not found in the data store, or if the instance is found but not in a
     /// terminal state, then the returned <see cref="PurgeResult"/> object will have a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>0</c>. Otherwise, the existing data will be purged and
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> will be <c>countOfInstancesPurged</c>.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> will be the count of purged instances.
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The unique ID of the orchestration instance to purge.</param>
@@ -388,8 +367,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>1</c> or <c>0</c>, depending on whether the target
-    /// instance was successfully purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public virtual Task<PurgeResult> PurgeInstanceAsync(
         string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
@@ -411,7 +390,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </param>
     /// <returns>
     /// This method returns a <see cref="PurgeResult"/> object after the operation has completed with a
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged,
+    /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(
         PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -338,6 +338,10 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <returns>An async pageable of the query results.</returns>
     public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
+    /// <inheritdoc cref="PurgeInstanceAsync(string, bool, CancellationToken)"/>
+    public virtual Task<PurgeResult> PurgeInstancesAsync(string instanceId, CancellationToken cancellation)
+        => this.PurgeInstanceAsync(instanceId, true, cancellation);
+
     /// <summary>
     /// Purges orchestration instance metadata from the durable store.
     /// </summary>
@@ -349,13 +353,17 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="OrchestrationRuntimeStatus.Completed"/>, <see cref="OrchestrationRuntimeStatus.Failed"/>, or
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/> state can be purged.
     /// </para><para>
+    /// Purging an orchestration will by default purge all of the child sub-orchestrations that were started by the
+    /// orchetration instance. If you don't want to purge sub-orchestration instances, you can set `recursive` flag to
+    /// false which will disable purging of child sub-orchestration instances.
     /// If <paramref name="instanceId"/> is not found in the data store, or if the instance is found but not in a
     /// terminal state, then the returned <see cref="PurgeResult"/> object will have a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>0</c>. Otherwise, the existing data will be purged and
-    /// <see cref="PurgeResult.PurgedInstanceCount"/> will be <c>1</c>.
+    /// <see cref="PurgeResult.PurgedInstanceCount"/> will be <c>countOfInstancesPurged</c>.
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The unique ID of the orchestration instance to purge.</param>
+    /// <param name="recursive">The optional parameter to recursively purge sub-orchestrations, true by default.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -365,12 +373,17 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// instance was successfully purged.
     /// </returns>
     public abstract Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, CancellationToken cancellation = default);
+        string instanceId, bool recursive = true, CancellationToken cancellation = default);
+
+    /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, bool, CancellationToken)"/>
+    public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
+        => this.PurgeAllInstancesAsync(new PurgeInstancesFilter(), true, cancellation);
 
     /// <summary>
     /// Purges orchestration instances metadata from the durable store.
     /// </summary>
     /// <param name="filter">The filter for which orchestrations to purge.</param>
+    /// <param name="recursive">The optional parameter to recursively purge sub-orchestrations, true by default.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -379,7 +392,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
     public abstract Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, CancellationToken cancellation = default);
+        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default);
 
     // TODO: Create task hub
 

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -209,9 +209,17 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
-    /// <inheritdoc cref="TerminateInstanceAsync(string, object, CancellationToken)"/>
+    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, null, cancellation);
+        => this.TerminateInstanceAsync(instanceId, null, true, cancellation);
+
+    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation)
+        => this.TerminateInstanceAsync(instanceId, output, true, cancellation);
+
+    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(string instanceId, bool recursive, CancellationToken cancellation)
+        => this.TerminateInstanceAsync(instanceId, null, recursive, cancellation);
 
     /// <summary>
     /// Terminates a running orchestration instance and updates its runtime status to
@@ -226,10 +234,12 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// the terminated state.
     /// </para>
     /// <para>
+    /// Terminating an orchestration by default will terminate all of the child sub-orchestrations that were started by
+    /// the orchetration instance. If you don't want to terminate sub-orchestration instances, you can set `recursive`
+    /// flag to false which will disable termination of child sub-orchestration instances.
     /// Terminating an orchestration instance has no effect on any in-flight activity function executions
-    /// or sub-orchestrations that were started by the terminated instance. Those actions will continue to run
-    /// without interruption. However, their results will be discarded. If you want to terminate sub-orchestrations,
-    /// you must issue separate terminate commands for each sub-orchestration instance.
+    /// that were started by the terminated instance. Those actions will continue to run
+    /// without interruption. However, their results will be discarded.
     /// </para><para>
     /// At the time of writing, there is no way to terminate an in-flight activity execution.
     /// </para><para>
@@ -238,13 +248,14 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </remarks>
     /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
     /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
+    /// <param name="recursive">The optional parameter to recursively termintate sub-orchestrations, true by default.</param>
     /// <param name="cancellation">
     /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
     /// termination of the orchestration once enqueued.
     /// </param>
     /// <returns>A task that completes when the terminate message is enqueued.</returns>
     public abstract Task TerminateInstanceAsync(
-        string instanceId, object? output = null, CancellationToken cancellation = default);
+        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default);
 
     /// <inheritdoc cref="SuspendInstanceAsync(string, string, CancellationToken)"/>
     public virtual Task SuspendInstanceAsync(string instanceId, CancellationToken cancellation)

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -233,9 +233,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// the terminated state.
     /// </para>
     /// <para>
-    /// Terminating an orchestration by default will terminate all of the child sub-orchestrations that were started by
-    /// the orchetration instance. If you don't want to terminate sub-orchestration instances, you can set <see cref="TerminateInstanceOptions.Recursive"/>
-    /// flag to false which will disable termination of child sub-orchestration instances. It is set to true by default.
+    /// Terminating an orchestration by default will not terminate any of the child sub-orchestrations that were started by
+    /// the orchetration instance. If you want to terminate sub-orchestration instances as well, you can set <see cref="TerminateInstanceOptions.Recursive"/>
+    /// flag to true which will enable termination of child sub-orchestration instances. It is set to false by default.
     /// Terminating an orchestration instance has no effect on any in-flight activity function executions
     /// that were started by the terminated instance. Those actions will continue to run
     /// without interruption. However, their results will be discarded.
@@ -351,9 +351,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="OrchestrationRuntimeStatus.Completed"/>, <see cref="OrchestrationRuntimeStatus.Failed"/>, or
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/> state can be purged.
     /// </para><para>
-    /// Purging an orchestration will by default purge all of the child sub-orchestrations that were started by the
-    /// orchetration instance. If you don't want to purge sub-orchestration instances, you can set <see cref="PurgeInstanceOptions.Recursive"/> flag to
-    /// false which will disable purging of child sub-orchestration instances. It is set to true by default.
+    /// Purging an orchestration will by default not purge any of the child sub-orchestrations that were started by the
+    /// orchetration instance. If you want to purge sub-orchestration instances, you can set <see cref="PurgeInstanceOptions.Recursive"/> flag to
+    /// true which will enable purging of child sub-orchestration instances. It is set to false by default.
     /// If <paramref name="instanceId"/> is not found in the data store, or if the instance is found but not in a
     /// terminal state, then the returned <see cref="PurgeResult"/> object will have a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>0</c>. Otherwise, the existing data will be purged and

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -255,8 +255,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// <para>
     /// Terminating an orchestration by default will terminate all of the child sub-orchestrations that were started by
-    /// the orchetration instance. If you don't want to terminate sub-orchestration instances, you can set `recursive`
-    /// flag to false which will disable termination of child sub-orchestration instances.
+    /// the orchetration instance. If you don't want to terminate sub-orchestration instances, you can set <see cref="TerminateInstanceOptions.Recursive"/>
+    /// flag to false which will disable termination of child sub-orchestration instances. It is set to true by default.
     /// Terminating an orchestration instance has no effect on any in-flight activity function executions
     /// that were started by the terminated instance. Those actions will continue to run
     /// without interruption. However, their results will be discarded.
@@ -357,9 +357,9 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <returns>An async pageable of the query results.</returns>
     public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
-    /// <inheritdoc cref="PurgeInstanceAsync(string, bool, CancellationToken)"/>
+    /// <inheritdoc cref="PurgeInstanceAsync(string, PurgeInstanceOptions, CancellationToken)"/>
     public virtual Task<PurgeResult> PurgeInstancesAsync(string instanceId, CancellationToken cancellation)
-        => this.PurgeInstanceAsync(instanceId, true, cancellation);
+        => this.PurgeInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>
     /// Purges orchestration instance metadata from the durable store.
@@ -373,8 +373,8 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/> state can be purged.
     /// </para><para>
     /// Purging an orchestration will by default purge all of the child sub-orchestrations that were started by the
-    /// orchetration instance. If you don't want to purge sub-orchestration instances, you can set `recursive` flag to
-    /// false which will disable purging of child sub-orchestration instances.
+    /// orchetration instance. If you don't want to purge sub-orchestration instances, you can set <see cref="PurgeInstanceOptions.Recursive"/> flag to
+    /// false which will disable purging of child sub-orchestration instances. It is set to true by default.
     /// If <paramref name="instanceId"/> is not found in the data store, or if the instance is found but not in a
     /// terminal state, then the returned <see cref="PurgeResult"/> object will have a
     /// <see cref="PurgeResult.PurgedInstanceCount"/> value of <c>0</c>. Otherwise, the existing data will be purged and
@@ -382,7 +382,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The unique ID of the orchestration instance to purge.</param>
-    /// <param name="recursive">The optional parameter to recursively purge sub-orchestrations, true by default.</param>
+    /// <param name="options">The optional options for purging the orchestration.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -392,20 +392,20 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// instance was successfully purged.
     /// </returns>
     public virtual Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, bool recursive = true, CancellationToken cancellation = default)
+        string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
     }
 
-    /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, bool, CancellationToken)"/>
+    /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, PurgeInstanceOptions, CancellationToken)"/>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
-        => this.PurgeAllInstancesAsync(new PurgeInstancesFilter(), true, cancellation);
+        => this.PurgeAllInstancesAsync(new PurgeInstancesFilter(), null, cancellation);
 
     /// <summary>
     /// Purges orchestration instances metadata from the durable store.
     /// </summary>
     /// <param name="filter">The filter for which orchestrations to purge.</param>
-    /// <param name="recursive">The optional parameter to recursively purge sub-orchestrations, true by default.</param>
+    /// <param name="options">The optional options for purging the orchestration.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -414,7 +414,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="PurgeResult.PurgedInstanceCount"/> indicating the number of orchestration instances that were purged.
     /// </returns>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
     }

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -209,20 +209,40 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
-    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
+    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, null, true, cancellation);
+        => this.TerminateInstanceAsync(instanceId, null, cancellation);
 
-    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
+    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(string instanceId, object? output)
+    {
+        TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
+        return this.TerminateInstanceAsync(instanceId, options);
+    }
+
+    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, output, true, cancellation);
+    {
+        TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
+        return this.TerminateInstanceAsync(instanceId, options, cancellation);
+    }
 
-    /// <inheritdoc cref="TerminateInstanceAsync(string, object, bool, CancellationToken)"/>
+    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
+    public virtual Task TerminateInstanceAsync(string instanceId, bool recursive)
+    {
+        TerminateInstanceOptions options = new() { Recursive = recursive };
+        return this.TerminateInstanceAsync(instanceId, options);
+    }
+
+    /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, bool recursive, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, null, recursive, cancellation);
+    {
+        TerminateInstanceOptions options = new() { Recursive = recursive };
+        return this.TerminateInstanceAsync(instanceId, options, cancellation);
+    }
 
     /// <summary>
-    /// Terminates a running orchestration instance and updates its runtime status to
+    /// Terminates an orchestration instance and updates its runtime status to
     /// <see cref="OrchestrationRuntimeStatus.Terminated"/>.
     /// </summary>
     /// <remarks>
@@ -247,15 +267,14 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
-    /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
-    /// <param name="recursive">The optional parameter to recursively termintate sub-orchestrations, true by default.</param>
+    /// <param name="options">The optional options for terminating the orchestration.</param>
     /// <param name="cancellation">
     /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
     /// termination of the orchestration once enqueued.
     /// </param>
     /// <returns>A task that completes when the terminate message is enqueued.</returns>
-    public abstract Task TerminateInstanceAsync(
-        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default);
+    public virtual Task TerminateInstanceAsync(string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+        => throw new NotSupportedException($"{this.GetType()} does not support orchestration termination.");
 
     /// <inheritdoc cref="SuspendInstanceAsync(string, string, CancellationToken)"/>
     public virtual Task SuspendInstanceAsync(string instanceId, CancellationToken cancellation)

--- a/src/Client/Core/PurgeInstanceOptions.cs
+++ b/src/Client/Core/PurgeInstanceOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Client;
+
+/// <summary>
+/// Options to purge an orchestration.
+/// </summary>
+public record PurgeInstanceOptions
+{
+    /// <summary>
+    /// Gets a value indicating whether to purge sub-orchestrations as well.
+    /// </summary>
+    public bool Recursive { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PurgeInstanceOptions"/> class.
+    /// </summary>
+    /// <param name="recursive">The optional boolean value indicating whether to purge sub-orchestrations as well.</param>
+    public PurgeInstanceOptions(bool recursive = true)
+    {
+        this.Recursive = recursive;
+    }
+}

--- a/src/Client/Core/PurgeInstanceOptions.cs
+++ b/src/Client/Core/PurgeInstanceOptions.cs
@@ -9,11 +9,6 @@ namespace Microsoft.DurableTask.Client;
 public record PurgeInstanceOptions
 {
     /// <summary>
-    /// Gets a value indicating whether to purge sub-orchestrations as well.
-    /// </summary>
-    public bool Recursive { get; init; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="PurgeInstanceOptions"/> class.
     /// </summary>
     /// <param name="recursive">The optional boolean value indicating whether to purge sub-orchestrations as well.</param>
@@ -21,4 +16,9 @@ public record PurgeInstanceOptions
     {
         this.Recursive = recursive;
     }
+
+    /// <summary>
+    /// Gets a value indicating whether to purge sub-orchestrations as well.
+    /// </summary>
+    public bool Recursive { get; init; }
 }

--- a/src/Client/Core/PurgeInstanceOptions.cs
+++ b/src/Client/Core/PurgeInstanceOptions.cs
@@ -6,19 +6,5 @@ namespace Microsoft.DurableTask.Client;
 /// <summary>
 /// Options to purge an orchestration.
 /// </summary>
-public record PurgeInstanceOptions
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PurgeInstanceOptions"/> class.
-    /// </summary>
-    /// <param name="recursive">The optional boolean value indicating whether to purge sub-orchestrations as well.</param>
-    public PurgeInstanceOptions(bool recursive = true)
-    {
-        this.Recursive = recursive;
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether to purge sub-orchestrations as well.
-    /// </summary>
-    public bool Recursive { get; init; }
-}
+/// <param name="Recursive">The optional boolean value indicating whether to purge sub-orchestrations as well.</param>
+public record PurgeInstanceOptions(bool Recursive = false);

--- a/src/Client/Core/TerminateInstanceOptions.cs
+++ b/src/Client/Core/TerminateInstanceOptions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Client;
+
+/// <summary>
+/// Options to terminate an orchestration.
+/// </summary>
+public class TerminateInstanceOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TerminateInstanceOptions"/> class.
+    /// </summary>
+    /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
+    /// <param name="recursive">The optional boolean value indicating whether to terminate sub-orchestrations as well.</param>
+    public TerminateInstanceOptions(object? output = null, bool recursive = true)
+    {
+        this.Output = output;
+        this.Recursive = recursive;
+    }
+
+    /// <summary>
+    /// Gets the optional output to set for the terminated orchestration instance.
+    /// </summary>
+    public object? Output { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether to terminate sub-orchestrations as well.
+    /// </summary>
+    public bool Recursive { get; init; }
+}

--- a/src/Client/Core/TerminateInstanceOptions.cs
+++ b/src/Client/Core/TerminateInstanceOptions.cs
@@ -4,28 +4,8 @@
 namespace Microsoft.DurableTask.Client;
 
 /// <summary>
-/// Options to terminate an orchestration.
+///  Options to terminate an orchestration.
 /// </summary>
-public record TerminateInstanceOptions
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TerminateInstanceOptions"/> class.
-    /// </summary>
-    /// <param name="output">The optional output to set for the terminated orchestration instance.</param>
-    /// <param name="recursive">The optional boolean value indicating whether to terminate sub-orchestrations as well.</param>
-    public TerminateInstanceOptions(object? output = null, bool recursive = true)
-    {
-        this.Output = output;
-        this.Recursive = recursive;
-    }
-
-    /// <summary>
-    /// Gets the optional output to set for the terminated orchestration instance.
-    /// </summary>
-    public object? Output { get; init; }
-
-    /// <summary>
-    /// Gets a value indicating whether to terminate sub-orchestrations as well.
-    /// </summary>
-    public bool Recursive { get; init; }
-}
+/// <param name="Output">The optional output to set for the terminated orchestration instance.</param>
+/// <param name="Recursive">The optional boolean value indicating whether to terminate sub-orchestrations as well.</param>
+public record TerminateInstanceOptions(object? Output = null, bool Recursive = false);

--- a/src/Client/Core/TerminateInstanceOptions.cs
+++ b/src/Client/Core/TerminateInstanceOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DurableTask.Client;
 /// <summary>
 /// Options to terminate an orchestration.
 /// </summary>
-public class TerminateInstanceOptions
+public record TerminateInstanceOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminateInstanceOptions"/> class.

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -124,7 +124,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task TerminateInstanceAsync(
-        string instanceId, object? output = null, CancellationToken cancellation = default)
+        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
     {
         Check.NotNullOrEmpty(instanceId);
         Check.NotEntity(this.options.EnableEntitySupport, instanceId);
@@ -137,6 +137,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             {
                 InstanceId = instanceId,
                 Output = serializedOutput,
+                Recursive = recursive,
             },
             cancellationToken: cancellation);
     }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -127,7 +127,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         object? output = options?.Output;
-        bool recursive = options?.Recursive ?? true;
+        bool recursive = options?.Recursive ?? false;
 
         Check.NotNullOrEmpty(instanceId);
         Check.NotEntity(this.options.EnableEntitySupport, instanceId);
@@ -327,7 +327,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     public override Task<PurgeResult> PurgeInstanceAsync(
         string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
-        bool recursive = options?.Recursive ?? true;
+        bool recursive = options?.Recursive ?? false;
         this.logger.PurgingInstanceMetadata(instanceId);
 
         P.PurgeInstancesRequest request = new() { InstanceId = instanceId, Recursive = recursive };
@@ -338,7 +338,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     public override Task<PurgeResult> PurgeAllInstancesAsync(
         PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
-        bool recursive = options?.Recursive ?? true;
+        bool recursive = options?.Recursive ?? false;
         this.logger.PurgingInstances(filter);
         P.PurgeInstancesRequest request = new()
         {

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -124,20 +124,25 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task TerminateInstanceAsync(
-        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
+        string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
+        if (options is null)
+        {
+            options = new TerminateInstanceOptions();
+        }
+
         Check.NotNullOrEmpty(instanceId);
         Check.NotEntity(this.options.EnableEntitySupport, instanceId);
 
         this.logger.TerminatingInstance(instanceId);
 
-        string? serializedOutput = this.DataConverter.Serialize(output);
+        string? serializedOutput = this.DataConverter.Serialize(options.Output);
         await this.sidecarClient.TerminateInstanceAsync(
             new P.TerminateRequest
             {
                 InstanceId = instanceId,
                 Output = serializedOutput,
-                Recursive = recursive,
+                Recursive = options.Recursive,
             },
             cancellationToken: cancellation);
     }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -322,17 +322,17 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, CancellationToken cancellation = default)
+        string instanceId, bool recursive = true, CancellationToken cancellation = default)
     {
         this.logger.PurgingInstanceMetadata(instanceId);
 
-        P.PurgeInstancesRequest request = new() { InstanceId = instanceId };
+        P.PurgeInstancesRequest request = new() { InstanceId = instanceId, Recursive = recursive };
         return this.PurgeInstancesCoreAsync(request, cancellation);
     }
 
     /// <inheritdoc/>
     public override Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
     {
         this.logger.PurgingInstances(filter);
         P.PurgeInstancesRequest request = new()
@@ -342,6 +342,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
                 CreatedTimeFrom = filter?.CreatedFrom.ToTimestamp(),
                 CreatedTimeTo = filter?.CreatedTo.ToTimestamp(),
             },
+            Recursive = recursive,
         };
 
         if (filter?.Statuses is not null)

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -327,18 +327,27 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, bool recursive = true, CancellationToken cancellation = default)
+        string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
+        if options is null
+        {
+            options = new PurgeInstanceOptions();
+        }
+
         this.logger.PurgingInstanceMetadata(instanceId);
 
-        P.PurgeInstancesRequest request = new() { InstanceId = instanceId, Recursive = recursive };
+        P.PurgeInstancesRequest request = new() { InstanceId = instanceId, Recursive = options.Recursive };
         return this.PurgeInstancesCoreAsync(request, cancellation);
     }
 
     /// <inheritdoc/>
     public override Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
+        if options is null
+        {
+            options = new PurgeInstanceOptions();
+        }
         this.logger.PurgingInstances(filter);
         P.PurgeInstancesRequest request = new()
         {
@@ -347,7 +356,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
                 CreatedTimeFrom = filter?.CreatedFrom.ToTimestamp(),
                 CreatedTimeTo = filter?.CreatedTo.ToTimestamp(),
             },
-            Recursive = recursive,
+            Recursive = options.Recursive,
         };
 
         if (filter?.Statuses is not null)

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -171,14 +171,10 @@ class ShimDurableTaskClient : DurableTaskClient
     public override Task TerminateInstanceAsync(
         string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
-        if (options is null)
-        {
-            options = new TerminateInstanceOptions();
-        }
-
+        object? output = options?.Output;
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
-        string? reason = this.DataConverter.Serialize(options.Output);
+        string? reason = this.DataConverter.Serialize(output);
         return this.Client.ForceTerminateTaskOrchestrationAsync(instanceId, reason);
     }
 

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -169,7 +169,7 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override Task TerminateInstanceAsync(
-        string instanceId, object? output = null, CancellationToken cancellation = default)
+        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
     {
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -95,7 +95,7 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, bool recursive = true, CancellationToken cancellation = default)
+        string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
@@ -105,7 +105,7 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         Check.NotNull(filter);
         cancellation.ThrowIfCancellationRequested();

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -93,6 +93,7 @@ class ShimDurableTaskClient : DurableTaskClient
         });
     }
 
+    //TODO: Support recursive purge of sub-orchestrations
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeInstanceAsync(
         string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
@@ -103,6 +104,7 @@ class ShimDurableTaskClient : DurableTaskClient
         return result.ConvertFromCore();
     }
 
+    // Support recursive purge of sub-orchestrations
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeAllInstancesAsync(
         PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
@@ -167,6 +169,7 @@ class ShimDurableTaskClient : DurableTaskClient
         string instanceId, string? reason = null, CancellationToken cancellation = default)
         => this.SendInstanceMessageAsync(instanceId, new ExecutionResumedEvent(-1, reason), cancellation);
 
+    //TODO: Support recursive termination of sub-orchestrations
     /// <inheritdoc/>
     public override Task TerminateInstanceAsync(
         string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -93,24 +93,26 @@ class ShimDurableTaskClient : DurableTaskClient
         });
     }
 
-    //TODO: Support recursive purge of sub-orchestrations
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeInstanceAsync(
         string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
+
+        // TODO: Support recursive purge of sub-orchestrations
         Core.PurgeResult result = await this.PurgeClient.PurgeInstanceStateAsync(instanceId);
         return result.ConvertFromCore();
     }
 
-    // Support recursive purge of sub-orchestrations
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeAllInstancesAsync(
         PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         Check.NotNull(filter);
         cancellation.ThrowIfCancellationRequested();
+
+        // TODO: Support recursive purge of sub-orchestrations
         Core.PurgeResult result = await this.PurgeClient.PurgeInstanceStateAsync(filter.ConvertToCore());
         return result.ConvertFromCore();
     }
@@ -169,7 +171,6 @@ class ShimDurableTaskClient : DurableTaskClient
         string instanceId, string? reason = null, CancellationToken cancellation = default)
         => this.SendInstanceMessageAsync(instanceId, new ExecutionResumedEvent(-1, reason), cancellation);
 
-    //TODO: Support recursive termination of sub-orchestrations
     /// <inheritdoc/>
     public override Task TerminateInstanceAsync(
         string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
@@ -178,6 +179,8 @@ class ShimDurableTaskClient : DurableTaskClient
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
         string? reason = this.DataConverter.Serialize(output);
+
+        // TODO: Support recursive termination of sub-orchestrations
         return this.Client.ForceTerminateTaskOrchestrationAsync(instanceId, reason);
     }
 

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -95,7 +95,7 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, CancellationToken cancellation = default)
+        string instanceId, bool recursive = true, CancellationToken cancellation = default)
     {
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
@@ -105,7 +105,7 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override async Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
     {
         Check.NotNull(filter);
         cancellation.ThrowIfCancellationRequested();

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -169,11 +169,16 @@ class ShimDurableTaskClient : DurableTaskClient
 
     /// <inheritdoc/>
     public override Task TerminateInstanceAsync(
-        string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
+        string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
+        if (options is null)
+        {
+            options = new TerminateInstanceOptions();
+        }
+
         Check.NotNullOrEmpty(instanceId);
         cancellation.ThrowIfCancellationRequested();
-        string? reason = this.DataConverter.Serialize(output);
+        string? reason = this.DataConverter.Serialize(options.Output);
         return this.Client.ForceTerminateTaskOrchestrationAsync(instanceId, reason);
     }
 

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -49,7 +49,6 @@ static class ProtoUtils
                         OrchestrationInstance = proto.ExecutionStarted.ParentInstance.OrchestrationInstance.ToCore(),
                         TaskScheduleId = proto.ExecutionStarted.ParentInstance.TaskScheduledId,
                     },
-                    Correlation = proto.ExecutionStarted.CorrelationData,
                     ScheduledStartTime = proto.ExecutionStarted.ScheduledStartTimestamp?.ToDateTime(),
                 };
                 break;

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -89,13 +89,13 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, bool recursive = true, CancellationToken cancellation = default)
+            string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -128,7 +128,7 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
+            string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -128,7 +128,7 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, object? output = null, CancellationToken cancellation = default)
+            string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -89,13 +89,13 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, CancellationToken cancellation = default)
+            string instanceId, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -158,7 +158,7 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, object? output = null, CancellationToken cancellation = default)
+            string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -119,13 +119,13 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, bool recursive = true, CancellationToken cancellation = default)
+            string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -119,13 +119,13 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, CancellationToken cancellation = default)
+            string instanceId, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, bool recursive = true, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -158,7 +158,7 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, object? output = null, bool recursive = true, CancellationToken cancellation = default)
+            string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This PR adds support to recursively terminate/purge sub-orchestrations in GrpcDurableTaskClient. It also sets the recursive behavior to be true by default. 

Closes: #260 