### PR TITLE
DateTime, Guid and Task Delay roslyn code fixers

### DIFF
--- a/src/Analyzers/Orchestration/DateTimeOrchestrationFixer.cs
+++ b/src/Analyzers/Orchestration/DateTimeOrchestrationFixer.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.DurableTask.Analyzers.Orchestration;
+
+/// <summary>
+/// Code fix provider for the <see cref="DateTimeOrchestrationAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DateTimeOrchestrationFixer))]
+[Shared]
+public sealed class DateTimeOrchestrationFixer : OrchestrationContextFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [DateTimeOrchestrationAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    protected override void RegisterCodeFixes(CodeFixContext context, OrchestrationCodeFixContext orchestrationContext)
+    {
+        // Parses the syntax node to see if it is a member access expression (e.g. DateTime.Now)
+        if (orchestrationContext.SyntaxNodeWithDiagnostic is not MemberAccessExpressionSyntax dateTimeExpression)
+        {
+            return;
+        }
+
+        // Gets the name of the TaskOrchestrationContext parameter (e.g. "context" or "ctx")
+        string contextParameterName = orchestrationContext.TaskOrchestrationContextSymbol.Name;
+
+        bool isDateTimeToday = dateTimeExpression.Name.ToString() == "Today";
+        string dateTimeTodaySuffix = isDateTimeToday ? ".Date" : string.Empty;
+        string recommendation = $"{contextParameterName}.CurrentUtcDateTime{dateTimeTodaySuffix}";
+
+        // e.g: "Use 'context.CurrentUtcDateTime' instead of 'DateTime.Now'"
+        // e.g: "Use 'context.CurrentUtcDateTime.Date' instead of 'DateTime.Today'"
+        string title = string.Format(
+            CultureInfo.InvariantCulture,
+            Resources.UseInsteadFixerTitle,
+            recommendation,
+            dateTimeExpression.ToString());
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: title,
+                createChangedDocument: c => ReplaceDateTime(context.Document, orchestrationContext.Root, dateTimeExpression, contextParameterName, isDateTimeToday),
+                equivalenceKey: title), // This key is used to prevent duplicate code fixes.
+            context.Diagnostics);
+    }
+
+    static Task<Document> ReplaceDateTime(Document document, SyntaxNode oldRoot, MemberAccessExpressionSyntax incorrectDateTimeSyntax, string contextParameterName, bool isDateTimeToday)
+    {
+        // Builds a 'context.CurrentUtcDateTime' syntax node
+        MemberAccessExpressionSyntax correctDateTimeSyntax =
+            MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                IdentifierName(contextParameterName),
+                IdentifierName("CurrentUtcDateTime"));
+
+        // If the original expression was DateTime.Today, we add ".Date" to the context expression.
+        if (isDateTimeToday)
+        {
+            correctDateTimeSyntax = MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                correctDateTimeSyntax,
+                IdentifierName("Date"));
+        }
+
+        // Replaces the old local declaration with the new local declaration.
+        SyntaxNode newRoot = oldRoot.ReplaceNode(incorrectDateTimeSyntax, correctDateTimeSyntax);
+        Document newDocument = document.WithSyntaxRoot(newRoot);
+
+        return Task.FromResult(newDocument);
+    }
+}

--- a/src/Analyzers/Orchestration/DelayOrchestrationFixer.cs
+++ b/src/Analyzers/Orchestration/DelayOrchestrationFixer.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.DurableTask.Analyzers.Orchestration;
+
+/// <summary>
+/// Code fix provider for the <see cref="DelayOrchestrationAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DelayOrchestrationFixer))]
+[Shared]
+public sealed class DelayOrchestrationFixer : OrchestrationContextFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [DelayOrchestrationAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    protected override void RegisterCodeFixes(CodeFixContext context, OrchestrationCodeFixContext orchestrationContext)
+    {
+        if (orchestrationContext.SyntaxNodeWithDiagnostic is not InvocationExpressionSyntax invocationExpressionsSyntax)
+        {
+            return;
+        }
+
+        if (orchestrationContext.SemanticModel.GetOperation(invocationExpressionsSyntax) is not IInvocationOperation invocationOperation)
+        {
+            return;
+        }
+
+        // Only fix Task.Delay(int[,CancellationToken]) or Task.Delay(TimeSpan[,CancellationToken]) invocations.
+        // For now, fixing Thread.Sleep(int) is not supported
+        if (!SymbolEqualityComparer.Default.Equals(invocationOperation.Type, orchestrationContext.KnownTypeSymbols.Task))
+        {
+            return;
+        }
+
+        Compilation compilation = orchestrationContext.SemanticModel.Compilation;
+        INamedTypeSymbol int32 = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        // Extracts the arguments from the Task.Delay invocation
+        IMethodSymbol taskDelaySymbol = invocationOperation.TargetMethod;
+        Debug.Assert(taskDelaySymbol.Parameters.Length >= 1, "Task.Delay should have at least one parameter");
+        bool isInt = SymbolEqualityComparer.Default.Equals(taskDelaySymbol.Parameters[0].Type, int32);
+        IArgumentOperation delayArgumentOperation = invocationOperation.Arguments[0];
+        IArgumentOperation? cancellationTokenArgumentOperation = invocationOperation.Arguments.Length == 2 ? invocationOperation.Arguments[1] : null;
+
+        // Gets the name of the TaskOrchestrationContext parameter (e.g. "context" or "ctx")
+        string contextParameterName = orchestrationContext.TaskOrchestrationContextSymbol.Name;
+        string recommendation = $"{contextParameterName}.CreateTimer";
+
+        // e.g: "Use 'context.CreateTimer' instead of 'Task.Delay'"
+        string title = string.Format(
+            CultureInfo.InvariantCulture,
+            Resources.UseInsteadFixerTitle,
+            recommendation,
+            "Task.Delay");
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: title,
+                createChangedDocument: c => ReplaceTaskDelay(
+                    context.Document, orchestrationContext.Root, invocationExpressionsSyntax, contextParameterName, delayArgumentOperation, cancellationTokenArgumentOperation, isInt),
+                equivalenceKey: title), // This key is used to prevent duplicate code fixes.
+            context.Diagnostics);
+    }
+
+    static Task<Document> ReplaceTaskDelay(
+        Document document,
+        SyntaxNode oldRoot,
+        InvocationExpressionSyntax incorrectTaskDelaySyntax,
+        string contextParameterName,
+        IArgumentOperation delayArgumentOperation,
+        IArgumentOperation? cancellationTokenArgumentOperation,
+        bool isInt)
+    {
+        if (delayArgumentOperation.Syntax is not ArgumentSyntax timeSpanOrIntArgumentSyntax)
+        {
+            return Task.FromResult(document);
+        }
+
+        // Either use the original TimeSpan argument, or in case it is an int, transform it into TimeSpan
+        ArgumentSyntax timeSpanArgumentSyntax;
+        if (isInt)
+        {
+            timeSpanArgumentSyntax =
+                Argument(
+                    InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("TimeSpan"),
+                            IdentifierName("FromMilliseconds")),
+                        ArgumentList(
+                            SeparatedList(new[] { timeSpanOrIntArgumentSyntax }))));
+        }
+        else
+        {
+            timeSpanArgumentSyntax = timeSpanOrIntArgumentSyntax;
+        }
+
+        // Either gets the original cancellation token argument or create a 'CancellationToken.None'
+        ArgumentSyntax cancellationTokenArgumentSyntax = cancellationTokenArgumentOperation?.Syntax as ArgumentSyntax ??
+            Argument(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    IdentifierName("CancellationToken"),
+                    IdentifierName("None")));
+
+        // Builds a 'context.CreateTimer(TimeSpan.FromMilliseconds(1000), CancellationToken.None)' syntax node
+        InvocationExpressionSyntax correctTimerSyntax =
+            InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    IdentifierName(contextParameterName),
+                    IdentifierName("CreateTimer")),
+                ArgumentList(
+                    SeparatedList(new[]
+                    {
+                        timeSpanArgumentSyntax,
+                        cancellationTokenArgumentSyntax,
+                    })));
+
+        // Replaces the old local declaration with the new local declaration.
+        SyntaxNode newRoot = oldRoot.ReplaceNode(incorrectTaskDelaySyntax, correctTimerSyntax);
+        Document newDocument = document.WithSyntaxRoot(newRoot);
+
+        return Task.FromResult(newDocument);
+    }
+}

--- a/src/Analyzers/Orchestration/GuidOrchestrationFixer.cs
+++ b/src/Analyzers/Orchestration/GuidOrchestrationFixer.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.DurableTask.Analyzers.Orchestration;
+
+/// <summary>
+/// Code fix provider for the <see cref="GuidOrchestrationAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GuidOrchestrationFixer))]
+[Shared]
+public sealed class GuidOrchestrationFixer : OrchestrationContextFixer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => [GuidOrchestrationAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    protected override void RegisterCodeFixes(CodeFixContext context, OrchestrationCodeFixContext orchestrationContext)
+    {
+        // Parses the syntax node to see if it is a invocation expression (Guid.NewGuid())
+        if (orchestrationContext.SyntaxNodeWithDiagnostic is not InvocationExpressionSyntax guidExpression)
+        {
+            return;
+        }
+
+        // Gets the name of the TaskOrchestrationContext parameter (e.g. "context" or "ctx")
+        string contextParameterName = orchestrationContext.TaskOrchestrationContextSymbol.Name;
+
+        string recommendation = $"{contextParameterName}.NewGuid()";
+
+        // e.g: "Use 'context.NewGuid()' instead of 'Guid.NewGuid()'"
+        string title = string.Format(
+            CultureInfo.InvariantCulture,
+            Resources.UseInsteadFixerTitle,
+            recommendation,
+            guidExpression.ToString());
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: title,
+                createChangedDocument: c => ReplaceGuid(context.Document, orchestrationContext.Root, guidExpression, contextParameterName),
+                equivalenceKey: title), // This key is used to prevent duplicate code fixes.
+            context.Diagnostics);
+    }
+
+    static Task<Document> ReplaceGuid(Document document, SyntaxNode oldRoot, InvocationExpressionSyntax incorrectGuidSyntax, string contextParameterName)
+    {
+        // Builds a 'context.NewGuid()' syntax node
+        InvocationExpressionSyntax correctGuidSyntax =
+            InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    IdentifierName(contextParameterName),
+                    IdentifierName("NewGuid")),
+                ArgumentList());
+
+        // Replaces the old local declaration with the new local declaration.
+        SyntaxNode newRoot = oldRoot.ReplaceNode(incorrectGuidSyntax, correctGuidSyntax);
+        Document newDocument = document.WithSyntaxRoot(newRoot);
+
+        return Task.FromResult(newDocument);
+    }
+}

--- a/src/Analyzers/Orchestration/OrchestrationContextFixer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationContextFixer.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.DurableTask.Analyzers.Orchestration;
+
+/// <summary>
+/// Context information for the <see cref="OrchestrationContextFixer"/>.
+/// </summary>
+/// <param name="semanticModel">The Semantic Model retrieved from the Document.</param>
+/// <param name="knownTypeSymbols">Well-known types that are used by the Durable analyzers.</param>
+/// <param name="oldRoot">The root Syntax Node retrieved from the Document.</param>
+/// <param name="syntaxNodeWithDiagnostic">Syntax Node that contains the diagnostic.</param>
+/// <param name="taskOrchestrationContextSymbol">The 'TaskOrchestrationContext' symbol.</param>
+public readonly struct OrchestrationCodeFixContext(
+    SemanticModel semanticModel,
+    KnownTypeSymbols knownTypeSymbols,
+    SyntaxNode root,
+    SyntaxNode syntaxNodeWithDiagnostic,
+    IParameterSymbol taskOrchestrationContextSymbol)
+{
+    /// <summary>
+    /// Gets the Semantic Model retrieved from the Document.
+    /// </summary>
+    public SemanticModel SemanticModel { get; } = semanticModel;
+
+    /// <summary>
+    /// Gets the well-known types that are used by the Durable analyzers.
+    /// </summary>
+    public KnownTypeSymbols KnownTypeSymbols { get; } = knownTypeSymbols;
+
+    /// <summary>
+    /// Gets the root Syntax Node retrieved from the Document.
+    /// </summary>
+    public SyntaxNode Root { get; } = root;
+
+    /// <summary>
+    /// Gets the Syntax Node that contains the diagnostic.
+    /// </summary>
+    public SyntaxNode SyntaxNodeWithDiagnostic { get; } = syntaxNodeWithDiagnostic;
+
+    /// <summary>
+    /// Gets the 'TaskOrchestrationContext' symbol.
+    /// </summary>
+    public IParameterSymbol TaskOrchestrationContextSymbol { get; } = taskOrchestrationContextSymbol;
+}
+
+/// <summary>
+/// Base class for code fix providers that fix issues in orchestrator methods by replacing a SyntaxNode with a TaskOrchestrationContext member or invocation.
+/// </summary>
+public abstract class OrchestrationContextFixer : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+        if (root == null)
+        {
+            return;
+        }
+
+        // Find the Syntax Node that is causing the diagnostic.
+        if (root.FindNode(context.Span, getInnermostNodeForTie: true) is not SyntaxNode syntaxNodeWithDiagnostic)
+        {
+            return;
+        }
+
+        SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+        if (semanticModel == null)
+        {
+            return;
+        }
+
+        // Analyze the data flow to determine which variables are assigned (reachable) within the scope.
+        DataFlowAnalysis? dataFlowAnalysis = semanticModel.AnalyzeDataFlow(syntaxNodeWithDiagnostic);
+        if (dataFlowAnalysis == null)
+        {
+            return;
+        }
+
+        KnownTypeSymbols knownTypeSymbols = new(semanticModel.Compilation);
+        if (knownTypeSymbols.TaskOrchestrationContext == null)
+        {
+            return;
+        }
+
+        // Find the TaskOrchestrationContext parameter available in the scope.
+        IParameterSymbol? taskOrchestrationContextSymbol = dataFlowAnalysis.DefinitelyAssignedOnEntry
+            .OfType<IParameterSymbol>()
+            .FirstOrDefault(
+                p => p.Type.Equals(knownTypeSymbols.TaskOrchestrationContext, SymbolEqualityComparer.Default));
+        if (taskOrchestrationContextSymbol == null)
+        {
+            // This method does not have a TaskOrchestrationContext parameter, so we should not offer this code fix.
+            return;
+        }
+
+        var orchestrationContext = new OrchestrationCodeFixContext(
+            semanticModel, knownTypeSymbols, root, syntaxNodeWithDiagnostic, taskOrchestrationContextSymbol);
+
+        this.RegisterCodeFixes(context, orchestrationContext);
+    }
+
+    /// <summary>
+    /// Registers a code fix for an orchestration diagnostic that can be fixed by replacing a SyntaxNode with a TaskOrchestrationContext member or invocation.
+    /// </summary>
+    /// <param name="context">A <see cref="CodeFixContext"/> containing context information about the diagnostics to fix.</param>
+    /// <param name="orchestrationContext">A <see cref="OrchestrationCodeFixContext"/> containing context information about the orchestration code fixer.</param>
+    protected abstract void RegisterCodeFixes(CodeFixContext context, OrchestrationCodeFixContext orchestrationContext);
+}


### PR DESCRIPTION
Following the same structure as #318, this PR adds roslyn code fixers for the diagnostics reported about non-deterministic usage of DateTime, Guid and Task delay. It suggests replacing them for the `TaskOrchestrationContext` alternatives, as suggested by [our docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-code-constraints?tabs=csharp).