### PR TITLE
Fix inner exception propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix filter not being passed along in `PurgeAllInstancesAsync` (https://github.com/microsoft/durabletask-dotnet/pull/289)
 
+### Microsoft.DurableTask.Abstractions
+
+- Enable inner exception detail propagation in `TaskFailureDetails` ([#290](https://github.com/microsoft/durabletask-dotnet/pull/290))
+
 ## v1.2.2
 
 ### Microsoft.DurableTask.Abstractions

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.16.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />

--- a/src/Client/OrchestrationServiceClientShim/ShimExtensions.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimExtensions.cs
@@ -64,7 +64,7 @@ static class ShimExtensions
     /// </summary>
     /// <param name="details">The details to convert.</param>
     /// <returns>The task failure details.</returns>
-    [return: NotNullIfNotNull("details")]
+    [return: NotNullIfNotNull(nameof(details))]
     public static TaskFailureDetails? ConvertFromCore(this Core.FailureDetails? details)
     {
         if (details is null)
@@ -81,7 +81,7 @@ static class ShimExtensions
     /// </summary>
     /// <param name="result">The result to convert.</param>
     /// <returns>The purge result.</returns>
-    [return: NotNullIfNotNull("result")]
+    [return: NotNullIfNotNull(nameof(result))]
     public static PurgeResult? ConvertFromCore(this Core.PurgeResult? result)
     {
         if (result is null)
@@ -97,7 +97,7 @@ static class ShimExtensions
     /// </summary>
     /// <param name="filter">The result to convert.</param>
     /// <returns>The purge result.</returns>
-    [return: NotNullIfNotNull("result")]
+    [return: NotNullIfNotNull(nameof(filter))]
     public static Core.PurgeInstanceFilter? ConvertToCore(this PurgeInstancesFilter? filter)
     {
         if (filter is null)

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -329,7 +329,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="status">The status to convert.</param>
     /// <returns>The converted status.</returns>
-    [return: NotNullIfNotNull("status")]
+    [return: NotNullIfNotNull(nameof(status))]
     internal static OrchestrationInstance? ToCore(this P.OrchestrationInstance? status)
     {
         if (status == null)
@@ -349,7 +349,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="failureDetails">The failure details to convert.</param>
     /// <returns>The converted failure details.</returns>
-    [return: NotNullIfNotNull("failureDetails")]
+    [return: NotNullIfNotNull(nameof(failureDetails))]
     internal static TaskFailureDetails? ToTaskFailureDetails(this P.TaskFailureDetails? failureDetails)
     {
         if (failureDetails == null)
@@ -369,7 +369,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="e">The exception to convert.</param>
     /// <returns>The task failure details.</returns>
-    [return: NotNullIfNotNull("e")]
+    [return: NotNullIfNotNull(nameof(e))]
     internal static P.TaskFailureDetails? ToTaskFailureDetails(this Exception? e)
     {
         if (e == null)
@@ -391,7 +391,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="entityBatchRequest">The entity batch request to convert.</param>
     /// <returns>The converted entity batch request.</returns>
-    [return: NotNullIfNotNull("entityBatchRequest")]
+    [return: NotNullIfNotNull(nameof(entityBatchRequest))]
     internal static EntityBatchRequest? ToEntityBatchRequest(this P.EntityBatchRequest? entityBatchRequest)
     {
         if (entityBatchRequest == null)
@@ -412,7 +412,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="operationRequest">The operation request to convert.</param>
     /// <returns>The converted operation request.</returns>
-    [return: NotNullIfNotNull("operationRequest")]
+    [return: NotNullIfNotNull(nameof(operationRequest))]
     internal static OperationRequest? ToOperationRequest(this P.OperationRequest? operationRequest)
     {
         if (operationRequest == null)
@@ -433,7 +433,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="operationResult">The operation result to convert.</param>
     /// <returns>The converted operation result.</returns>
-    [return: NotNullIfNotNull("operationResult")]
+    [return: NotNullIfNotNull(nameof(operationResult))]
     internal static OperationResult? ToOperationResult(this P.OperationResult? operationResult)
     {
         if (operationResult == null)
@@ -465,7 +465,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="operationResult">The operation result to convert.</param>
     /// <returns>The converted operation result.</returns>
-    [return: NotNullIfNotNull("operationResult")]
+    [return: NotNullIfNotNull(nameof(operationResult))]
     internal static P.OperationResult? ToOperationResult(this OperationResult? operationResult)
     {
         if (operationResult == null)
@@ -500,7 +500,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="operationAction">The operation action to convert.</param>
     /// <returns>The converted operation action.</returns>
-    [return: NotNullIfNotNull("operationAction")]
+    [return: NotNullIfNotNull(nameof(operationAction))]
     internal static OperationAction? ToOperationAction(this P.OperationAction? operationAction)
     {
         if (operationAction == null)
@@ -540,7 +540,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="operationAction">The operation action to convert.</param>
     /// <returns>The converted operation action.</returns>
-    [return: NotNullIfNotNull("operationAction")]
+    [return: NotNullIfNotNull(nameof(operationAction))]
     internal static P.OperationAction? ToOperationAction(this OperationAction? operationAction)
     {
         if (operationAction == null)
@@ -584,7 +584,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="entityBatchResult">The operation result to convert.</param>
     /// <returns>The converted operation result.</returns>
-    [return: NotNullIfNotNull("entityBatchResult")]
+    [return: NotNullIfNotNull(nameof(entityBatchResult))]
     internal static EntityBatchResult? ToEntityBatchResult(this P.EntityBatchResult? entityBatchResult)
     {
         if (entityBatchResult == null)
@@ -606,7 +606,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="entityBatchResult">The operation result to convert.</param>
     /// <returns>The converted operation result.</returns>
-    [return: NotNullIfNotNull("entityBatchResult")]
+    [return: NotNullIfNotNull(nameof(entityBatchResult))]
     internal static P.EntityBatchResult? ToEntityBatchResult(this EntityBatchResult? entityBatchResult)
     {
         if (entityBatchResult == null)
@@ -638,7 +638,7 @@ static class ProtoUtils
     /// </summary>
     /// <param name="parameters">The DT.Core representation.</param>
     /// <returns>The gRPC representation.</returns>
-    [return: NotNullIfNotNull("parameters")]
+    [return: NotNullIfNotNull(nameof(parameters))]
     internal static TaskOrchestrationEntityParameters? ToCore(this P.OrchestratorEntityParameters? parameters)
     {
         if (parameters == null)

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -195,7 +195,10 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         catch (global::DurableTask.Core.Exceptions.SubOrchestrationFailedException e)
         {
             // Hide the core DTFx types and instead use our own
-            throw new TaskFailedException(orchestratorName, e.ScheduleId, e);
+            throw new TaskFailedException(
+                orchestratorName,
+                e.ScheduleId,
+                TaskFailureDetails.FromCoreFailureDetails(e.FailureDetails!));
         }
     }
 

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -257,16 +257,16 @@ sealed partial class GrpcDurableTaskWorker
                 {
                     InstanceId = request.InstanceId,
                     Actions =
-                {
-                    new P.OrchestratorAction
                     {
-                        CompleteOrchestration = new P.CompleteOrchestrationAction
+                        new P.OrchestratorAction
                         {
-                            OrchestrationStatus = P.OrchestrationStatus.Failed,
-                            FailureDetails = failureDetails,
+                            CompleteOrchestration = new P.CompleteOrchestrationAction
+                            {
+                                OrchestrationStatus = P.OrchestrationStatus.Failed,
+                                FailureDetails = failureDetails,
+                            },
                         },
                     },
-                },
                 };
             }
 
@@ -313,12 +313,7 @@ sealed partial class GrpcDurableTaskWorker
             }
             catch (Exception applicationException)
             {
-                failureDetails = new P.TaskFailureDetails
-                {
-                    ErrorType = applicationException.GetType().FullName,
-                    ErrorMessage = applicationException.Message,
-                    StackTrace = applicationException.StackTrace,
-                };
+                failureDetails = applicationException.ToTaskFailureDetails();
             }
 
             int outputSizeInBytes = 0;

--- a/test/Grpc.IntegrationTests/Grpc.IntegrationTests.csproj
+++ b/test/Grpc.IntegrationTests/Grpc.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.52.0" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar" Version="0.3.0" />
+    <PackageReference Include="Microsoft.DurableTask.Sidecar" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -62,10 +62,15 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.Contains(nameof(MyOrchestrationImpl), failureDetails.StackTrace);
         Assert.DoesNotContain(nameof(MyActivityImpl), failureDetails.StackTrace);
 
-        // Check that the inner exception was populated correctly
+        // Check that the inner exception - i.e. the exact exception that failed the orchestration - was populated correctly
         Assert.NotNull(failureDetails.InnerFailure);
-        Assert.Equal(typeof(CustomException).FullName, failureDetails.InnerFailure!.ErrorType);
-        Assert.Equal("Inner!", failureDetails.InnerFailure.ErrorMessage);
+        Assert.Equal(typeof(Exception).FullName, failureDetails.InnerFailure!.ErrorType);
+        Assert.Equal(errorMessage, failureDetails.InnerFailure.ErrorMessage);
+
+        // Check that the inner-most exception was populated correctly too (the custom exception type)
+        Assert.NotNull(failureDetails.InnerFailure.InnerFailure);
+        Assert.Equal(typeof(CustomException).FullName, failureDetails.InnerFailure.InnerFailure!.ErrorType);
+        Assert.Equal("Inner!", failureDetails.InnerFailure.InnerFailure.ErrorMessage);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of fixing https://github.com/Azure/azure-functions-durable-extension/issues/2476

There were various places where we weren't correctly setting the inner failure details for `TaskFailureDetails`. This PR fixes those and adds a new test to cover this scenario specifically.

Note that this PR depends on updates to DurableTask.Core (https://github.com/Azure/durabletask/pull/1067) and DurableTask.Sidecar (https://github.com/microsoft/durabletask-sidecar/pull/24). I'm not expecting this PR to build until we have the new versions of those packages available.