### PR TITLE
Add codeQL support

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -1,0 +1,69 @@
+# This workflow generates weekly CodeQL reports for this repo, a security requirements.
+# The workflow is adapted from the following reference: https://github.com/Azure-Samples/azure-functions-python-stream-openai/pull/2/files
+# Generic comments on how to modify these file are left intactfor future maintenance.
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main"]
+  schedule:
+    - cron: '0 0 * * 1' # Weekly Monday run, needed for weekly reports
+  workflow_call: # allows to be invoked as part of a larger workflow
+  workflow_dispatch: # allows for the workflow to run manually see: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
+
+env:
+  solution: DurableTask.sln
+  config: Release
+
+jobs:
+  invoke-build-workflow: # Call re-useable build workflow
+    uses: ./.github/workflows/build.yml
+
+  analyze:
+    name: Analyze
+    needs: invoke-build-workflow # Can only test after build completes
+
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    # - name: Checkout repository
+    #   uses: actions/checkout@v3
+
+    - name: Download built-code
+      uses: actions/download-artifact@v2
+      with:
+        name: built-code
+        path: ./  # This path will match the upload path
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # Run CodeQL analysis
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -16,6 +16,17 @@ trigger:
 # CI only, does not trigger on PRs.
 pr: none
 
+schedules:
+# Build nightly to catch any new CVEs and report SDL often.
+# We are also required to generated CodeQL reports weekly, so this
+# helps us meet that.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
     repositories:
         - repository: 1es


### PR DESCRIPTION
DurableTask-Dotnet version of this PR: https://github.com/Azure/durabletask/pull/1131

CodeQL (Code Query Language?) is a service that checks against CVEs and other compliance requirements using static analysis in our repos. It needs to be executed weekly.

Our 1ES pipeline already has this, but we need to make it run weekly, so our 1ES pipeline now has a weekly schedule.
We also need to add it directly on GitHub, which is done through the codeQL.yml GitHub workflow.