### PR TITLE
using a visitor to decouple the orchestrations discovery from analysis

### DIFF
--- a/src/Analyzers/KnownTypeSymbols.cs
+++ b/src/Analyzers/KnownTypeSymbols.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DurableTask.Analyzers;
 /// <see href="https://github.com/dotnet/runtime/blob/2a846acb1a92e811427babe3ff3f047f98c5df02/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs">System.Text.Json.SourceGeneration</see> source code.
 /// Lazy initialization is used to avoid the the initialization of all types during class construction, since not all symbols are used by all analyzers.
 /// </summary>
-sealed class KnownTypeSymbols(Compilation compilation)
+public sealed class KnownTypeSymbols(Compilation compilation)
 {
     readonly Compilation compilation = compilation;
 

--- a/src/Analyzers/Orchestration/DateTimeOrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/DateTimeOrchestrationAnalyzer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.DurableTask.Analyzers.Orchestration.DateTimeOrchestrationAnalyzer;
 
 namespace Microsoft.DurableTask.Analyzers.Orchestration;
 
@@ -13,7 +13,7 @@ namespace Microsoft.DurableTask.Analyzers.Orchestration;
 /// Analyzer that reports a warning when a non-deterministic DateTime property is used in an orchestration method.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class DateTimeOrchestrationAnalyzer : OrchestrationAnalyzer
+public sealed class DateTimeOrchestrationAnalyzer : OrchestrationAnalyzer<DateTimeOrchestrationVisitor>
 {
     /// <summary>
     /// Diagnostic ID supported for the analyzer.
@@ -34,54 +34,44 @@ public sealed class DateTimeOrchestrationAnalyzer : OrchestrationAnalyzer
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
-    /// <inheritdoc/>
-    protected override void RegisterAdditionalCompilationStartAction(CompilationStartAnalysisContext context, OrchestrationAnalysisResult orchestrationAnalysisResult)
+    /// <summary>
+    /// Visitor that inspects the method body for DateTime properties.
+    /// </summary>
+    public sealed class DateTimeOrchestrationVisitor : MethodProbeOrchestrationVisitor
     {
-        INamedTypeSymbol systemDateTimeSymbol = context.Compilation.GetSpecialType(SpecialType.System_DateTime);
+        INamedTypeSymbol systemDateTimeSymbol = null!;
 
-        // stores the symbols (such as methods) and the DateTime references used in them
-        ConcurrentBag<(ISymbol Symbol, IPropertyReferenceOperation Operation)> dateTimeUsage = [];
-
-        // search for usages of DateTime.Now, DateTime.UtcNow, DateTime.Today and store them
-        context.RegisterOperationAction(
-            ctx =>
+        /// <inheritdoc/>
+        public override bool Initialize()
         {
-            ctx.CancellationToken.ThrowIfCancellationRequested();
+            this.systemDateTimeSymbol = this.Compilation.GetSpecialType(SpecialType.System_DateTime);
+            return true;
+        }
 
-            var operation = (IPropertyReferenceOperation)ctx.Operation;
-            IPropertySymbol property = operation.Property;
-
-            if (!property.ContainingSymbol.Equals(systemDateTimeSymbol, SymbolEqualityComparer.Default))
+        /// <inheritdoc/>
+        protected override void VisitMethod(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+        {
+            IOperation? methodOperation = semanticModel.GetOperation(methodSyntax);
+            if (methodOperation is null)
             {
                 return;
             }
 
-            if (property.Name is nameof(DateTime.Now) or nameof(DateTime.UtcNow) or nameof(DateTime.Today))
+            foreach (IPropertyReferenceOperation operation in methodOperation.Descendants().OfType<IPropertyReferenceOperation>())
             {
-                ISymbol method = ctx.ContainingSymbol;
-                dateTimeUsage.Add((method, operation));
-            }
-        },
-            OperationKind.PropertyReference);
+                IPropertySymbol property = operation.Property;
 
-        // compare whether the found DateTime usages occur in methods invoked by orchestrations
-        context.RegisterCompilationEndAction(ctx =>
-        {
-            foreach ((ISymbol symbol, IPropertyReferenceOperation operation) in dateTimeUsage)
-            {
-                if (symbol is IMethodSymbol method)
+                if (!property.ContainingSymbol.Equals(this.systemDateTimeSymbol, SymbolEqualityComparer.Default))
                 {
-                    if (orchestrationAnalysisResult.OrchestrationsByMethod.TryGetValue(method, out ConcurrentBag<AnalyzedOrchestration> orchestrations))
-                    {
-                        string methodName = symbol.Name;
-                        string dateTimePropertyName = operation.Property.ToString();
-                        string orchestrationNames = string.Join(", ", orchestrations.Select(o => o.Name).OrderBy(n => n));
+                    return;
+                }
 
-                        // e.g.: "The method 'Method1' uses 'System.Date.Now' that may cause non-deterministic behavior when invoked from orchestration 'MyOrchestrator'"
-                        ctx.ReportDiagnostic(Rule, operation, methodName, dateTimePropertyName, orchestrationNames);
-                    }
+                if (property.Name is nameof(DateTime.Now) or nameof(DateTime.UtcNow) or nameof(DateTime.Today))
+                {
+                    // e.g.: "The method 'Method1' uses 'System.Date.Now' that may cause non-deterministic behavior when invoked from orchestration 'MyOrchestrator'"
+                    reportDiagnostic(RoslynExtensions.BuildDiagnostic(Rule, operation.Syntax, methodSymbol.Name, property.ToString(), orchestrationName));
                 }
             }
-        });
+        }
     }
 }

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -205,7 +205,11 @@ public abstract class OrchestrationAnalyzer<TOrchestrationVisitor> : DiagnosticA
 }
 
 /// <summary>
-/// Base class for visitors that analyze orchestrations.
+/// An Orchestration Visitor allows a concrete implementation of an analyzer to visit different types of orchestrations,
+/// such as Durable Functions, TaskOrchestrator, ITaskOrchestrator, and OrchestratorFunc.
+/// It provides a set of methods that can be overridden to inspect different types of orchestrations.
+/// Besides, it provides a method to initialize the visitor members, checking for available symbols and
+/// return whether the concrete implementation visitor should continue running and perform its analysis.
 /// </summary>
 public abstract class OrchestrationVisitor
 {

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -214,7 +214,7 @@ public abstract class OrchestrationAnalyzer<TOrchestrationVisitor> : DiagnosticA
 public abstract class OrchestrationVisitor
 {
     /// <summary>
-    /// Gets the compilation adquired from analyzer context.
+    /// Gets the Compilation instance acquired from the analyzer context, including syntax trees, semantic models, and other information.
     /// </summary>
     protected Compilation Compilation { get; private set; } = null!;
 

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -11,90 +11,6 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.DurableTask.Analyzers.Orchestration;
 
 /// <summary>
-/// Base class for visitors that analyze orchestrations.
-/// </summary>
-public abstract class OrchestrationVisitor
-{
-    /// <summary>
-    /// Gets the compilation adquired from analyzer context.
-    /// </summary>
-    protected Compilation Compilation { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the set of well-known type symbols.
-    /// </summary>
-    protected KnownTypeSymbols KnownTypeSymbols { get; private set; } = null!;
-
-    /// <summary>
-    /// Initializes the visitor members and returns whether the concrete implementation visitor was initialized.
-    /// </summary>
-    /// <param name="compilation">The compilation acquired from analyzer context.</param>
-    /// <param name="knownTypeSymbols">The set of well-known type symbols instance.</param>
-    /// <returns>True if the analyzer can continue; false otherwise.</returns>
-    public bool Initialize(Compilation compilation, KnownTypeSymbols knownTypeSymbols)
-    {
-        this.Compilation = compilation;
-        this.KnownTypeSymbols = knownTypeSymbols;
-
-        return this.Initialize();
-    }
-
-    /// <summary>
-    /// Initializes a visitor concrete implementation instance and returns whether the analysis should continue.
-    /// </summary>
-    /// <returns>True if the analyzer can continue; false otherwise.</returns>
-    public virtual bool Initialize() => true;
-
-    /// <summary>
-    /// Visits a Durable Function orchestration.
-    /// </summary>
-    /// <param name="semanticModel">Semantic Model.</param>
-    /// <param name="methodSyntax">Method Syntax Node.</param>
-    /// <param name="methodSymbol">Method Symbol.</param>
-    /// <param name="orchestrationName">Durable Function name.</param>
-    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
-    public virtual void VisitDurableFunction(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
-    {
-    }
-
-    /// <summary>
-    /// Visits a TaskOrchestrator&lt;T1,T2&gt; orchestration.
-    /// </summary>
-    /// <param name="semanticModel">Semantic Model.</param>
-    /// <param name="methodSyntax">Method Syntax Node.</param>
-    /// <param name="methodSymbol">Method Symbol.</param>
-    /// <param name="orchestrationName">Class name.</param>
-    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
-    public virtual void VisitTaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
-    {
-    }
-
-    /// <summary>
-    /// Visits an ITaskOrchestrator orchestration.
-    /// </summary>
-    /// <param name="semanticModel">Semantic Model.</param>
-    /// <param name="methodSyntax">Method Syntax Node.</param>
-    /// <param name="methodSymbol">Method Symbol.</param>
-    /// <param name="orchestrationName">Class name.</param>
-    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
-    public virtual void VisitITaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
-    {
-    }
-
-    /// <summary>
-    /// Visits an Orchestrator Func orchestration.
-    /// </summary>
-    /// <param name="semanticModel">Semantic Model.</param>
-    /// <param name="methodSyntax">Method Syntax Node.</param>
-    /// <param name="methodSymbol">Method Symbol.</param>
-    /// <param name="orchestrationName">Class name.</param>
-    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
-    public virtual void VisitFuncOrchestrator(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
-    {
-    }
-}
-
-/// <summary>
 /// Base class for analyzers that analyze orchestrations.
 /// </summary>
 /// <typeparam name="TOrchestrationVisitor">Orchestration Visitor to be used during Orchestrations discovery.</typeparam>
@@ -285,6 +201,90 @@ public abstract class OrchestrationAnalyzer<TOrchestrationVisitor> : DiagnosticA
             },
                 OperationKind.Invocation);
         });
+    }
+}
+
+/// <summary>
+/// Base class for visitors that analyze orchestrations.
+/// </summary>
+public abstract class OrchestrationVisitor
+{
+    /// <summary>
+    /// Gets the compilation adquired from analyzer context.
+    /// </summary>
+    protected Compilation Compilation { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the set of well-known type symbols.
+    /// </summary>
+    protected KnownTypeSymbols KnownTypeSymbols { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes the visitor members and returns whether the concrete implementation visitor was initialized.
+    /// </summary>
+    /// <param name="compilation">The compilation acquired from analyzer context.</param>
+    /// <param name="knownTypeSymbols">The set of well-known type symbols instance.</param>
+    /// <returns>True if the analyzer can continue; false otherwise.</returns>
+    public bool Initialize(Compilation compilation, KnownTypeSymbols knownTypeSymbols)
+    {
+        this.Compilation = compilation;
+        this.KnownTypeSymbols = knownTypeSymbols;
+
+        return this.Initialize();
+    }
+
+    /// <summary>
+    /// Initializes a visitor concrete implementation instance and returns whether the analysis should continue.
+    /// </summary>
+    /// <returns>True if the analyzer can continue; false otherwise.</returns>
+    public virtual bool Initialize() => true;
+
+    /// <summary>
+    /// Visits a Durable Function orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Durable Function name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitDurableFunction(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits a TaskOrchestrator&lt;T1,T2&gt; orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitTaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits an ITaskOrchestrator orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitITaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits an Orchestrator Func orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitFuncOrchestrator(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
     }
 }
 

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -28,7 +28,7 @@ public abstract class OrchestrationVisitor
     /// <summary>
     /// Initializes the visitor members and returns whether the concrete implementation visitor was initialized.
     /// </summary>
-    /// <param name="compilation">The compilation adquired from analyzer context.</param>
+    /// <param name="compilation">The compilation acquired from analyzer context.</param>
     /// <param name="knownTypeSymbols">The set of well-known type symbols instance.</param>
     /// <returns>True if the analyzer can continue; false otherwise.</returns>
     public bool Initialize(Compilation compilation, KnownTypeSymbols knownTypeSymbols)

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -11,9 +11,94 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.DurableTask.Analyzers.Orchestration;
 
 /// <summary>
+/// Base class for visitors that analyze orchestrations.
+/// </summary>
+public abstract class OrchestrationVisitor
+{
+    /// <summary>
+    /// Gets the compilation adquired from analyzer context.
+    /// </summary>
+    protected Compilation Compilation { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the set of well-known type symbols.
+    /// </summary>
+    protected KnownTypeSymbols KnownTypeSymbols { get; private set; } = null!;
+
+    /// <summary>
+    /// Initializes the visitor members and returns whether the concrete implementation visitor was initialized.
+    /// </summary>
+    /// <param name="compilation">The compilation adquired from analyzer context.</param>
+    /// <param name="knownTypeSymbols">The set of well-known type symbols instance.</param>
+    /// <returns>True if the analyzer can continue; false otherwise.</returns>
+    public bool Initialize(Compilation compilation, KnownTypeSymbols knownTypeSymbols)
+    {
+        this.Compilation = compilation;
+        this.KnownTypeSymbols = knownTypeSymbols;
+
+        return this.Initialize();
+    }
+
+    /// <summary>
+    /// Initializes a visitor concrete implementation instance and returns whether the analysis should continue.
+    /// </summary>
+    /// <returns>True if the analyzer can continue; false otherwise.</returns>
+    public virtual bool Initialize() => true;
+
+    /// <summary>
+    /// Visits a Durable Function orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Durable Function name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitDurableFunction(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits a TaskOrchestrator&lt;T1,T2&gt; orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitTaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits an ITaskOrchestrator orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitITaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+
+    /// <summary>
+    /// Visits an Orchestrator Func orchestration.
+    /// </summary>
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Class name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    public virtual void VisitFuncOrchestrator(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
+}
+
+/// <summary>
 /// Base class for analyzers that analyze orchestrations.
 /// </summary>
-public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
+/// <typeparam name="TOrchestrationVisitor">Orchestration Visitor to be used during Orchestrations discovery.</typeparam>
+public abstract class OrchestrationAnalyzer<TOrchestrationVisitor> : DiagnosticAnalyzer where TOrchestrationVisitor : OrchestrationVisitor, new()
 {
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -41,7 +126,11 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            OrchestrationAnalysisResult result = new();
+            TOrchestrationVisitor visitor = new();
+            if (!visitor.Initialize(context.Compilation, knownSymbols))
+            {
+                return;
+            }
 
             // look for Durable Functions Orchestrations
             context.RegisterSyntaxNodeAction(
@@ -64,10 +153,9 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                AnalyzedOrchestration orchestration = new(functionName);
                 var rootMethodSyntax = (MethodDeclarationSyntax)ctx.Node;
 
-                FindInvokedMethods(ctx.SemanticModel, rootMethodSyntax, methodSymbol, orchestration, result);
+                visitor.VisitDurableFunction(ctx.SemanticModel, rootMethodSyntax, methodSymbol, functionName, ctx.ReportDiagnostic);
             },
                 SyntaxKind.MethodDeclaration);
 
@@ -94,12 +182,12 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                AnalyzedOrchestration orchestration = new(classSymbol.Name);
+                string functionName = classSymbol.Name;
 
                 IEnumerable<MethodDeclarationSyntax> methodSyntaxes = methodSymbol.GetSyntaxNodes();
                 foreach (MethodDeclarationSyntax rootMethodSyntax in methodSyntaxes)
                 {
-                    FindInvokedMethods(ctx.SemanticModel, rootMethodSyntax, methodSymbol, orchestration, result);
+                    visitor.VisitTaskOrchestrator(ctx.SemanticModel, rootMethodSyntax, methodSymbol, functionName, ctx.ReportDiagnostic);
                 }
             },
                 SyntaxKind.ClassDeclaration);
@@ -127,12 +215,12 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                AnalyzedOrchestration orchestration = new(classSymbol.Name);
+                string functionName = classSymbol.Name;
 
                 IEnumerable<MethodDeclarationSyntax> methodSyntaxes = methodSymbol.GetSyntaxNodes();
                 foreach (MethodDeclarationSyntax rootMethodSyntax in methodSyntaxes)
                 {
-                    FindInvokedMethods(ctx.SemanticModel, rootMethodSyntax, methodSymbol, orchestration, result);
+                    visitor.VisitITaskOrchestrator(ctx.SemanticModel, rootMethodSyntax, methodSymbol, functionName, ctx.ReportDiagnostic);
                 }
             },
                 SyntaxKind.ClassDeclaration);
@@ -166,21 +254,24 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
 
                 // obtains the method symbol from the delegate creation operation
                 IMethodSymbol? methodSymbol = null;
+                SyntaxNode? methodSyntax = null;
                 switch (delegateCreationOperation.Target)
                 {
                     case IAnonymousFunctionOperation lambdaOperation:
                         // use the containing symbol of the lambda (e.g. the class declaring it) as the method symbol
                         methodSymbol = ctx.ContainingSymbol as IMethodSymbol;
+                        methodSyntax = delegateCreationOperation.Syntax;
                         break;
                     case IMethodReferenceOperation methodReferenceOperation:
                         // use the method reference as the method symbol
                         methodSymbol = methodReferenceOperation.Method;
+                        methodSyntax = methodReferenceOperation.Method.DeclaringSyntaxReferences.First().GetSyntax();
                         break;
                     default:
                         break;
                 }
 
-                if (methodSymbol == null)
+                if (methodSymbol == null || methodSyntax == null)
                 {
                     return;
                 }
@@ -190,39 +281,66 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
                 Optional<object?> name = nameArgument.GetConstantValueFromAttribute(ctx.Operation.SemanticModel!, ctx.CancellationToken);
                 string orchestrationName = name.Value?.ToString() ?? methodSymbol.Name;
 
-                AnalyzedOrchestration orchestration = new(orchestrationName);
-
-                SyntaxNode funcRootSyntax = delegateCreationOperation.Syntax;
-
-                FindInvokedMethods(ctx.Operation.SemanticModel!, funcRootSyntax, methodSymbol, orchestration, result);
+                visitor.VisitFuncOrchestrator(ctx.Operation.SemanticModel!, methodSyntax, methodSymbol, orchestrationName, ctx.ReportDiagnostic);
             },
                 OperationKind.Invocation);
-
-            // allows concrete implementations to register specific actions/analysis and then check if they happen in any of the orchestration methods
-            this.RegisterAdditionalCompilationStartAction(context, result);
         });
+    }
+}
+
+/// <summary>
+/// Visitor that recursively inspects the methods invoked by an orchestration root method.
+/// </summary>
+public class MethodProbeOrchestrationVisitor : OrchestrationVisitor
+{
+    readonly ConcurrentDictionary<IMethodSymbol, ConcurrentBag<string>> orchestrationsByMethod = new(SymbolEqualityComparer.Default);
+
+    /// <inheritdoc/>
+    public override void VisitDurableFunction(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+        this.FindInvokedMethods(semanticModel, methodSyntax, methodSymbol, orchestrationName, reportDiagnostic);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitTaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+        this.FindInvokedMethods(semanticModel, methodSyntax, methodSymbol, orchestrationName, reportDiagnostic);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitITaskOrchestrator(SemanticModel semanticModel, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+        this.FindInvokedMethods(semanticModel, methodSyntax, methodSymbol, orchestrationName, reportDiagnostic);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitFuncOrchestrator(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+        this.FindInvokedMethods(semanticModel, methodSyntax, methodSymbol, orchestrationName, reportDiagnostic);
     }
 
     /// <summary>
-    /// Register additional actions to be executed after the compilation has started.
-    /// It is expected from a concrete implementation of <see cref="OrchestrationAnalyzer"/> to register a
-    /// <see cref="CompilationStartAnalysisContext.RegisterCompilationEndAction"/>
-    /// and then compare that to any discovered violations happened in any of the symbols in <paramref name="orchestrationAnalysisResult"/>.
+    /// Visits a method independent of the orchestration type.
     /// </summary>
-    /// <param name="context">Context originally provided by <see cref="AnalysisContext.RegisterCompilationAction"/>.</param>
-    /// <param name="orchestrationAnalysisResult">Collection of symbols referenced by orchestrations.</param>
-    protected abstract void RegisterAdditionalCompilationStartAction(CompilationStartAnalysisContext context, OrchestrationAnalysisResult orchestrationAnalysisResult);
+    /// <param name="semanticModel">Semantic Model.</param>
+    /// <param name="methodSyntax">Method Syntax Node.</param>
+    /// <param name="methodSymbol">Method Symbol.</param>
+    /// <param name="orchestrationName">Orchestration name.</param>
+    /// <param name="reportDiagnostic">Function that can be used to report diagnostics.</param>
+    protected virtual void VisitMethod(SemanticModel semanticModel, SyntaxNode methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+    {
+    }
 
     // Recursively find all methods invoked by the orchestration root method and call the appropriate visitor method
-    static void FindInvokedMethods(
+    void FindInvokedMethods(
         SemanticModel semanticModel,
         SyntaxNode callerSyntax,
         IMethodSymbol callerSymbol,
-        AnalyzedOrchestration rootOrchestration,
-        OrchestrationAnalysisResult result)
+        string rootOrchestration,
+        Action<Diagnostic> reportDiagnostic)
     {
         // add the visited method to the list of orchestrations
-        ConcurrentBag<AnalyzedOrchestration> orchestrations = result.OrchestrationsByMethod.GetOrAdd(callerSymbol, []);
+        ConcurrentBag<string> orchestrations = this.orchestrationsByMethod.GetOrAdd(callerSymbol, []);
         if (orchestrations.Contains(rootOrchestration))
         {
             // previously tracked method, leave to avoid infinite recursion
@@ -230,6 +348,9 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
         }
 
         orchestrations.Add(rootOrchestration);
+
+        // allow derived visitors to inspect methods independent of the specific orchestration type:
+        this.VisitMethod(semanticModel, callerSyntax, callerSymbol, rootOrchestration, reportDiagnostic);
 
         foreach (InvocationExpressionSyntax invocationSyntax in callerSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
@@ -249,39 +370,8 @@ public abstract class OrchestrationAnalyzer : DiagnosticAnalyzer
             IEnumerable<MethodDeclarationSyntax> calleeSyntaxes = calleeMethodSymbol.GetSyntaxNodes();
             foreach (MethodDeclarationSyntax calleeSyntax in calleeSyntaxes)
             {
-                FindInvokedMethods(semanticModel, calleeSyntax, calleeMethodSymbol, rootOrchestration, result);
+                this.FindInvokedMethods(semanticModel, calleeSyntax, calleeMethodSymbol, rootOrchestration, reportDiagnostic);
             }
         }
-    }
-
-    /// <summary>
-    /// Data structure to store the result of the orchestration methods analysis.
-    /// </summary>
-    protected readonly struct OrchestrationAnalysisResult
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrchestrationAnalysisResult"/> struct.
-        /// </summary>
-        public OrchestrationAnalysisResult()
-        {
-            this.OrchestrationsByMethod = new(SymbolEqualityComparer.Default);
-        }
-
-        /// <summary>
-        /// Gets the orchestrations that invokes/reaches a given method.
-        /// </summary>
-        public ConcurrentDictionary<IMethodSymbol, ConcurrentBag<AnalyzedOrchestration>> OrchestrationsByMethod { get; }
-    }
-
-    /// <summary>
-    /// Data structure to store the orchestration data.
-    /// </summary>
-    /// <param name="name">Name of the orchestration.</param>
-    protected readonly struct AnalyzedOrchestration(string name)
-    {
-        /// <summary>
-        /// Gets the name of the orchestration.
-        /// </summary>
-        public string Name { get; } = name;
     }
 }

--- a/src/Analyzers/RoslynExtensions.cs
+++ b/src/Analyzers/RoslynExtensions.cs
@@ -110,18 +110,50 @@ static class RoslynExtensions
     }
 
     /// <summary>
-    /// Reports a diagnostic for a given operation.
+    /// Compares a method symbol with a type symbol and a method name.
     /// </summary>
-    /// <param name="ctx">Context for a compilation action.</param>
-    /// <param name="descriptor">Diagnostic Descriptor to be reported.</param>
-    /// <param name="operation">Operation which the location will be extracted.</param>
-    /// <param name="messageArgs">Diagnostic message arguments to be reported.</param>
-    public static void ReportDiagnostic(this CompilationAnalysisContext ctx, DiagnosticDescriptor descriptor, IOperation operation, params string[] messageArgs)
+    /// <param name="methodSymbol">The method symbol to compare.</param>
+    /// <param name="typeSymbol">The expected type symbol which the method symbol should be contained.</param>
+    /// <param name="methodName">The expected method name.</param>
+    /// <returns>True if the method symbol is contained in the type symbol and has the method name, false otherwise.</returns>
+    public static bool IsEqualTo(this IMethodSymbol methodSymbol, INamedTypeSymbol? typeSymbol, string methodName)
     {
-        ctx.ReportDiagnostic(BuildDiagnostic(descriptor, operation.Syntax, messageArgs));
+        return methodSymbol.ContainingType.Equals(typeSymbol, SymbolEqualityComparer.Default) &&
+            methodSymbol.Name.Equals(methodName, StringComparison.Ordinal);
     }
 
-    static Diagnostic BuildDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params string[] messageArgs)
+    /// <summary>
+    /// Builds a diagnostic based on a symbol location.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic Descriptor to be reported.</param>
+    /// <param name="symbol">Symbol that has the violation. Its location will be extracted and added to the diagnostic.</param>
+    /// <param name="messageArgs">Diagnostic message arguments to be reported.</param>
+    /// <returns>The Diagnostic based on the symbol location.</returns>
+    public static Diagnostic BuildDiagnostic(DiagnosticDescriptor descriptor, ISymbol symbol, params string[] messageArgs)
+    {
+        return BuildDiagnostic(descriptor, symbol.DeclaringSyntaxReferences.First().GetSyntax(), messageArgs);
+    }
+
+    /// <summary>
+    /// Builds a diagnostic based on an operation location.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic Descriptor to be reported.</param>
+    /// <param name="operation">Operation that has the violation. Its location will be extracted and added to the diagnostic.</param>
+    /// <param name="messageArgs">Diagnostic message arguments to be reported.</param>
+    /// <returns>The Diagnostic based on the operation location.</returns>
+    public static Diagnostic BuildDiagnostic(DiagnosticDescriptor descriptor, IOperation operation, params string[] messageArgs)
+    {
+        return BuildDiagnostic(descriptor, operation.Syntax, messageArgs);
+    }
+
+    /// <summary>
+    /// Builds a diagnostic based on a syntax node location.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic Descriptor to be reported.</param>
+    /// <param name="syntaxNode">Syntax Node that has the violation. Its location will be extracted and added to the diagnostic.</param>
+    /// <param name="messageArgs">Diagnostic message arguments to be reported.</param>
+    /// <returns>The Diagnostic based on the syntax node location.</returns>
+    public static Diagnostic BuildDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode syntaxNode, params string[] messageArgs)
     {
         return Diagnostic.Create(descriptor, syntaxNode.GetLocation(), messageArgs);
     }

--- a/test/Analyzers.Tests/Orchestration/DateTimeOrchestrationAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Orchestration/DateTimeOrchestrationAnalyzerTests.cs
@@ -78,9 +78,10 @@ long Level2() => Level3();
 long Level3() => {|#0:DateTime.Now|}.Ticks;
 ");
 
-        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("Level3", "System.DateTime.Now", "Run1, Run2");
+        DiagnosticResult expected1 = BuildDiagnostic().WithLocation(0).WithArguments("Level3", "System.DateTime.Now", "Run1");
+        DiagnosticResult expected2 = BuildDiagnostic().WithLocation(0).WithArguments("Level3", "System.DateTime.Now", "Run2");
 
-        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected1, expected2);
     }
 
     [Fact]


### PR DESCRIPTION
I realized that `OrchestrationAnalyzer` base class was performing two responsibilities:

1. Discovering orchestrations
2. Recursively finding methods invocations

While this was ok for the first 3 concrete implementations (DateTime, Guid and Delay analyzers), I couldn't properly use the base class to inspect discovered orchestrations and inspect their method signatures (when looking for Cancellation Tokens, checking bindings, etc).
The discovery behavior was tightly coupled to the recursive method invocation finding. 

In order to decouple it, I propose we introduce `OrchestrationVisitor`, a class that will contain the logic to be executed after an orchestration is found. `MethodProbeOrchestrationVisitor` represents the existent recursive method invocation behavior it had before.

This abstraction greatly simplified the code, allowing us to even remove the usage of concurrent collections and compilation end actions. 