### PR TITLE
Remove Microsoft.DurableTask.Sidecar.Protobuf reference in Shared.csproj

### DIFF
--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.8.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes the `Microsoft.DurableTask.Sidecar.Protobuf` package dependency from Shared.csproj since it wasn't being used.