### PR TITLE
Update to latest protobuf definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+## v1.5.0
+
+- Implement work item completion tokens for standalone worker scenarios ([#359](https://github.com/microsoft/durabletask-dotnet/pull/359))
+- Support for worker concurrency configuration ([#359](https://github.com/microsoft/durabletask-dotnet/pull/359))
+- Bump System.Text.Json to 6.0.10
+
 ## v1.4.0
 
 - Microsoft.Azure.DurableTask.Core dependency increased to `3.0.0`

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -223,18 +223,21 @@ static class ProtoUtils
     /// <param name="instanceId">The orchestrator instance ID.</param>
     /// <param name="customStatus">The orchestrator customer status or <c>null</c> if no custom status.</param>
     /// <param name="actions">The orchestrator actions.</param>
+    /// <param name="completionToken">The completion token from the work item.</param>
     /// <returns>The orchestrator response.</returns>
     /// <exception cref="NotSupportedException">When an orchestrator action is unknown.</exception>
     internal static P.OrchestratorResponse ConstructOrchestratorResponse(
         string instanceId,
         string? customStatus,
-        IEnumerable<OrchestratorAction> actions)
+        IEnumerable<OrchestratorAction> actions,
+        string completionToken)
     {
         Check.NotNull(actions);
         var response = new P.OrchestratorResponse
         {
             InstanceId = instanceId,
             CustomStatus = customStatus,
+            CompletionToken = completionToken,
         };
 
         foreach (OrchestratorAction action in actions)
@@ -605,9 +608,12 @@ static class ProtoUtils
     /// Converts a <see cref="EntityBatchResult" /> to <see cref="P.EntityBatchResult" />.
     /// </summary>
     /// <param name="entityBatchResult">The operation result to convert.</param>
+    /// <param name="completionToken">The completion token from the work item.</param>
     /// <returns>The converted operation result.</returns>
     [return: NotNullIfNotNull(nameof(entityBatchResult))]
-    internal static P.EntityBatchResult? ToEntityBatchResult(this EntityBatchResult? entityBatchResult)
+    internal static P.EntityBatchResult? ToEntityBatchResult(
+        this EntityBatchResult? entityBatchResult,
+        string completionToken)
     {
         if (entityBatchResult == null)
         {
@@ -618,6 +624,7 @@ static class ProtoUtils
         {
             EntityState = entityBatchResult.EntityState,
             FailureDetails = entityBatchResult.FailureDetails.ToProtobuf(),
+            CompletionToken = completionToken,
         };
 
         foreach (OperationAction action in entityBatchResult.Actions!)

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -624,7 +624,6 @@ static class ProtoUtils
         {
             EntityState = entityBatchResult.EntityState,
             FailureDetails = entityBatchResult.FailureDetails.ToProtobuf(),
-            CompletionToken = completionToken,
         };
 
         foreach (OperationAction action in entityBatchResult.Actions!)

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -223,7 +223,10 @@ static class ProtoUtils
     /// <param name="instanceId">The orchestrator instance ID.</param>
     /// <param name="customStatus">The orchestrator customer status or <c>null</c> if no custom status.</param>
     /// <param name="actions">The orchestrator actions.</param>
-    /// <param name="completionToken">The completion token from the work item.</param>
+    /// <param name="completionToken">
+    /// The completion token for the work item. It must be the exact same <see cref="P.WorkItem.CompletionToken" />
+    /// value that was provided by the corresponding <see cref="P.WorkItem"/> that triggered the orchestrator execution.
+    /// </param>
     /// <returns>The orchestrator response.</returns>
     /// <exception cref="NotSupportedException">When an orchestrator action is unknown.</exception>
     internal static P.OrchestratorResponse ConstructOrchestratorResponse(

--- a/src/Shared/Grpc/ProtoUtils.cs
+++ b/src/Shared/Grpc/ProtoUtils.cs
@@ -608,12 +608,9 @@ static class ProtoUtils
     /// Converts a <see cref="EntityBatchResult" /> to <see cref="P.EntityBatchResult" />.
     /// </summary>
     /// <param name="entityBatchResult">The operation result to convert.</param>
-    /// <param name="completionToken">The completion token from the work item.</param>
     /// <returns>The converted operation result.</returns>
     [return: NotNullIfNotNull(nameof(entityBatchResult))]
-    internal static P.EntityBatchResult? ToEntityBatchResult(
-        this EntityBatchResult? entityBatchResult,
-        string completionToken)
+    internal static P.EntityBatchResult? ToEntityBatchResult(this EntityBatchResult? entityBatchResult)
     {
         if (entityBatchResult == null)
         {

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -84,19 +84,14 @@ public class DurableTaskWorkerOptions
     public TimeSpan MaximumTimerInterval { get; set; } = TimeSpan.FromDays(3);
 
     /// <summary>
-    /// Gets or sets the maximum number of concurrent activity work items that can be processed by the worker.
+    /// Gets options for the Durable Task worker concurrency.
     /// </summary>
-    public int MaximumConcurrentActivityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
-
-    /// <summary>
-    /// Gets or sets the maximum number of concurrent orchestration work items that can be processed by the worker.
-    /// </summary>
-    public int MaximumConcurrentOrchestrationWorkItems { get; set; } = 100 * Environment.ProcessorCount;
-
-    /// <summary>
-    /// Gets or sets the maximum number of concurrent entity work items that can be processed by the worker.
-    /// </summary>
-    public int MaximumConcurrentEntityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+    /// <remarks>
+    /// Worker concurrency options control how many work items of a particular type (e.g., orchestration, activity,
+    /// or entity) can be processed concurrently by the worker. It is recommended to set these values based on the
+    /// expected workload and the resources available on the machine running the worker.
+    /// </remarks>
+    public ConcurrencyOptions Concurrency { get; } = new();
 
     /// <summary>
     /// Gets a value indicating whether <see cref="DataConverter" /> was explicitly set or not.
@@ -122,5 +117,26 @@ public class DurableTaskWorkerOptions
             other.MaximumTimerInterval = this.MaximumTimerInterval;
             other.EnableEntitySupport = this.EnableEntitySupport;
         }
+    }
+
+    /// <summary>
+    /// Options for the Durable Task worker concurrency.
+    /// </summary>
+    public class ConcurrencyOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent activity work items that can be processed by the worker.
+        /// </summary>
+        public int MaximumConcurrentActivityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent orchestration work items that can be processed by the worker.
+        /// </summary>
+        public int MaximumConcurrentOrchestrationWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent entity work items that can be processed by the worker.
+        /// </summary>
+        public int MaximumConcurrentEntityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
     }
 }

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -84,6 +84,21 @@ public class DurableTaskWorkerOptions
     public TimeSpan MaximumTimerInterval { get; set; } = TimeSpan.FromDays(3);
 
     /// <summary>
+    /// Gets or sets the maximum number of concurrent activity work items that can be processed by the worker.
+    /// </summary>
+    public int MaximumConcurrentActivityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent orchestration work items that can be processed by the worker.
+    /// </summary>
+    public int MaximumConcurrentOrchestrationWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent entity work items that can be processed by the worker.
+    /// </summary>
+    public int MaximumConcurrentEntityWorkItems { get; set; } = 100 * Environment.ProcessorCount;
+
+    /// <summary>
     /// Gets a value indicating whether <see cref="DataConverter" /> was explicitly set or not.
     /// </summary>
     /// <remarks>

--- a/src/Worker/Core/Worker.csproj
+++ b/src/Worker/Core/Worker.csproj
@@ -11,7 +11,7 @@ The worker is responsible for processing durable task work items.</PackageDescri
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -167,7 +167,7 @@ sealed partial class GrpcDurableTaskWorker
                     {
                         this.RunBackgroundTask(
                             workItem,
-                            () => this.OnRunEntityBatchAsync(workItem.EntityRequest, workItem.CompletionToken));
+                            () => this.OnRunEntityBatchAsync(workItem.EntityRequest));
                     }
                     else if (workItem.RequestCase == P.WorkItem.RequestOneofCase.HealthPing)
                     {
@@ -361,7 +361,7 @@ sealed partial class GrpcDurableTaskWorker
             await this.sidecar.CompleteActivityTaskAsync(response);
         }
 
-        async Task OnRunEntityBatchAsync(P.EntityBatchRequest request, string completionToken)
+        async Task OnRunEntityBatchAsync(P.EntityBatchRequest request)
         {
             var coreEntityId = DTCore.Entities.EntityId.FromString(request.InstanceId);
             EntityId entityId = new(coreEntityId.Name, coreEntityId.Key);
@@ -420,7 +420,7 @@ sealed partial class GrpcDurableTaskWorker
             }
 
             // convert the result to protobuf format and send it back
-            P.EntityBatchResult response = batchResult.ToEntityBatchResult(completionToken);
+            P.EntityBatchResult response = batchResult.ToEntityBatchResult();
             await this.sidecar.CompleteEntityTaskAsync(response);
         }
     }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -139,8 +139,10 @@ sealed partial class GrpcDurableTaskWorker
             return this.sidecar!.GetWorkItems(
                 new P.GetWorkItemsRequest
                 {
-                    MaxConcurrentActivityWorkItems = workerOptions.MaximumConcurrentActivityWorkItems,
-                    MaxConcurrentOrchestrationWorkItems = workerOptions.MaximumConcurrentOrchestrationWorkItems,
+                    MaxConcurrentActivityWorkItems =
+                        workerOptions.Concurrency.MaximumConcurrentActivityWorkItems,
+                    MaxConcurrentOrchestrationWorkItems =
+                        workerOptions.Concurrency.MaximumConcurrentOrchestrationWorkItems,
                 },
                 cancellationToken: cancellation);
         }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -34,7 +34,7 @@ sealed partial class GrpcDurableTaskWorker
         {
             this.worker = worker;
             this.sidecar = sidecar;
-            this.shimFactory = new DurableTaskShimFactory(this.worker.options, this.worker.loggerFactory);
+            this.shimFactory = new DurableTaskShimFactory(this.worker.grpcOptions, this.worker.loggerFactory);
         }
 
         ILogger Logger => this.worker.logger;
@@ -102,7 +102,7 @@ sealed partial class GrpcDurableTaskWorker
 
             if (runtimeState.ExecutionStartedEvent == null)
             {
-                // TODO: What's the right way to handle this? Callback to the sidecar with a retryable error request?
+                // TODO: What's the right way to handle this? Callback to the sidecar with a retriable error request?
                 throw new InvalidOperationException("The provided orchestration history was incomplete");
             }
 
@@ -133,8 +133,16 @@ sealed partial class GrpcDurableTaskWorker
             await this.sidecar!.HelloAsync(EmptyMessage, cancellationToken: cancellation);
             this.Logger.EstablishedWorkItemConnection();
 
+            DurableTaskWorkerOptions workerOptions = this.worker.workerOptions;
+
             // Get the stream for receiving work-items
-            return this.sidecar!.GetWorkItems(new P.GetWorkItemsRequest(), cancellationToken: cancellation);
+            return this.sidecar!.GetWorkItems(
+                new P.GetWorkItemsRequest
+                {
+                    MaxConcurrentActivityWorkItems = workerOptions.MaximumConcurrentActivityWorkItems,
+                    MaxConcurrentOrchestrationWorkItems = workerOptions.MaximumConcurrentOrchestrationWorkItems,
+                },
+                cancellationToken: cancellation);
         }
 
         async Task ProcessWorkItemsAsync(AsyncServerStreamingCall<P.WorkItem> stream, CancellationToken cancellation)
@@ -145,16 +153,25 @@ sealed partial class GrpcDurableTaskWorker
                 {
                     if (workItem.RequestCase == P.WorkItem.RequestOneofCase.OrchestratorRequest)
                     {
-                        this.RunBackgroundTask(workItem, () => this.OnRunOrchestratorAsync(
-                            workItem.OrchestratorRequest));
+                        this.RunBackgroundTask(
+                            workItem,
+                            () => this.OnRunOrchestratorAsync(workItem.OrchestratorRequest, workItem.CompletionToken));
                     }
                     else if (workItem.RequestCase == P.WorkItem.RequestOneofCase.ActivityRequest)
                     {
-                        this.RunBackgroundTask(workItem, () => this.OnRunActivityAsync(workItem.ActivityRequest));
+                        this.RunBackgroundTask(
+                            workItem,
+                            () => this.OnRunActivityAsync(workItem.ActivityRequest, workItem.CompletionToken));
                     }
                     else if (workItem.RequestCase == P.WorkItem.RequestOneofCase.EntityRequest)
                     {
-                        this.RunBackgroundTask(workItem, () => this.OnRunEntityBatchAsync(workItem.EntityRequest));
+                        this.RunBackgroundTask(
+                            workItem,
+                            () => this.OnRunEntityBatchAsync(workItem.EntityRequest, workItem.CompletionToken));
+                    }
+                    else if (workItem.RequestCase == P.WorkItem.RequestOneofCase.HealthPing)
+                    {
+                        // No-op
                     }
                     else
                     {
@@ -188,7 +205,7 @@ sealed partial class GrpcDurableTaskWorker
             });
         }
 
-        async Task OnRunOrchestratorAsync(P.OrchestratorRequest request)
+        async Task OnRunOrchestratorAsync(P.OrchestratorRequest request, string completionToken)
         {
             OrchestratorExecutionResult? result = null;
             P.TaskFailureDetails? failureDetails = null;
@@ -248,7 +265,8 @@ sealed partial class GrpcDurableTaskWorker
                 response = ProtoUtils.ConstructOrchestratorResponse(
                     request.InstanceId,
                     result.CustomStatus,
-                    result.Actions);
+                    result.Actions,
+                    completionToken);
             }
             else
             {
@@ -256,6 +274,7 @@ sealed partial class GrpcDurableTaskWorker
                 response = new P.OrchestratorResponse
                 {
                     InstanceId = request.InstanceId,
+                    CompletionToken = completionToken,
                     Actions =
                     {
                         new P.OrchestratorAction
@@ -279,7 +298,7 @@ sealed partial class GrpcDurableTaskWorker
             await this.sidecar.CompleteOrchestratorTaskAsync(response);
         }
 
-        async Task OnRunActivityAsync(P.ActivityRequest request)
+        async Task OnRunActivityAsync(P.ActivityRequest request, string completionToken)
         {
             OrchestrationInstance instance = request.OrchestrationInstance.ToCore();
             string rawInput = request.Input;
@@ -336,12 +355,13 @@ sealed partial class GrpcDurableTaskWorker
                 TaskId = request.TaskId,
                 Result = output,
                 FailureDetails = failureDetails,
+                CompletionToken = completionToken,
             };
 
             await this.sidecar.CompleteActivityTaskAsync(response);
         }
 
-        async Task OnRunEntityBatchAsync(P.EntityBatchRequest request)
+        async Task OnRunEntityBatchAsync(P.EntityBatchRequest request, string completionToken)
         {
             var coreEntityId = DTCore.Entities.EntityId.FromString(request.InstanceId);
             EntityId entityId = new(coreEntityId.Name, coreEntityId.Key);
@@ -400,7 +420,7 @@ sealed partial class GrpcDurableTaskWorker
             }
 
             // convert the result to protobuf format and send it back
-            P.EntityBatchResult response = batchResult.ToEntityBatchResult();
+            P.EntityBatchResult response = batchResult.ToEntityBatchResult(completionToken);
             await this.sidecar.CompleteEntityTaskAsync(response);
         }
     }

--- a/src/Worker/Grpc/GrpcEntityRunner.cs
+++ b/src/Worker/Grpc/GrpcEntityRunner.cs
@@ -69,7 +69,7 @@ public static class GrpcEntityRunner
         TaskEntity entity = factory.CreateEntity(entityName, implementation, id);
         EntityBatchResult result = await entity.ExecuteOperationBatchAsync(batch);
 
-        P.EntityBatchResult response = result.ToEntityBatchResult();
+        P.EntityBatchResult response = result.ToEntityBatchResult(completionToken: string.Empty /* doesn't apply */);
         byte[] responseBytes = response.ToByteArray();
         return Convert.ToBase64String(responseBytes);
     }

--- a/src/Worker/Grpc/GrpcEntityRunner.cs
+++ b/src/Worker/Grpc/GrpcEntityRunner.cs
@@ -69,7 +69,7 @@ public static class GrpcEntityRunner
         TaskEntity entity = factory.CreateEntity(entityName, implementation, id);
         EntityBatchResult result = await entity.ExecuteOperationBatchAsync(batch);
 
-        P.EntityBatchResult response = result.ToEntityBatchResult(completionToken: string.Empty /* doesn't apply */);
+        P.EntityBatchResult response = result.ToEntityBatchResult();
         byte[] responseBytes = response.ToByteArray();
         return Convert.ToBase64String(responseBytes);
     }

--- a/src/Worker/Grpc/GrpcOrchestrationRunner.cs
+++ b/src/Worker/Grpc/GrpcOrchestrationRunner.cs
@@ -115,7 +115,8 @@ public static class GrpcOrchestrationRunner
         P.OrchestratorResponse response = ProtoUtils.ConstructOrchestratorResponse(
             request.InstanceId,
             result.CustomStatus,
-            result.Actions);
+            result.Actions,
+            completionToken: string.Empty /* doesn't apply */);
         byte[] responseBytes = response.ToByteArray();
         return Convert.ToBase64String(responseBytes);
     }


### PR DESCRIPTION
Summary of changes:

- Updates to latest proto definitions in microsoft/durabletask-proto
- Implements new work item completion token APIs
- Updates System.Text.Json dependency to 6.0.10 to address CVEs
- Adds work item concurrency configuration
- Bump the version from 1.4.0 to 1.5.0 since there is new public surface area (concurrency configuration)

Note that changes to the worker packages generally aren't applicable to Durable Functions but rather are intended to support alternative "sidecar" endpoints, such as Dapr or DTS. The protobuf-related changes in particular are required for DTS.

Note that this change should be merged only after https://github.com/microsoft/durabletask-protobuf/pull/28 is merged. We also need to update the submodule pointer to point to the `main` branch rather than the PR branch.