### PR TITLE
Function orchestration bindings analyzer

### DIFF
--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,6 +9,7 @@ DURABLE0001 | Orchestration | Warning | DateTimeOrchestrationAnalyzer
 DURABLE0002 | Orchestration | Warning | GuidOrchestrationAnalyzer
 DURABLE0003 | Orchestration | Warning | DelayOrchestrationAnalyzer
 DURABLE0007 | Orchestration | Warning | CancellationTokenOrchestrationAnalyzer
+DURABLE0008 | Orchestration | Warning | OtherBindingsOrchestrationAnalyzer
 DURABLE1001 | Attribute Binding | Error | OrchestrationTriggerBindingAnalyzer
 DURABLE1002 | Attribute Binding | Error | DurableClientBindingAnalyzer
 DURABLE1003 | Attribute Binding | Error | EntityTriggerBindingAnalyzer

--- a/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
+++ b/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
@@ -36,7 +36,7 @@ class OtherBindingsOrchestrationAnalyzer : OrchestrationAnalyzer<OtherBindingsOr
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     /// <summary>
-    /// Visitor that inspects Durable Functions's method signatures for parameters binding other than OrchestrationTrigger.
+    /// Visitor that inspects Durable Functions' method signatures for parameters binding other than OrchestrationTrigger.
     /// </summary>
     public sealed class OtherBindingsOrchestrationOrchestrationVisitor : OrchestrationVisitor
     {

--- a/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
+++ b/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.DurableTask.Analyzers.Orchestration;
+using static Microsoft.DurableTask.Analyzers.Functions.Orchestration.OtherBindingsOrchestrationAnalyzer;
+
+namespace Microsoft.DurableTask.Analyzers.Functions.Orchestration;
+
+/// <summary>
+/// Analyzer that reports a warning when a Durable Function Orchestration has parameters bindings other than OrchestrationTrigger.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+class OtherBindingsOrchestrationAnalyzer : OrchestrationAnalyzer<OtherBindingsOrchestrationOrchestrationVisitor>
+{
+    /// <summary>
+    /// Diagnostic ID supported for the analyzer.
+    /// </summary>
+    public const string DiagnosticId = "DURABLE0008";
+
+    static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.OtherBindingsOrchestrationAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+    static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.OtherBindingsOrchestrationAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        AnalyzersCategories.Orchestration,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    /// <summary>
+    /// Visitor that inspects Durable Functions's method signatures for parameters binding other than OrchestrationTrigger.
+    /// </summary>
+    public sealed class OtherBindingsOrchestrationOrchestrationVisitor : OrchestrationVisitor
+    {
+        ImmutableArray<INamedTypeSymbol> bannedBindings;
+
+        /// <inheritdoc/>
+        public override bool Initialize()
+        {
+            List<INamedTypeSymbol> candidateSymbols = [
+                this.KnownTypeSymbols.DurableClientAttribute,
+                this.KnownTypeSymbols.EntityTriggerAttribute,
+                ];
+
+            // filter out null values, since some of them may not be available during compilation
+            this.bannedBindings = candidateSymbols.Where(s => s != null).ToImmutableArray();
+
+            return this.bannedBindings.Length > 0;
+        }
+
+        /// <inheritdoc/>
+        public override void VisitDurableFunction(SemanticModel sm, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol, string orchestrationName, Action<Diagnostic> reportDiagnostic)
+        {
+            foreach (IParameterSymbol parameter in methodSymbol.Parameters)
+            {
+                IEnumerable<INamedTypeSymbol?> attributesSymbols = parameter.GetAttributes().Select(att => att.AttributeClass);
+
+                if (attributesSymbols.Any(att => att != null && this.bannedBindings.Contains(att, SymbolEqualityComparer.Default)))
+                {
+                    reportDiagnostic(RoslynExtensions.BuildDiagnostic(Rule, parameter, orchestrationName));
+                }
+            }
+        }
+    }
+}

--- a/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
+++ b/src/Analyzers/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
@@ -45,13 +45,13 @@ class OtherBindingsOrchestrationAnalyzer : OrchestrationAnalyzer<OtherBindingsOr
         /// <inheritdoc/>
         public override bool Initialize()
         {
-            List<INamedTypeSymbol> candidateSymbols = [
+            List<INamedTypeSymbol?> candidateSymbols = [
                 this.KnownTypeSymbols.DurableClientAttribute,
                 this.KnownTypeSymbols.EntityTriggerAttribute,
                 ];
 
             // filter out null values, since some of them may not be available during compilation
-            this.bannedBindings = candidateSymbols.Where(s => s != null).ToImmutableArray();
+            this.bannedBindings = candidateSymbols.Where(s => s != null).ToImmutableArray()!;
 
             return this.bannedBindings.Length > 0;
         }

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -159,4 +159,10 @@
   <data name="CancellationTokenOrchestrationAnalyzerTitle" xml:space="preserve">
     <value>CancellationToken should not be used as an orchestrator function parameter</value>
   </data>
+  <data name="OtherBindingsOrchestrationAnalyzerMessageFormat" xml:space="preserve">
+    <value>Orchestration '{0}' is using multiple bindings</value>
+  </data>
+  <data name="OtherBindingsOrchestrationAnalyzerTitle" xml:space="preserve">
+    <value>OrchestrationTrigger methods must not use any other bindings</value>
+  </data>
 </root>

--- a/test/Analyzers.Tests/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
+++ b/test/Analyzers.Tests/Functions/Orchestration/OtherBindingsOrchestrationAnalyzer.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.DurableTask.Analyzers.Functions.Orchestration;
+using VerifyCS = Microsoft.DurableTask.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Microsoft.DurableTask.Analyzers.Functions.Orchestration.OtherBindingsOrchestrationAnalyzer>;
+
+namespace Microsoft.DurableTask.Analyzers.Tests.Functions.Orchestration;
+
+public class OtherBindingsOrchestrationAnalyzerTests
+{
+    [Fact]
+    public async Task EmptyCodeHasNoDiag()
+    {
+        string code = @"";
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionOrchestrationWithNoBannedBindingHasNoDiag()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+[Function(""Run"")]
+void Method([OrchestrationTrigger] TaskOrchestrationContext context)
+{
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionOrchestrationUsingDurableClientHasDiag()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+[Function(""Run"")]
+void Method([OrchestrationTrigger] TaskOrchestrationContext context, {|#0:[DurableClient] DurableTaskClient client|})
+{
+}
+");
+
+        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("Run");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task DurableFunctionOrchestrationUsingEntityTriggerHasDiag()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+[Function(""Run"")]
+void Method([OrchestrationTrigger] TaskOrchestrationContext context, {|#0:[EntityTrigger] TaskEntityDispatcher dispatcher|})
+{
+}
+");
+
+        DiagnosticResult expected = BuildDiagnostic().WithLocation(0).WithArguments("Run");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+
+    [Fact]
+    public async Task DurableFunctionOrchestrationUsingMultipleBannedBindingsHasDiag()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+[Function(""Run"")]
+void Method([OrchestrationTrigger] TaskOrchestrationContext context,
+{|#0:[EntityTrigger] TaskEntityDispatcher dispatcher|},
+{|#1:[DurableClient] DurableTaskClient client|})
+{
+}
+");
+
+        DiagnosticResult[] expected = Enumerable.Range(0, 2).Select(
+            i => BuildDiagnostic().WithLocation(i).WithArguments("Run")).ToArray();
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    static DiagnosticResult BuildDiagnostic()
+    {
+        return VerifyCS.Diagnostic(OtherBindingsOrchestrationAnalyzer.DiagnosticId);
+    }
+}


### PR DESCRIPTION
Adds an analyzer that reports a warning when a Durable Function orchestration has parameters bindings other than `OrchestrationTrigger` (such as `DurableClient` or `EntityTrigger`).