### PR TITLE
fix errors detected by new version of stylecop

### DIFF
--- a/src/Abstractions/Entities/EntityInstanceId.cs
+++ b/src/Abstractions/Entities/EntityInstanceId.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DurableTask.Entities;
 public readonly record struct EntityInstanceId
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="EntityInstanceId"/> class.
+    /// Initializes a new instance of the <see cref="EntityInstanceId"/> struct.
     /// </summary>
     /// <param name="name">The entity name.</param>
     /// <param name="key">The entity key.</param>

--- a/src/Client/Core/Entities/EntityQuery.cs
+++ b/src/Client/Core/Entities/EntityQuery.cs
@@ -8,12 +8,12 @@ namespace Microsoft.DurableTask.Client.Entities;
 /// </summary>
 public record EntityQuery
 {
-    string? instanceIdStartsWith;
-
     /// <summary>
     /// The default page size.
     /// </summary>
     public const int DefaultPageSize = 100;
+
+    string? instanceIdStartsWith;
 
     /// <summary>
     /// Gets the optional starts-with expression for the entity instance ID.


### PR DESCRIPTION
after [upgrading the version of StyleCop](https://github.com/microsoft/durabletask-dotnet/pull/284/commits/f0120f32e0df80fca59f48bedb4de97f01b8268b), some new warnings/recommendations appeared. This PR fixes:
- [Constructor summary documentation should begin with standard text](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md)
- ['public' members should come before 'private' members](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md)