### PR TITLE
Add DebugType as portable, to generate deterministic nupkgs in 1ES

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,6 +13,11 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>recommended</AnalysisMode>
     <SharedRoot>$(SrcRoot)Shared/</SharedRoot>
+    <!-- This setting makes symbol files (PDBs) available within the DLLs
+    themselves, which is seemingly necessary for having a 'deterministic' build checkmark in our NuGet package.
+    This is recommended for NuGet packages, as per: https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
+    The connection to deterministic builds is explored here: https://www.meziantou.net/creating-reproducible-build-in-dotnet.htm -->
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <Import Project="$(EngRoot)targets/Release.props" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,11 +13,10 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>recommended</AnalysisMode>
     <SharedRoot>$(SrcRoot)Shared/</SharedRoot>
-    <!-- This setting makes symbol files (PDBs) available within the DLLs
-    themselves, which is seemingly necessary for having a 'deterministic' build checkmark in our NuGet package.
+    <!-- This setting makes symbol files (PDBs) available, which is seemingly necessary for having a 'deterministic' build checkmark in our NuGet package.
     This is recommended for NuGet packages, as per: https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
     The connection to deterministic builds is explored here: https://www.meziantou.net/creating-reproducible-build-in-dotnet.htm -->
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <Import Project="$(EngRoot)targets/Release.props" />


### PR DESCRIPTION
While migrating to our new 1ES CI, we realized that the `nupkg`s generated by this repo were not getting the "deterministic" flag in the [NuGet package explorer](https://apps.microsoft.com/detail/9wzdncrdmdm3?hl=en-US&gl=US). 

After a lot of experimentation, we discovered the reason for this was that our packages did not set the `DebugType` MSBuild property to ~`embedded`~ `portable` which apparently is needed for deterministic builds. The need for this property (and others we were already setting) is explained here: https://www.meziantou.net/creating-reproducible-build-in-dotnet.htm

To be honest, I don't know why previous CI environment still generated deterministic builds, even without this flag. That's a mystery for another day. For now, and to unblock upcoming releases, we'll set the `DebugType` of our packages to ~`embedded`~ `portable` to all the expected checkmarks in the NuGet package explorer.

**For comparison, here's the view of the NuGet package before this change:**

<img width="361" alt="image (1)" src="https://github.com/user-attachments/assets/9118c009-03ba-4998-a0b4-ae84485f09c1">

and here it is after:

<img width="385" alt="image" src="https://github.com/user-attachments/assets/dfcea974-277a-4e31-9b8e-5b63475eca71">

**Edit 9/18:** a previous version of this PR set the `DebugType` as `embedded`. I've set it to `portable` on this date based on this feedback: https://github.com/microsoft/durabletask-dotnet/pull/343#discussion_r1764247171
