### PR TITLE
Fixed issue 288: the filter passed to PurgeAllInstancesAsync is now used, instead of creating a new fitler.

### DIFF
--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -378,7 +378,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
 
     /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, PurgeInstanceOptions, CancellationToken)"/>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
-        => this.PurgeAllInstancesAsync(new PurgeInstancesFilter(), null, cancellation);
+        => this.PurgeAllInstancesAsync(filter, null, cancellation);
 
     /// <summary>
     /// Purges orchestration instances metadata from the durable store.


### PR DESCRIPTION
the filter passed to PurgeAllInstancesAsync is now used, instead of creating a new fitler.