### PR TITLE
Set correct target folder in package signing step

### DIFF
--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -76,6 +76,6 @@ jobs:
         - template: ci/sign-files.yml@eng
           parameters:
             displayName: Sign NugetPackages
-            folderPath: $(build.artifactStagingDirectory)
+            folderPath: $(pkg_dir)
             pattern: '*.nupkg'
             signType: nuget


### PR DESCRIPTION
As in title, seems we were trying to find `.nupkg`s in the wrong directory