### PR TITLE
Add optional cancellation tokens again in `DurableTaskClient`

### DIFF
--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -337,7 +337,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
     /// <inheritdoc cref="PurgeInstanceAsync(string, PurgeInstanceOptions, CancellationToken)"/>
-    public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation = default)
+    public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation)
         => this.PurgeInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>
@@ -377,7 +377,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     }
 
     /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, PurgeInstanceOptions, CancellationToken)"/>
-    public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation = default)
+    public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
         => this.PurgeAllInstancesAsync(filter, null, cancellation);
 
     /// <summary>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -377,7 +377,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     }
 
     /// <inheritdoc cref="PurgeAllInstancesAsync(PurgeInstancesFilter, PurgeInstanceOptions, CancellationToken)"/>
-    public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation)
+    public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation = default)
         => this.PurgeAllInstancesAsync(filter, null, cancellation);
 
     /// <summary>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -210,11 +210,11 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation = default)
+    public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
         => this.TerminateInstanceAsync(instanceId, null, cancellation);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation = default)
+    public virtual Task TerminateInstanceAsync(string instanceId, object? output = null, CancellationToken cancellation = default)
     {
         TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
         return this.TerminateInstanceAsync(instanceId, options, cancellation);

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -210,7 +210,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
-    public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
+    public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation = default)
         => this.TerminateInstanceAsync(instanceId, null, cancellation);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
@@ -337,7 +337,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null);
 
     /// <inheritdoc cref="PurgeInstanceAsync(string, PurgeInstanceOptions, CancellationToken)"/>
-    public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation)
+    public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation = default)
         => this.PurgeInstanceAsync(instanceId, null, cancellation);
 
     /// <summary>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -216,7 +216,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, object? output = null, CancellationToken cancellation = default)
     {
-        TerminateInstanceOptions? options = output is null ? null : new() { Output = output };
+        TerminateInstanceOptions? options = new() { Output = output };
         return this.TerminateInstanceAsync(instanceId, options, cancellation);
     }
 
@@ -252,7 +252,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// termination of the orchestration once enqueued.
     /// </param>
     /// <returns>A task that completes when the terminate message is enqueued.</returns>
-    public virtual Task TerminateInstanceAsync(string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+    public virtual Task TerminateInstanceAsync(string instanceId, TerminateInstanceOptions options, CancellationToken cancellation = default)
         => throw new NotSupportedException($"{this.GetType()} does not support orchestration termination.");
 
     /// <inheritdoc cref="SuspendInstanceAsync(string, string, CancellationToken)"/>

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -211,7 +211,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, CancellationToken cancellation)
-        => this.TerminateInstanceAsync(instanceId, null, cancellation);
+        => this.TerminateInstanceAsync(instanceId, output: null, cancellation);
 
     /// <inheritdoc cref="TerminateInstanceAsync(string, TerminateInstanceOptions, CancellationToken)"/>
     public virtual Task TerminateInstanceAsync(string instanceId, object? output = null, CancellationToken cancellation = default)


### PR DESCRIPTION
Between tags 1.1.1. and 1.2.0 (https://github.com/microsoft/durabletask-dotnet/compare/v1.1.1...v1.2.0#diff-c7a6ad429a79519f6c23e141c7d033c7066d66ef34af21302c877fbdd62171c7R373), we made several changes to `DurableTaskClient` that unfortunately changed regressed some behavior.

In particular, we made the following 3 changes:

| Before | After |
| -------| ------|
|     public virtual Task TerminateInstanceAsync(string instanceId, object? output = null, CancellationToken cancellation = default) |     public virtual Task TerminateInstanceAsync(string instanceId, object? output, CancellationToken cancellation = default)|
|     public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation = default) |     public virtual Task<PurgeResult> PurgeInstanceAsync(string instanceId, CancellationToken cancellation) |
|     public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation = default) |      public virtual Task<PurgeResult> PurgeAllInstancesAsync(PurgeInstancesFilter filter, CancellationToken cancellation) |

In other words, we made several previously "optional" parameters mandatory. This caused .NET to start dispatching **different** implementations for this method, which led to users seeing "method not supported" exceptions, as reported here: https://github.com/microsoft/durabletask-dotnet/issues/282#issuecomment-2114590648

This PR aims to bring back the original interfaces by making those parameters optional again, in hopes to restore the original method dispatch resolution.

_Still to be tested._