### PR TITLE
Increase DTFx.Core version to v3.0.0 and Increase Release Target to v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.4.0
+
+- Microsoft.Azure.DurableTask.Core dependency increased to `3.0.0`
+
 ## v1.3.0
 
 ### Microsoft.DurableTask.Abstractions

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1 />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1 />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />

--- a/src/Abstractions/RELEASENOTES.md
+++ b/src/Abstractions/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Microsoft.Azure.DurableTask.Core dependency increased to `2.17.1`
+- Microsoft.Azure.DurableTask.Core dependency increased to `3.0.0`


### PR DESCRIPTION
As titled. 
Microsoft.Extensions.Logging.Abstractions 6.0.0->6.0.1 as we upgrade this in DurableTask.Core