### PR TITLE
Add versioning support in durablttask-dotnet(phase1)

### DIFF
--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -30,6 +30,26 @@ public readonly struct TaskName : IEquatable<TaskName>
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="TaskName"/> struct.
+    /// </summary>
+    /// <param name="name">The name of the task. Providing <c>null</c> will yield the default struct.</param>
+    /// <param name="version">The version of the task.</param>
+    public TaskName(string name, string version)
+    {
+        if (name is null)
+        {
+            // Force the default struct when null is passed in.
+            this.Name = null!;
+            this.Version = version!;
+        }
+        else
+        {
+            this.Name = name;
+            this.Version = version;
+        }
+    }
+
+    /// <summary>
     /// Gets the name of the task without the version.
     /// </summary>
     /// <value>

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -23,6 +23,11 @@ public abstract class TaskOrchestrationContext
     public abstract string InstanceId { get; }
 
     /// <summary>
+    /// Gets the version of the current orchestration instance.
+    /// </summary>
+    public abstract string InstanceVersion { get; }
+
+    /// <summary>
     /// Gets the parent instance or <c>null</c> if there is no parent orchestration.
     /// </summary>
     public abstract ParentOrchestrationInstance? Parent { get; }

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -52,6 +52,9 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     public override string InstanceId => this.innerContext.OrchestrationInstance.InstanceId;
 
     /// <inheritdoc/>
+    public override string InstanceVersion => this.innerContext.OrchestrationInstance.InstanceVersion;
+
+    /// <inheritdoc/>
     public override ParentOrchestrationInstance? Parent => this.invocationContext.Parent;
 
     /// <inheritdoc/>


### PR DESCRIPTION

Code updates:

- TaskName

  Add a new constructor that sets the version expected by the client.

  The existing code has a version field and associated implementation, but no constructor to set the version is provided. Adding this constructor makes it possible to do so in client-side code:

  ```c#
  string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
    new TaskName(nameof(HelloOrchestration), "1.2.0"));
  ```
    

- TaskOrchestrationContext

  Add new abstract method to get instance version.

  So that in the orchestration code, we get the instance version by this context:

  ```c#
      public static async Task<List<string>> RunOrchestrator(
          [OrchestrationTrigger] TaskOrchestrationContext context)
      {
  			string instanceVersion = context.InstanceVersion;
        ......
      }
  ```

- TaskOrchestrationContextWrapper

  Implemented new added abstract method to get instance version.

  This method will get the value of instance version from OrchestrationContext which is updated to add InstanceVersion filed and pass the value in another PR in durable repo.



