### PR TITLE
WIP: Rewind APIs

### DIFF
--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -290,6 +290,32 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     public abstract Task ResumeInstanceAsync(
         string instanceId, string? reason = null, CancellationToken cancellation = default);
 
+    /// <summary>
+    /// Rewinds the specified orchestration instance to a previous, non-failed state.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only orchestrations in a failed state can be rewound. Attempting to rewind an orchestration in a non-failed
+    /// state may result in either a no-op or a failure depending on the backend implementation.
+    /// </para><para>
+    /// Rewind works by rewriting an orchestration's history to remove the most recent failure records, and then
+    /// re-executing the orchestration with the modified history. This effectively "rewinds" the orchestration to a
+    /// previous "good" state, allowing it to re-execute the logic that caused the original failure.
+    /// </para><para>
+    /// Rewinding an orchestration is intended to be used in cases where a failure is caused by a transient issue that
+    /// has since been resolved. It is not intended to be used as a general-purpose retry mechanism.
+    /// </para>
+    /// </remarks>
+    /// <param name="instanceId">The instance ID of the orchestration to rewind.</param>
+    /// <param name="reason">The optional rewind reason, which is recorded in the orchestration history.</param>
+    /// <param name="cancellation">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the rewind API call. Note that cancelling this
+    /// token does not cancel the rewind operation once it has been successfully enqueued.
+    /// </param>
+    /// <returns>A task that completes when the rewind operation was been successfully.</returns>
+    public abstract Task RewindInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default);
+
     /// <inheritdoc cref="GetInstanceAsync(string, bool, CancellationToken)"/>
     public virtual Task<OrchestrationMetadata?> GetInstanceAsync(
         string instanceId, CancellationToken cancellation)

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -192,6 +192,28 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
+    public override async Task RewindInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        if (string.IsNullOrEmpty(instanceId))
+        {
+            throw new ArgumentNullException(nameof(instanceId));
+        }
+
+        try
+        {
+            await this.sidecarClient.RewindInstanceAsync(
+                new P.RewindInstanceRequest { InstanceId = instanceId, Reason = reason },
+                cancellationToken: cancellation);
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+        {
+            throw new OperationCanceledException(
+                $"The {nameof(this.RewindInstanceAsync)} operation was canceled.", e, cancellation);
+        }
+    }
+
+    /// <inheritdoc/>
     public override async Task<OrchestrationMetadata?> GetInstancesAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -185,6 +185,16 @@ class ShimDurableTaskClient : DurableTaskClient
     }
 
     /// <inheritdoc/>
+    public override Task RewindInstanceAsync(
+        string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        // At the time of writing, there is no IOrchestrationXXXClient interface that supports rewind.
+        // Rather, it's only supported by specific backend implementations like Azure Storage. Once an interface
+        // with rewind is added to DurableTask.Core, we can add support for it here.
+        throw new NotSupportedException("Rewind is not supported by the current client.");
+    }
+
+    /// <inheritdoc/>
     public override async Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(
         string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
     {
@@ -219,7 +229,7 @@ class ShimDurableTaskClient : DurableTaskClient
         }
     }
 
-    [return: NotNullIfNotNull("state")]
+    [return: NotNullIfNotNull(nameof(state))]
     OrchestrationMetadata? ToMetadata(Core.OrchestrationState? state, bool getInputsAndOutputs)
     {
         if (state is null)


### PR DESCRIPTION
This PR adds `RewindInstanceAsync` to the `DurableTaskClient` and `GrpcDurableTaskClient` classes.

There are a couple things that need to be done before this PR can be merged:

- [ ] [Required] Integration tests targeting real backends (since the implementation of rewind is currently backend-specific)
- [ ] [Optional] Updates to DurableTask.Core to support the shim implementation