### PR TITLE
Fix TaskFailureDetails.IsCausedBy to support custom exceptions and 3rd party exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+# Unreleased
+
+- Fix `TaskFailureDetails.IsCausedBy` to support custom exceptions and 3rd party exceptions ([#273](https://github.com/microsoft/durabletask-dotnet/pull/273))
+
 # v1.2.0
 
 - Adds support to recursively terminate/purge sub-orchestrations in `GrpcDurableTaskClient` (https://github.com/microsoft/durabletask-dotnet/pull/262)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/2697

### Problem

The issue was a misunderstanding of how `Type.GetType()` works. The `ErrorType` property in `TaskFailureDetails` has the type name and the namespace, but not the assembly name. Calling `Type.GetType()` without the assembly name only works for types defined in mscorelib and types defined in the entrypoint assembly. However, it doesn't work with types defined externally, including in the app assembly when running in a host like Azure Functions (or a test host process).

### Solution

The solution is to enumerate the assemblies in the current assembly load context to look for the specified exception types.

### Additionally

- This PR also adds a new overload to `IsCausedBy` which takes a `Type` parameter, as an alternative to a `T` type parameter.
- This PR also enhances the existing tests to cover the previously missed scenarios.