### PR TITLE
Increase patch ver to 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## <version>
+## v1.2.3
 
 ### Microsoft.DurableTask.Client
 
@@ -9,6 +9,7 @@
 ### Microsoft.DurableTask.Abstractions
 
 - Enable inner exception detail propagation in `TaskFailureDetails` ([#290](https://github.com/microsoft/durabletask-dotnet/pull/290))
+- Microsoft.Azure.DurableTask.Core dependency increased to `2.17.0`
 
 ## v1.2.2
 

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.2.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Abstractions/RELEASENOTES.md
+++ b/src/Abstractions/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- Microsoft.Azure.DurableTask.Core dependency increased to `2.17.0`


### PR DESCRIPTION
As titled. Routine PR for v1.2.3 release.

DurableTask.Core v2.16.2 -> v2.17.0 and this has been updated in PR #290 