### PR TITLE
Re-introduce default cancellationToken for `PurgeInstanceAsync` for backwards compatibility

### DIFF
--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -337,7 +337,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
     /// <inheritdoc cref="PurgeInstanceAsync(string, PurgeInstanceOptions, CancellationToken)"/>
-    public virtual Task<PurgeResult> PurgeInstancesAsync(string instanceId, CancellationToken cancellation)
+    public virtual Task<PurgeResult> PurgeInstancesAsync(string instanceId, CancellationToken cancellation = default)
         => this.PurgeInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>


### PR DESCRIPTION
Follow-up to: https://github.com/microsoft/durabletask-dotnet/pull/262

It would appear that in the refactoring above we accidentally made a breaking change to our `PurgeInstancesAsync` API, dropping the declaration of a `PurgeInstanceAsync(string instanceId, CancellationToken cancellation = default)` method, which is overriden [here](https://github.com/Azure/azure-functions-durable-extension/blob/b227f215a0b0d8ba3daee2cd06f791cf4e259c1e/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs#L54).

At a glance, I suspect this is the reason for our smoke test failures in the `worker.extensions.durabletask` package: https://github.com/Azure/azure-functions-durable-extension/actions/runs/8428205010/job/23080260061?pr=2772

Failure trace:

> #10 7.776 /root/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs(54,39): error CS0115: 'FunctionsDurableTaskClient.PurgeInstanceAsync(string, CancellationToken)': no suitable method found to override [/root/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj]


This PR is a naive attempt at trying to fix them.