### PR TITLE
Make RetryPolicy.HandleAsync obsolete

### DIFF
--- a/src/Abstractions/RetryPolicy.cs
+++ b/src/Abstractions/RetryPolicy.cs
@@ -123,8 +123,11 @@ public class RetryPolicy
     /// </value>
     public TimeSpan RetryTimeout { get; }
 
+#pragma warning disable SA1623 // Property summary documentation should match accessors
     /// <summary>
-    /// Gets or sets a Func to call on exception to determine if retries should proceed.
+    /// This functionality is not implemented. Will be removed in the future. Use TaskOptions.FromRetryHandler instead.
     /// </summary>
+    [Obsolete("This functionality is not implemented. Will be removed in the future. Use TaskOptions.FromRetryHandler instead.")]
     public Func<Exception, Task<bool>>? HandleAsync { get; set; }
+#pragma warning restore SA1623 // Property summary documentation should match accessors
 }


### PR DESCRIPTION
The `HandleAsync` property was accidentally added to the `RetryPolicy` class during the initial development of retry handling. It has no implementation at all and some users are trying to use it and opening issues because it's not doing anything. This PR marks it with an `[Obsolete]` attribute and directs users to the correct API for custom retry handlers.