### PR TITLE
Rev version to 1.2.2

### DIFF
--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Version 1.2.1 was internally release to our ADO feed to CI testing with the DF isolated extension: https://github.com/Azure/azure-functions-durable-extension/pull/2772. At that point, we discovered a breaking change that was later fixed in this repo: https://github.com/microsoft/durabletask-dotnet/pull/267.

I can confirm that this fix the CI failures in the DF isolated extension. However, since we cannot re-use version 1.2.1 anymore (we already have a permanent instance of it in the internal ADO), I'm creating this PR to rev the package version to 1.2.2. 

After merging, we'll push this ADO, pass the CI tests in the DF isolated extension, and finish the release.