### PR TITLE
Matching Input and Output Type Activity Analyzer

### DIFF
--- a/src/Analyzers/Activities/MatchingInputOutputTypeActivityAnalyzer.cs
+++ b/src/Analyzers/Activities/MatchingInputOutputTypeActivityAnalyzer.cs
@@ -1,0 +1,352 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.DurableTask.Analyzers.Activities;
+
+/// <summary>
+/// Analyzer that checks for mismatches between the input and output types of Activities invocations and their definitions.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MatchingInputOutputTypeActivityAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The diagnostic ID for the diagnostic that reports when the input argument type of an Activity invocation does not match the input parameter type of the Activity definition.
+    /// </summary>
+    public const string InputArgumentTypeMismatchDiagnosticId = "DURABLE2001";
+
+    /// <summary>
+    /// The diagnostic ID for the diagnostic that reports when the output argument type of an Activity invocation does not match the return type of the Activity definition.
+    /// </summary>
+    public const string OutputArgumentTypeMismatchDiagnosticId = "DURABLE2002";
+
+    static readonly LocalizableString InputArgumentTypeMismatchTitle = new LocalizableResourceString(nameof(Resources.InputArgumentTypeMismatchAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+    static readonly LocalizableString InputArgumentTypeMismatchMessageFormat = new LocalizableResourceString(nameof(Resources.InputArgumentTypeMismatchAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    static readonly LocalizableString OutputArgumentTypeMismatchTitle = new LocalizableResourceString(nameof(Resources.OutputArgumentTypeMismatchAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+    static readonly LocalizableString OutputArgumentTypeMismatchMessageFormat = new LocalizableResourceString(nameof(Resources.OutputArgumentTypeMismatchAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    static readonly DiagnosticDescriptor InputArgumentTypeMismatchRule = new(
+        InputArgumentTypeMismatchDiagnosticId,
+        InputArgumentTypeMismatchTitle,
+        InputArgumentTypeMismatchMessageFormat,
+        AnalyzersCategories.Activity,
+        DiagnosticSeverity.Warning,
+        customTags: [WellKnownDiagnosticTags.CompilationEnd],
+        isEnabledByDefault: true);
+
+    static readonly DiagnosticDescriptor OutputArgumentTypeMismatchRule = new(
+        OutputArgumentTypeMismatchDiagnosticId,
+        OutputArgumentTypeMismatchTitle,
+        OutputArgumentTypeMismatchMessageFormat,
+        AnalyzersCategories.Activity,
+        DiagnosticSeverity.Warning,
+        customTags: [WellKnownDiagnosticTags.CompilationEnd],
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [InputArgumentTypeMismatchRule, OutputArgumentTypeMismatchRule];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            KnownTypeSymbols knownSymbols = new(context.Compilation);
+
+            if (knownSymbols.ActivityTriggerAttribute == null || knownSymbols.FunctionNameAttribute == null ||
+                knownSymbols.DurableTaskRegistry == null || knownSymbols.TaskActivityBase == null ||
+                knownSymbols.Task == null || knownSymbols.TaskT == null)
+            {
+                // symbols not available in this compilation, skip analysis
+                return;
+            }
+
+            IMethodSymbol taskActivityRunAsync = knownSymbols.TaskActivityBase.GetMembers("RunAsync").OfType<IMethodSymbol>().Single();
+            INamedTypeSymbol voidSymbol = context.Compilation.GetSpecialType(SpecialType.System_Void);
+
+            // Search for Activity invocations
+            ConcurrentBag<ActivityInvocation> invocations = [];
+            context.RegisterOperationAction(
+                ctx =>
+                {
+                    ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (ctx.Operation is not IInvocationOperation invocationOperation)
+                    {
+                        return;
+                    }
+
+                    IMethodSymbol targetMethod = invocationOperation.TargetMethod;
+                    if (!targetMethod.IsEqualTo(knownSymbols.TaskOrchestrationContext, "CallActivityAsync"))
+                    {
+                        return;
+                    }
+
+                    Debug.Assert(invocationOperation.Arguments.Length is 2 or 3, "CallActivityAsync has 2 or 3 parameters");
+                    Debug.Assert(invocationOperation.Arguments[0].Parameter?.Name == "name", "First parameter of CallActivityAsync is name");
+                    IArgumentOperation activityNameArgumentOperation = invocationOperation.Arguments[0];
+
+                    // extracts the constant value from the argument (e.g.: it can be a nameof, string literal or const field)
+                    Optional<object?> constant = ctx.Operation.SemanticModel!.GetConstantValue(activityNameArgumentOperation.Value.Syntax);
+                    if (!constant.HasValue)
+                    {
+                        // not a constant value, we cannot correlate this invocation to an existent activity in compile time
+                        return;
+                    }
+
+                    string activityName = constant.Value!.ToString();
+
+                    // Try to extract the input argument from the invocation
+                    ITypeSymbol? inputType = null;
+                    IArgumentOperation? inputArgumentParameter = invocationOperation.Arguments.SingleOrDefault(a => a.Parameter?.Name == "input");
+                    if (inputArgumentParameter != null && inputArgumentParameter.ArgumentKind != ArgumentKind.DefaultValue)
+                    {
+                        // if the argument is not null or a default value provided by the compiler, get the type before the conversion to object
+                        TypeInfo inputTypeInfo = ctx.Operation.SemanticModel.GetTypeInfo(inputArgumentParameter.Value.Syntax, ctx.CancellationToken);
+                        inputType = inputTypeInfo.Type;
+                    }
+
+                    // If the CallActivityAsync<TOutput> method is used, we extract the output type from TypeArguments
+                    ITypeSymbol? outputType = targetMethod.OriginalDefinition.Arity == 1 && targetMethod.TypeArguments.Length == 1 ?
+                        targetMethod.TypeArguments[0] : null;
+
+                    invocations.Add(new ActivityInvocation()
+                    {
+                        Name = activityName,
+                        InputType = inputType,
+                        OutputType = outputType,
+                        InvocationSyntaxNode = invocationOperation.Syntax,
+                    });
+                },
+                OperationKind.Invocation);
+
+            // Search for Durable Functions Activities definitions
+            ConcurrentBag<ActivityDefinition> activities = [];
+            context.RegisterSymbolAction(
+                ctx =>
+                {
+                    ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (ctx.Symbol is not IMethodSymbol methodSymbol)
+                    {
+                        return;
+                    }
+
+                    if (!methodSymbol.ContainsAttributeInAnyMethodArguments(knownSymbols.ActivityTriggerAttribute))
+                    {
+                        return;
+                    }
+
+                    if (!methodSymbol.TryGetSingleValueFromAttribute(knownSymbols.FunctionNameAttribute, out string functionName))
+                    {
+                        return;
+                    }
+
+                    IParameterSymbol? inputParam = methodSymbol.Parameters.SingleOrDefault(
+                        p => p.GetAttributes().Any(a => knownSymbols.ActivityTriggerAttribute.Equals(a.AttributeClass, SymbolEqualityComparer.Default)));
+                    if (inputParam == null)
+                    {
+                        // Azure Functions Activity methods must have an input parameter
+                        return;
+                    }
+
+                    ITypeSymbol? inputType = inputParam.Type;
+
+                    ITypeSymbol? outputType = methodSymbol.ReturnType;
+                    if (outputType.Equals(voidSymbol, SymbolEqualityComparer.Default) ||
+                        outputType.Equals(knownSymbols.Task, SymbolEqualityComparer.Default))
+                    {
+                        // If the method returns void or Task, we consider it as having no output
+                        outputType = null;
+                    }
+                    else if (outputType.OriginalDefinition.Equals(knownSymbols.TaskT, SymbolEqualityComparer.Default) &&
+                             outputType is INamedTypeSymbol outputNamedType)
+                    {
+                        // If the method is Task<T>, we consider T as the output type
+                        Debug.Assert(outputNamedType.TypeArguments.Length == 1, "Task<T> has one type argument");
+                        outputType = outputNamedType.TypeArguments[0];
+                    }
+
+                    activities.Add(new ActivityDefinition()
+                    {
+                        Name = functionName,
+                        InputType = inputType,
+                        OutputType = outputType,
+                    });
+                },
+                SymbolKind.Method);
+
+            // Search for TaskActivity<TInput, TOutput> definitions
+            context.RegisterSyntaxNodeAction(
+                ctx =>
+                {
+                    ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (ctx.ContainingSymbol is not INamedTypeSymbol classSymbol)
+                    {
+                        return;
+                    }
+
+                    if (classSymbol.IsAbstract)
+                    {
+                        return;
+                    }
+
+                    // Check if the class has a method that overrides TaskActivity.RunAsync
+                    IMethodSymbol? methodOverridingRunAsync = null;
+                    INamedTypeSymbol? baseType = classSymbol; // start from the current class
+                    while (baseType != null)
+                    {
+                        foreach (IMethodSymbol method in baseType.GetMembers().OfType<IMethodSymbol>())
+                        {
+                            if (SymbolEqualityComparer.Default.Equals(method.OverriddenMethod?.OriginalDefinition, taskActivityRunAsync))
+                            {
+                                methodOverridingRunAsync = method.OverriddenMethod;
+                                break;
+                            }
+                        }
+
+                        baseType = baseType.BaseType;
+                    }
+
+                    // TaskActivity.RunAsync method not found in the class hierarchy
+                    if (methodOverridingRunAsync == null)
+                    {
+                        return;
+                    }
+
+                    // gets the closed constructed TaskActivity<TInput, TOutput> type, so we can extract TInput and TOutput
+                    INamedTypeSymbol closedConstructedTaskActivity = methodOverridingRunAsync.ContainingType;
+                    Debug.Assert(closedConstructedTaskActivity.TypeArguments.Length == 2, "TaskActivity has TInput and TOutput");
+
+                    activities.Add(new ActivityDefinition()
+                    {
+                        Name = classSymbol.Name,
+                        InputType = closedConstructedTaskActivity.TypeArguments[0],
+                        OutputType = closedConstructedTaskActivity.TypeArguments[1],
+                    });
+                },
+                SyntaxKind.ClassDeclaration);
+
+            // Search for Func/Action activities directly registered through DurableTaskRegistry
+            context.RegisterOperationAction(
+                ctx =>
+                {
+                    ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (ctx.Operation is not IInvocationOperation invocation)
+                    {
+                        return;
+                    }
+
+                    if (!SymbolEqualityComparer.Default.Equals(invocation.Type, knownSymbols.DurableTaskRegistry))
+                    {
+                        return;
+                    }
+
+                    // there are 8 AddActivityFunc overloads, with combinations of Activity Name, TInput and TOutput
+                    if (invocation.TargetMethod.Name != "AddActivityFunc")
+                    {
+                        return;
+                    }
+
+                    // all overloads have the parameter 'name', either as an Action or a Func
+                    IArgumentOperation? activityNameArgumentOperation = invocation.Arguments.SingleOrDefault(a => a.Parameter!.Name == "name");
+                    if (activityNameArgumentOperation == null)
+                    {
+                        return;
+                    }
+
+                    // extracts the constant value from the argument (e.g.: it can be a nameof, string literal or const field)
+                    Optional<object?> constant = ctx.Operation.SemanticModel!.GetConstantValue(activityNameArgumentOperation.Value.Syntax);
+                    if (!constant.HasValue)
+                    {
+                        // not a constant value, we cannot correlate this invocation to an existent activity in compile time
+                        return;
+                    }
+
+                    string activityName = constant.Value!.ToString();
+
+                    ITypeSymbol? inputType = invocation.TargetMethod.GetTypeArgumentByParameterName("TInput");
+                    ITypeSymbol? outputType = invocation.TargetMethod.GetTypeArgumentByParameterName("TOutput");
+
+                    activities.Add(new ActivityDefinition()
+                    {
+                        Name = activityName,
+                        InputType = inputType,
+                        OutputType = outputType,
+                    });
+                },
+                OperationKind.Invocation);
+
+            // At the end of the compilation, we correlate the invocations with the definitions
+            context.RegisterCompilationEndAction(ctx =>
+            {
+                // index by name for faster lookup
+                Dictionary<string, ActivityDefinition> activitiesByName = activities.ToDictionary(a => a.Name, a => a);
+
+                foreach (ActivityInvocation invocation in invocations)
+                {
+                    if (!activitiesByName.TryGetValue(invocation.Name, out ActivityDefinition activity))
+                    {
+                        // Activity not found, we cannot correlate this invocation to an existent activity in compile time.
+                        // We could add a diagnostic here if we want to enforce that, but while we experiment with this analyzer,
+                        // we should prevent false positives.
+                        continue;
+                    }
+
+                    if (!SymbolEqualityComparer.Default.Equals(invocation.InputType, activity.InputType))
+                    {
+                        string actual = invocation.InputType?.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat) ?? "none";
+                        string expected = activity.InputType?.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat) ?? "none";
+                        string activityName = invocation.Name;
+
+                        Diagnostic diagnostic = RoslynExtensions.BuildDiagnostic(InputArgumentTypeMismatchRule, invocation.InvocationSyntaxNode, actual, expected, activityName);
+                        ctx.ReportDiagnostic(diagnostic);
+                    }
+
+                    if (!SymbolEqualityComparer.Default.Equals(invocation.OutputType, activity.OutputType))
+                    {
+                        string actual = invocation.OutputType?.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat) ?? "none";
+                        string expected = activity.OutputType?.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat) ?? "none";
+                        string activityName = invocation.Name;
+
+                        Diagnostic diagnostic = RoslynExtensions.BuildDiagnostic(OutputArgumentTypeMismatchRule, invocation.InvocationSyntaxNode, actual, expected, activityName);
+                        ctx.ReportDiagnostic(diagnostic);
+                    }
+                }
+            });
+        });
+    }
+
+    struct ActivityInvocation
+    {
+        public string Name { get; set; }
+
+        public ITypeSymbol? InputType { get; set; }
+
+        public ITypeSymbol? OutputType { get; set; }
+
+        public SyntaxNode InvocationSyntaxNode { get; set; }
+    }
+
+    struct ActivityDefinition
+    {
+        public string Name { get; set; }
+
+        public ITypeSymbol? InputType { get; set; }
+
+        public ITypeSymbol? OutputType { get; set; }
+    }
+}

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -16,3 +16,5 @@ DURABLE0008 | Orchestration | Warning | OtherBindingsOrchestrationAnalyzer
 DURABLE1001 | Attribute Binding | Error | OrchestrationTriggerBindingAnalyzer
 DURABLE1002 | Attribute Binding | Error | DurableClientBindingAnalyzer
 DURABLE1003 | Attribute Binding | Error | EntityTriggerBindingAnalyzer
+DURABLE2001 | Activity | Warning | MatchingInputOutputTypeActivityAnalyzer
+DURABLE2002 | Activity | Warning | MatchingInputOutputTypeActivityAnalyzer

--- a/src/Analyzers/AnalyzersCategories.cs
+++ b/src/Analyzers/AnalyzersCategories.cs
@@ -17,4 +17,9 @@ static class AnalyzersCategories
     /// The category for the attribute binding related analyzers.
     /// </summary>
     public const string AttributeBinding = "Attribute Binding";
+
+    /// <summary>
+    /// The category for the activity related analyzers.
+    /// </summary>
+    public const string Activity = "Activity";
 }

--- a/src/Analyzers/KnownTypeSymbols.Durable.cs
+++ b/src/Analyzers/KnownTypeSymbols.Durable.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DurableTask.Analyzers;
 public sealed partial class KnownTypeSymbols
 {
     INamedTypeSymbol? taskOrchestratorInterface;
+    INamedTypeSymbol? taskActivityBase;
     INamedTypeSymbol? durableTaskRegistry;
     INamedTypeSymbol? taskOrchestrationContext;
     INamedTypeSymbol? durableTaskClient;
@@ -22,6 +23,11 @@ public sealed partial class KnownTypeSymbols
     /// Gets an ITaskOrchestrator type symbol.
     /// </summary>
     public INamedTypeSymbol? TaskOrchestratorInterface => this.GetOrResolveFullyQualifiedType("Microsoft.DurableTask.ITaskOrchestrator", ref this.taskOrchestratorInterface);
+
+    /// <summary>
+    /// Gets a TaskActivity&lt;TInput,TOutput&gt; type symbol.
+    /// </summary>
+    public INamedTypeSymbol? TaskActivityBase => this.GetOrResolveFullyQualifiedType("Microsoft.DurableTask.TaskActivity`2", ref this.taskActivityBase);
 
     /// <summary>
     /// Gets a DurableTaskRegistry type symbol.

--- a/src/Analyzers/KnownTypeSymbols.Functions.cs
+++ b/src/Analyzers/KnownTypeSymbols.Functions.cs
@@ -16,6 +16,7 @@ public sealed partial class KnownTypeSymbols
     INamedTypeSymbol? functionOrchestrationAttribute;
     INamedTypeSymbol? functionNameAttribute;
     INamedTypeSymbol? durableClientAttribute;
+    INamedTypeSymbol? activityTriggerAttribute;
     INamedTypeSymbol? entityTriggerAttribute;
     INamedTypeSymbol? taskEntityDispatcher;
 
@@ -33,6 +34,11 @@ public sealed partial class KnownTypeSymbols
     /// Gets a DurableClientAttribute type symbol.
     /// </summary>
     public INamedTypeSymbol? DurableClientAttribute => this.GetOrResolveFullyQualifiedType("Microsoft.Azure.Functions.Worker.DurableClientAttribute", ref this.durableClientAttribute);
+
+    /// <summary>
+    /// Gets an ActivityTriggerAttribute type symbol.
+    /// </summary>
+    public INamedTypeSymbol? ActivityTriggerAttribute => this.GetOrResolveFullyQualifiedType("Microsoft.Azure.Functions.Worker.ActivityTriggerAttribute", ref this.activityTriggerAttribute);
 
     /// <summary>
     /// Gets an EntityTriggerAttribute type symbol.

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -183,4 +183,16 @@
   <data name="ThreadTaskOrchestrationAnalyzerTitle" xml:space="preserve">
     <value>Thread and Task calls must be deterministic inside an orchestrator function</value>
   </data>
+  <data name="InputArgumentTypeMismatchAnalyzerMessageFormat" xml:space="preserve">
+    <value>CallActivityAsync is passing the incorrect type '{0}' instead of '{1}' to the activity function '{2}'</value>
+  </data>
+  <data name="InputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
+    <value>Activity function calls use the wrong argument type</value>
+  </data>
+  <data name="OutputArgumentTypeMismatchAnalyzerMessageFormat" xml:space="preserve">
+    <value>CallActivityAsync is expecting the return type '{0}' that does not match the return type '{1}' of the activity function '{2}'</value>
+  </data>
+  <data name="OutputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
+    <value>Activity function call return type doesn't match function definition return type</value>
+  </data>
 </root>

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -193,6 +193,6 @@
     <value>CallActivityAsync is expecting the return type '{0}' and that does not match the return type '{1}' of the activity function '{2}'</value>
   </data>
   <data name="OutputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
-    <value>Activity function call return type doesn't match function definition return type</value>
+    <value>Activity function call return type doesn't match the function definition return type</value>
   </data>
 </root>

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -190,7 +190,7 @@
     <value>Activity function calls use the wrong argument type</value>
   </data>
   <data name="OutputArgumentTypeMismatchAnalyzerMessageFormat" xml:space="preserve">
-    <value>CallActivityAsync is expecting the return type '{0}' that does not match the return type '{1}' of the activity function '{2}'</value>
+    <value>CallActivityAsync is expecting the return type '{0}' and that does not match the return type '{1}' of the activity function '{2}'</value>
   </data>
   <data name="OutputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
     <value>Activity function call return type doesn't match function definition return type</value>

--- a/src/Analyzers/RoslynExtensions.cs
+++ b/src/Analyzers/RoslynExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -83,6 +84,28 @@ static class RoslynExtensions
     {
         IEnumerable<IMethodSymbol> methods = typeSymbol.GetMembers(methodSymbol.Name).OfType<IMethodSymbol>();
         return methods.FirstOrDefault(m => m.OverriddenMethod != null && m.OverriddenMethod.OriginalDefinition.Equals(methodSymbol, SymbolEqualityComparer.Default));
+    }
+
+    /// <summary>
+    /// Gets the type argument of a method by its parameter name.
+    /// </summary>
+    /// <param name="method">Method symbol.</param>
+    /// <param name="parameterName">Type argument name.</param>
+    /// <returns>The type argument symbol.</returns>
+    public static ITypeSymbol? GetTypeArgumentByParameterName(this IMethodSymbol method, string parameterName)
+    {
+        (ITypeParameterSymbol param, int idx) = method.TypeParameters
+                                                        .Where(t => t.Name == parameterName)
+                                                        .Select((t, i) => (t, i))
+                                                        .SingleOrDefault();
+
+        if (param != null)
+        {
+            Debug.Assert(idx >= 0, "parameter index is not negative");
+            return method.TypeArguments[idx];
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/test/Analyzers.Tests/Activities/MatchingInputOutputTypeActivityAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Activities/MatchingInputOutputTypeActivityAnalyzerTests.cs
@@ -1,0 +1,419 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.DurableTask.Analyzers.Activities;
+using VerifyCS = Microsoft.DurableTask.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Microsoft.DurableTask.Analyzers.Activities.MatchingInputOutputTypeActivityAnalyzer>;
+
+namespace Microsoft.DurableTask.Analyzers.Tests.Activities;
+
+public class MatchingInputOutputTypeActivityAnalyzerTests
+{
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMatchingInputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await context.CallActivityAsync(nameof(SayHello), ""Tokyo"");
+}
+
+[Function(nameof(SayHello))]
+void SayHello([ActivityTrigger] string name)
+{
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMismatchedInputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await {|#0:context.CallActivityAsync(nameof(SayHello), 123456)|};
+}
+
+[Function(nameof(SayHello))]
+void SayHello([ActivityTrigger] string name)
+{
+}
+");
+        DiagnosticResult expected = BuildInputDiagnostic().WithLocation(0).WithArguments("int", "string", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMissingInputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await {|#0:context.CallActivityAsync(nameof(SayHello))|};
+}
+
+[Function(nameof(SayHello))]
+void SayHello([ActivityTrigger] string name)
+{
+}
+");
+        DiagnosticResult expected = BuildInputDiagnostic().WithLocation(0).WithArguments("none", "string", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMatchingOutputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    int output = await {|#0:context.CallActivityAsync<int>(nameof(SayHello), ""Tokyo"")|};
+}
+
+[Function(nameof(SayHello))]
+int SayHello([ActivityTrigger] string name)
+{
+    return 42;
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMatchingTaskTOutputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    int output = await {|#0:context.CallActivityAsync<int>(nameof(SayHello), ""Tokyo"")|};
+}
+
+[Function(nameof(SayHello))]
+Task<int> SayHello([ActivityTrigger] string name)
+{
+    return Task.FromResult(42);
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMatchingVoidOutputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await {|#0:context.CallActivityAsync(nameof(SayHello), ""Tokyo"")|};
+}
+
+[Function(nameof(SayHello))]
+void SayHello([ActivityTrigger] string name)
+{
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMatchingTaskOutputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await {|#0:context.CallActivityAsync(nameof(SayHello), ""Tokyo"")|};
+}
+
+[Function(nameof(SayHello))]
+Task SayHello([ActivityTrigger] string name)
+{
+    return Task.CompletedTask;
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task DurableFunctionActivityInvocationWithMismatchedOutputType()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    string output = await {|#0:context.CallActivityAsync<string>(nameof(SayHello), ""Tokyo"")|};
+}
+
+[Function(nameof(SayHello))]
+int SayHello([ActivityTrigger] string name)
+{
+    return 42;
+}
+");
+
+        DiagnosticResult expected = BuildOutputDiagnostic().WithLocation(0).WithArguments("string", "int", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+
+    [Fact]
+    public async Task TaskActivityInvocationWithMatchingInputTypeAndOutputType()
+    {
+        string code = Wrapper.WrapTaskOrchestrator(@"
+public class Caller {
+    async Task Method(TaskOrchestrationContext context)
+    {
+        await context.CallActivityAsync<string>(nameof(MyActivity), ""Tokyo"");
+    }
+}
+
+public class MyActivity : TaskActivity<string, string>
+{
+    public override Task<string> RunAsync(TaskActivityContext context, string cityName)
+    {
+        return Task.FromResult(cityName);
+    }
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task TaskActivityInvocationWithMismatchedInputType()
+    {
+        string code = Wrapper.WrapTaskOrchestrator(@"
+public class Caller {
+    async Task Method(TaskOrchestrationContext context)
+    {
+        await {|#0:context.CallActivityAsync<string>(nameof(MyActivity), ""Tokyo"")|};
+    }
+}
+
+public class MyActivity : TaskActivity<int, string>
+{
+    public override Task<string> RunAsync(TaskActivityContext context, int cityCode)
+    {
+        return Task.FromResult(cityCode.ToString());
+    }
+}
+");
+
+        DiagnosticResult expected = BuildInputDiagnostic().WithLocation(0).WithArguments("string", "int", "MyActivity");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task TaskActivityInvocationWithMismatchedOutputType()
+    {
+        string code = Wrapper.WrapTaskOrchestrator(@"
+public class Caller {
+    async Task Method(TaskOrchestrationContext context)
+    {
+        await {|#0:context.CallActivityAsync<string>(nameof(MyActivity), ""Tokyo"")|};
+    }
+}
+
+public class MyActivity : TaskActivity<string, int>
+{
+    public override Task<int> RunAsync(TaskActivityContext context, string city)
+    {
+        return Task.FromResult(city.Length);
+    }
+}
+");
+
+        DiagnosticResult expected = BuildOutputDiagnostic().WithLocation(0).WithArguments("string", "int", "MyActivity");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task TaskActivityInvocationWithOneTypeParameterDefinedInAbstractClass()
+    {
+        string code = Wrapper.WrapTaskOrchestrator(@"
+public class Caller {
+    async Task Method(TaskOrchestrationContext context)
+    {
+        await context.CallActivityAsync<int>(nameof(AnotherActivity), 5);
+    }
+}
+
+public class AnotherActivity : EchoActivity<int> { }
+
+public abstract class EchoActivity<T> : TaskActivity<T, T>
+{
+    public override Task<T> RunAsync(TaskActivityContext context, T input)
+    {
+        return Task.FromResult(input);
+    }
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMatchingInputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await context.CallActivityAsync(""SayHello"", ""Tokyo""));
+
+tasks.AddActivityFunc<string>(""SayHello"", (context, city) => { });
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMatchingNoInputTypeAndNoOutputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await context.CallActivityAsync(""SayHello""));
+
+tasks.AddActivityFunc(""SayHello"", (context) => { });
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMismatchedInputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await {|#0:context.CallActivityAsync(""SayHello"", 42)|});
+
+tasks.AddActivityFunc<string>(""SayHello"", (context, city) => { });
+");
+
+        DiagnosticResult expected = BuildInputDiagnostic().WithLocation(0).WithArguments("int", "string", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMismatchedNoInputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await {|#0:context.CallActivityAsync(""SayHello"", ""Tokyo"")|});
+
+tasks.AddActivityFunc(""SayHello"", (context) => { });
+");
+
+        DiagnosticResult expected = BuildInputDiagnostic().WithLocation(0).WithArguments("string", "none", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMatchingOutputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await context.CallActivityAsync<string>(""SayHello""));
+
+tasks.AddActivityFunc<string>(""SayHello"", (context) => ""hello"");
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMismatchedOutputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await {|#0:context.CallActivityAsync<int>(""SayHello"")|});
+
+tasks.AddActivityFunc<string>(""SayHello"", (context) => ""hello"");
+");
+
+        DiagnosticResult expected = BuildOutputDiagnostic().WithLocation(0).WithArguments("int", "string", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task LambdaActivityInvocationWithMismatchedNoOutputType()
+    {
+        string code = Wrapper.WrapFuncOrchestrator(@"
+tasks.AddOrchestratorFunc(""HelloSequence"", async context =>
+    await {|#0:context.CallActivityAsync<int>(""SayHello"")|});
+
+tasks.AddActivityFunc(""SayHello"", (context) => { });
+");
+
+        DiagnosticResult expected = BuildOutputDiagnostic().WithLocation(0).WithArguments("int", "none", "SayHello");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+
+    [Fact]
+    public async Task ActivityInvocationWithConstantNameIsDiscovered()
+    {
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+const string name = ""SayHello"";
+
+async Task Method(TaskOrchestrationContext context)
+{
+    // the ones containing the output mismatch diagnostic mean they were discovered
+    await {|#0:context.CallActivityAsync<string>(""SayHello"", ""Tokyo"")|};
+    await {|#1:context.CallActivityAsync<string>(nameof(SayHello), ""Tokyo"")|};
+    await {|#2:context.CallActivityAsync<string>(name, ""Tokyo"")|};
+
+    // not diagnostics here, because the name could not be determined (since it is not a constant)
+    string anotherName = ""SayHello"";
+    await context.CallActivityAsync<string>(anotherName, ""Tokyo"");
+}
+
+[Function(nameof(SayHello))]
+int SayHello([ActivityTrigger] string name) => 42;
+");
+
+        DiagnosticResult[] expected = Enumerable.Range(0, 3).Select(i =>
+            BuildOutputDiagnostic().WithLocation(i).WithArguments("string", "int", "SayHello")).ToArray();
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ActivityInvocationWithNonExistentActivity()
+    {
+        // When the Activity is not found, we cannot correlate this invocation to an existent activity in compile time
+        // or it is defined in another assembly. We could add a diagnostic here if we want to enforce that,
+        // but while we experiment with this analyzer, we will not report a diagnostic to prevent false positives.
+
+        string code = Wrapper.WrapDurableFunctionOrchestration(@"
+async Task Method(TaskOrchestrationContext context)
+{
+    await context.CallActivityAsync<string>(""ActivityNotFound"", ""Tokyo"");
+}
+");
+
+        await VerifyCS.VerifyDurableTaskAnalyzerAsync(code);
+    }
+
+
+    static DiagnosticResult BuildInputDiagnostic()
+    {
+        return VerifyCS.Diagnostic(MatchingInputOutputTypeActivityAnalyzer.InputArgumentTypeMismatchDiagnosticId);
+    }
+
+    static DiagnosticResult BuildOutputDiagnostic()
+    {
+        return VerifyCS.Diagnostic(MatchingInputOutputTypeActivityAnalyzer.OutputArgumentTypeMismatchDiagnosticId);
+    }
+}


### PR DESCRIPTION
This new analyzer will search for `TaskOrchestrationContext.CallActivityAsync` invocations and check if the provided input and output types matches the related Activity definition. The activity can be either an Azure Function activity, a Durable Task Activity or a Durable Task Func/Action. If there is a mismatch between the types, the analyzer reports `DURABLE2001` (input mismatch) or `DURABLE2002` (output mismatch).

The code uses activity name to correlate the invocations and their definitions, which must be constant in compile time. For instance, they can be defined using `nameof` operator, string `const` fields or locals, and string literals. If the invocation name can't be determined (because it is not constant a compile time), the code ignores the checking to avoid a false positive report.