### PR TITLE
Attribute binding mismatching Roslyn code fixers

### DIFF
--- a/src/Analyzers/Analyzers.csproj
+++ b/src/Analyzers/Analyzers.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24165.2" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Analyzers/Functions/AttributeBinding/DurableClientBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/DurableClientBindingFixer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
+
+/// <summary>
+/// Code fixer for the <see cref="DurableClientBindingAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatchingAttributeBindingFixer))]
+[Shared]
+public sealed class DurableClientBindingFixer : MatchingAttributeBindingFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [DurableClientBindingAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public override string ExpectedType => "DurableTaskClient";
+}

--- a/src/Analyzers/Functions/AttributeBinding/EntityTriggerBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/EntityTriggerBindingFixer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
+
+/// <summary>
+/// Code fixer for the <see cref="EntityTriggerBindingAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatchingAttributeBindingFixer))]
+[Shared]
+public sealed class EntityTriggerBindingFixer : MatchingAttributeBindingFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [EntityTriggerBindingAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public override string ExpectedType => "TaskEntityDispatcher";
+}

--- a/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
@@ -44,7 +44,7 @@ public abstract class MatchingAttributeBindingFixer : CodeFixProvider
         // e.g: "Use 'TaskOrchestrationContext' instead of 'string'"
         string title = string.Format(
             CultureInfo.InvariantCulture,
-            Resources.MatchingAttributeBindingFixerTitle,
+            Resources.UseInsteadFixerTitle,
             this.ExpectedType,
             incorrectTypeSyntax.ToString());
 

--- a/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
+
+/// <summary>
+/// Base class for code fixers that fix the type of a parameter to match the expected type.
+/// </summary>
+public abstract class MatchingAttributeBindingFixer : CodeFixProvider
+{
+    /// <summary>
+    /// Gets the expected type to be used during the code fix.
+    /// </summary>
+    public abstract string ExpectedType { get; }
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+        if (root == null)
+        {
+            return;
+        }
+
+        // Find the parameter syntax node that is causing the diagnostic.
+        if (root.FindNode(context.Span) is not ParameterSyntax parameterSyntax)
+        {
+            return;
+        }
+
+        TypeSyntax? incorrectTypeSyntax = parameterSyntax.Type;
+        if (incorrectTypeSyntax == null)
+        {
+            return;
+        }
+
+        // e.g: "Use 'TaskOrchestrationContext' instead of 'string'"
+        string title = string.Format(
+            CultureInfo.InvariantCulture,
+            Resources.MatchingAttributeBindingFixerTitle,
+            this.ExpectedType,
+            incorrectTypeSyntax.ToString());
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: title,
+                createChangedDocument: _ => ReplaceMismatchedType(context.Document, root, incorrectTypeSyntax, this.ExpectedType),
+                equivalenceKey: title), // This key is used to prevent duplicate code fixes.
+            context.Diagnostics);
+    }
+
+    static Task<Document> ReplaceMismatchedType(Document document, SyntaxNode oldRoot, TypeSyntax incorrectTypeSyntax, string expectedType)
+    {
+        // Create the correct type syntax by using the identifier name provided by the derived class.
+        TypeSyntax correctTypeSyntax = SyntaxFactory.IdentifierName(expectedType);
+
+        // Replace the old local declaration with the new local declaration.
+        SyntaxNode newRoot = oldRoot.ReplaceNode(incorrectTypeSyntax, correctTypeSyntax);
+        Document newDocument = document.WithSyntaxRoot(newRoot);
+
+        return Task.FromResult(newDocument);
+    }
+}

--- a/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/MatchingAttributeBindingFixer.cs
@@ -21,6 +21,9 @@ public abstract class MatchingAttributeBindingFixer : CodeFixProvider
     public abstract string ExpectedType { get; }
 
     /// <inheritdoc/>
+    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);

--- a/src/Analyzers/Functions/AttributeBinding/OrchestrationTriggerBindingFixer.cs
+++ b/src/Analyzers/Functions/AttributeBinding/OrchestrationTriggerBindingFixer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
+
+/// <summary>
+/// Code fixer for the <see cref="OrchestrationTriggerBindingAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatchingAttributeBindingFixer))]
+[Shared]
+public sealed class OrchestrationTriggerBindingFixer : MatchingAttributeBindingFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [OrchestrationTriggerBindingAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public override string ExpectedType => "TaskOrchestrationContext";
+}

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -195,4 +195,7 @@
   <data name="OutputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
     <value>Activity function call return type doesn't match the function definition return type</value>
   </data>
+  <data name="MatchingAttributeBindingFixerTitle" xml:space="preserve">
+    <value>Use {0} instead of {1}</value>
+  </data>
 </root>

--- a/src/Analyzers/Resources.resx
+++ b/src/Analyzers/Resources.resx
@@ -195,7 +195,7 @@
   <data name="OutputArgumentTypeMismatchAnalyzerTitle" xml:space="preserve">
     <value>Activity function call return type doesn't match the function definition return type</value>
   </data>
-  <data name="MatchingAttributeBindingFixerTitle" xml:space="preserve">
-    <value>Use {0} instead of {1}</value>
+  <data name="UseInsteadFixerTitle" xml:space="preserve">
+    <value>Use '{0}' instead of '{1}'</value>
   </data>
 </root>

--- a/test/Analyzers.Tests/Functions/AttributeBinding/DurableClientBindingAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Functions/AttributeBinding/DurableClientBindingAnalyzerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
 
 namespace Microsoft.DurableTask.Analyzers.Tests.Functions.AttributeBinding;
 
-public class DurableClientBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<DurableClientBindingAnalyzer>
+public class DurableClientBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<DurableClientBindingAnalyzer, DurableClientBindingFixer>
 {
     protected override string ExpectedDiagnosticId => DurableClientBindingAnalyzer.DiagnosticId;
 

--- a/test/Analyzers.Tests/Functions/AttributeBinding/EntityTriggerBindingAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Functions/AttributeBinding/EntityTriggerBindingAnalyzerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
 
 namespace Microsoft.DurableTask.Analyzers.Tests.Functions.AttributeBinding;
 
-public class EntityTriggerBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<EntityTriggerBindingAnalyzer>
+public class EntityTriggerBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<EntityTriggerBindingAnalyzer, EntityTriggerBindingFixer>
 {
     protected override string ExpectedDiagnosticId => EntityTriggerBindingAnalyzer.DiagnosticId;
 

--- a/test/Analyzers.Tests/Functions/AttributeBinding/OrchestrationTriggerBindingAnalyzerTests.cs
+++ b/test/Analyzers.Tests/Functions/AttributeBinding/OrchestrationTriggerBindingAnalyzerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.DurableTask.Analyzers.Functions.AttributeBinding;
 
 namespace Microsoft.DurableTask.Analyzers.Tests.Functions.AttributeBinding;
 
-public class OrchestrationTriggerBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<OrchestrationTriggerBindingAnalyzer>
+public class OrchestrationTriggerBindingAnalyzerTests : MatchingAttributeBindingSpecificationTests<OrchestrationTriggerBindingAnalyzer, OrchestrationTriggerBindingFixer>
 {
     protected override string ExpectedDiagnosticId => OrchestrationTriggerBindingAnalyzer.DiagnosticId;
 

--- a/test/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.Durable.cs
+++ b/test/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier.Durable.cs
@@ -21,15 +21,7 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
         Test test = new()
         {
             TestCode = source,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60.AddPackages([
-                new PackageIdentity("Azure.Storage.Blobs", "12.17.0"),
-                new PackageIdentity("Azure.Storage.Queues", "12.17.0"),
-                new PackageIdentity("Azure.Data.Tables", "12.8.3"),
-                new PackageIdentity("Microsoft.Azure.Cosmos", "3.39.1"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.21.0"),
-                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.DurableTask", "1.1.1"),
-                new PackageIdentity("Microsoft.Data.SqlClient", "5.2.0"),
-                ]),
+            ReferenceAssemblies = References.CommonAssemblies,
         };
 
         test.ExpectedDiagnostics.AddRange(expected);

--- a/test/Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.Durable.cs
+++ b/test/Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.Durable.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.DurableTask.Analyzers.Tests.Verifiers;
+
+public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
+{
+    public static Task VerifyDurableTaskAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        return VerifyDurableTaskAnalyzerAsync(source, null, expected);
+    }
+
+    public static async Task VerifyDurableTaskAnalyzerAsync(string source, Action<Test>? configureTest = null, params DiagnosticResult[] expected)
+    {
+        await RunAsync(expected, new Test()
+        {
+            TestCode = source,
+        }, configureTest);
+    }
+
+    public static Task VerifyDurableTaskCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+    {
+        return VerifyDurableTaskCodeFixAsync(source, [expected], fixedSource);
+    }
+
+    public static async Task VerifyDurableTaskCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    {
+        await RunAsync(expected, new Test()
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+        });
+    }
+
+    static async Task RunAsync(DiagnosticResult[] expected, Test test, Action<Test>? configureTest = null)
+    {
+        test.ReferenceAssemblies = References.CommonAssemblies;
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        configureTest?.Invoke(test);
+
+        await test.RunAsync(CancellationToken.None);
+    }
+}

--- a/test/Analyzers.Tests/Verifiers/References.cs
+++ b/test/Analyzers.Tests/Verifiers/References.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.DurableTask.Analyzers.Tests.Verifiers;
+
+public static class References
+{
+    static readonly Lazy<ReferenceAssemblies> durableAssemblyReferences = new(() => BuildReferenceAssemblies());
+
+    public static ReferenceAssemblies CommonAssemblies => durableAssemblyReferences.Value;
+
+    static ReferenceAssemblies BuildReferenceAssemblies() => ReferenceAssemblies.Net.Net60.AddPackages([
+                new PackageIdentity("Azure.Storage.Blobs", "12.17.0"),
+                new PackageIdentity("Azure.Storage.Queues", "12.17.0"),
+                new PackageIdentity("Azure.Data.Tables", "12.8.3"),
+                new PackageIdentity("Microsoft.Azure.Cosmos", "3.39.1"),
+                new PackageIdentity("Microsoft.Azure.Functions.Worker", "1.21.0"),
+                new PackageIdentity("Microsoft.Azure.Functions.Worker.Extensions.DurableTask", "1.1.1"),
+                new PackageIdentity("Microsoft.Data.SqlClient", "5.2.0"),
+                ]);
+}


### PR DESCRIPTION
Introduces Roslyn code fixers for the attribute binding mismatching diagnostics.
They essentially change the wrong type for the expected type. The code fixers are for `TaskOrchestrationContext`, `TaskEntityDispatcher` and `DurableTaskClient`. Besides those 3 code fixers, I had to do some small refactoring to our test infrastructure to allow the fixers to be tested.