### PR TITLE
fix analyzer exception 'Syntax node is not within syntax tree'

### DIFF
--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -316,7 +316,12 @@ public class MethodProbeOrchestrationVisitor : OrchestrationVisitor
             IEnumerable<MethodDeclarationSyntax> calleeSyntaxes = calleeMethodSymbol.GetSyntaxNodes();
             foreach (MethodDeclarationSyntax calleeSyntax in calleeSyntaxes)
             {
-                this.FindInvokedMethods(semanticModel, calleeSyntax, calleeMethodSymbol, rootOrchestration, reportDiagnostic);
+                // Since the syntax tree of the callee method might be different from the caller method, we need to get the correct semantic model,
+                // avoiding the exception 'Syntax node is not within syntax tree'.
+                SemanticModel sm = semanticModel.SyntaxTree == calleeSyntax.SyntaxTree ?
+                    semanticModel : semanticModel.Compilation.GetSemanticModel(calleeSyntax.SyntaxTree);
+
+                this.FindInvokedMethods(sm, calleeSyntax, calleeMethodSymbol, rootOrchestration, reportDiagnostic);
             }
         }
     }

--- a/test/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.Durable.cs
+++ b/test/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.Durable.cs
@@ -13,6 +13,11 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
     public static async Task VerifyDurableTaskAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
+        await VerifyDurableTaskAnalyzerAsync(source, null, expected);
+    }
+
+    public static async Task VerifyDurableTaskAnalyzerAsync(string source, Action<Test>? configureTest = null, params DiagnosticResult[] expected)
+    {
         Test test = new()
         {
             TestCode = source,
@@ -23,6 +28,8 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
         };
 
         test.ExpectedDiagnostics.AddRange(expected);
+
+        configureTest?.Invoke(test);
 
         await test.RunAsync(CancellationToken.None);
     }


### PR DESCRIPTION
During orchestration method analysis, since the syntax tree of the callee method might be different from the caller method, we need to get the correct semantic model when they differ.