### PR TITLE
Guid.NewGuid Roslyn Analyzer

### DIFF
--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 DURABLE0001 | Orchestration | Warning | DateTimeOrchestrationAnalyzer
+DURABLE0002 | Orchestration | Warning | GuidOrchestrationAnalyzer

--- a/src/Analyzers/KnownTypeSymbols.cs
+++ b/src/Analyzers/KnownTypeSymbols.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Microsoft.CodeAnalysis;
@@ -20,6 +20,7 @@ sealed class KnownTypeSymbols(Compilation compilation)
     INamedTypeSymbol? taskOrchestratorInterface;
     INamedTypeSymbol? taskOrchestratorBaseClass;
     INamedTypeSymbol? durableTaskRegistry;
+    INamedTypeSymbol? guid;
 
     /// <summary>
     /// Gets an OrchestrationTriggerAttribute type symbol.
@@ -45,6 +46,11 @@ sealed class KnownTypeSymbols(Compilation compilation)
     /// Gets a DurableTaskRegistry type symbol.
     /// </summary>
     public INamedTypeSymbol? DurableTaskRegistry => this.GetOrResolveFullyQualifiedType("Microsoft.DurableTask.DurableTaskRegistry", ref this.durableTaskRegistry);
+
+    /// <summary>
+    /// Gets a Guid type symbol.
+    /// </summary>
+    public INamedTypeSymbol? GuidType => this.GetOrResolveFullyQualifiedType(typeof(Guid).FullName, ref this.guid);
 
     INamedTypeSymbol? GetOrResolveFullyQualifiedType(string fullyQualifiedName, ref INamedTypeSymbol? field)
     {

--- a/src/Analyzers/Orchestration/GuidOrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/GuidOrchestrationAnalyzer.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.DurableTask.Analyzers.Orchestration;
+
+/// <summary>
+/// Analyzer that reports a warning when Guid.NewGuid() is used in an orchestration method.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class GuidOrchestrationAnalyzer : OrchestrationAnalyzer
+{
+    /// <summary>
+    /// Diagnostic ID supported for the analyzer.
+    /// </summary>
+    internal const string DiagnosticId = "DURABLE0002";
+
+    static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.GuidOrchestrationAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+    static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.GuidOrchestrationAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        AnalyzersCategories.Orchestration,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    /// <inheritdoc/>
+    protected override void RegisterAdditionalCompilationStartAction(CompilationStartAnalysisContext context, OrchestrationAnalysisResult orchestrationAnalysisResult)
+    {
+        var knownSymbols = new KnownTypeSymbols(context.Compilation);
+
+        if (knownSymbols.GuidType == null)
+        {
+            return;
+        }
+
+        ConcurrentBag<(ISymbol Symbol, IInvocationOperation Invocation)> guidUsage = [];
+
+        context.RegisterOperationAction(
+            ctx =>
+        {
+            ctx.CancellationToken.ThrowIfCancellationRequested();
+
+            IInvocationOperation invocation = (IInvocationOperation)ctx.Operation;
+
+            if (!invocation.TargetMethod.ContainingType.Equals(knownSymbols.GuidType, SymbolEqualityComparer.Default))
+            {
+                return;
+            }
+
+            if (invocation.TargetMethod.Name is nameof(Guid.NewGuid))
+            {
+                ISymbol method = ctx.ContainingSymbol;
+                guidUsage.Add((method, invocation));
+            }
+        },
+            OperationKind.Invocation);
+
+        // compare whether the found Guid usages occur in methods invoked by orchestrations
+        context.RegisterCompilationEndAction(ctx =>
+        {
+            foreach ((ISymbol symbol, IInvocationOperation operation) in guidUsage)
+            {
+                if (symbol is IMethodSymbol method)
+                {
+                    if (orchestrationAnalysisResult.OrchestrationsByMethod.TryGetValue(method, out ConcurrentBag<AnalyzedOrchestration> orchestrations))
+                    {
+                        string methodName = symbol.Name;
+                        string invocationName = operation.TargetMethod.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat);
+                        string orchestrationNames = string.Join(", ", orchestrations.Select(o => o.Name).OrderBy(n => n));
+
+                        // e.g.: "The method 'Method1' uses 'Guid.NewGuid()' that may cause non-deterministic behavior when invoked from orchestration 'MyOrchestrator'"
+                        ctx.ReportDiagnostic(Rule, operation, methodName, invocationName, orchestrationNames);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -123,4 +123,10 @@
   <data name="DateTimeOrchestrationAnalyzerTitle" xml:space="preserve">
     <value>System.DateTime calls must be deterministic inside an orchestration</value>
   </data>
+  <data name="GuidOrchestrationAnalyzerMessageFormat" xml:space="preserve">
+    <value>The method '{0}' uses '{1}' that may cause non-deterministic behavior when invoked from orchestration '{2}'</value>
+  </data>
+  <data name="GuidOrchestrationAnalyzerTitle" xml:space="preserve">
+    <value>System.Guid calls must be deterministic inside an orchestration</value>
+  </data>
 </root>

--- a/test/Analyzers.Tests/Orchestration/GuidOrchestrationAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Orchestration/GuidOrchestrationAnalyzerTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.DurableTask.Analyzers.Orchestration;
+
+using VerifyCS = Microsoft.DurableTask.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Microsoft.DurableTask.Analyzers.Orchestration.GuidOrchestrationAnalyzer>;
+
+namespace Microsoft.DurableTask.Analyzers.Tests.Orchestration;
+
+public class GuidOrchestrationAnalyzerTests
+{
+    [Fact]
+    public async Task EmptyCodeWithSymbolsAvailableHasNoDiag()
+    {
+        string code = @"";
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionOrchestrationUsingNewGuidHasDiag()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+[Function(""Run"")]
+Guid Method([OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    return {|#0:Guid.NewGuid()|};
+}
+");
+
+        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("Method", "Guid.NewGuid()", "Run");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task TaskOrchestratorUsingNewGuidHasDiag()
+    {
+        string code = Wrapper.WrapTaskOrchestrator(@"
+public class MyOrchestrator : TaskOrchestrator<string, Guid>
+{
+    public override Task<Guid> RunAsync(TaskOrchestrationContext context, string input)
+    {
+        return Task.FromResult({|#0:Guid.NewGuid()|});
+    }
+}
+");
+
+        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("RunAsync", "Guid.NewGuid()", "MyOrchestrator");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task FuncOrchestratorUsingNewGuidHasDiag()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", context =>
+{
+    return {|#0:Guid.NewGuid()|};
+});
+");
+
+        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("Main", "Guid.NewGuid()", "HelloSequence");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    static DiagnosticResult BuildDiagnostic()
+    {
+        return VerifyCS.Diagnostic(GuidOrchestrationAnalyzer.DiagnosticId);
+    }
+}


### PR DESCRIPTION
This analyzer produces the diagnostic DURABLE0002, is the equivalent of [DF0102](https://github.com/Azure/azure-functions-durable-extension/blob/cf9f4c228d9d6dd7b8d2ac3f3abb38415f7d6e11/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/GuidAnalyzer.cs#L14) in the in-proc version of the analyzer. It looks for usages of `Guid.NewGuid()` in orchestrations (and their method invocations).