### PR TITLE
moving analyzer code wrapper to its own class

### DIFF
--- a/test/Analyzers.Tests/Wrapper.cs
+++ b/test/Analyzers.Tests/Wrapper.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Analyzers.Tests;
+
+public static class Wrapper
+{
+    public static string WrapDurableFunctionOrchestration(string code)
+    {
+        return $@"
+{Usings()}
+class Orchestrator
+{{
+{code}
+}}
+";
+    }
+
+    public static string WrapTaskOrchestrator(string code)
+    {
+        return $@"
+{Usings()}
+{code}
+";
+    }
+
+    public static string WrapFuncOrchestrator(string code)
+    {
+        return $@"
+{Usings()}
+
+public class Program
+{{
+    public static void Main()
+    {{
+        new ServiceCollection().AddDurableTaskWorker(builder =>
+        {{
+            builder.AddTasks(tasks =>
+            {{
+                {code}
+            }});
+        }});
+    }}
+}}
+";
+    }
+
+    static string Usings()
+    {
+        return $@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.DependencyInjection;
+";
+    }
+}


### PR DESCRIPTION
This PR refactors the analyzer tests code wrapping to another class, allowing us to be reused by different test classes than the date time one.