### PR TITLE
Fixes neutral language warning in analyzer

### DIFF
--- a/src/Analyzers/Analyzers.csproj
+++ b/src/Analyzers/Analyzers.csproj
@@ -25,6 +25,7 @@
   <PropertyGroup>
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix>preview.1</VersionSuffix>
+    <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After the introduction of the resources file in the Analyzers project, [`CA1824` warning ](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1824) started to appear, indicating that we don't have a neutral language.