### PR TITLE
Upgrade Versions of Artifact Action

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -48,7 +48,7 @@ jobs:
       run: dotnet pack $solution --configuration $config --no-build
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pkg
         path: out/pkg


### PR DESCRIPTION
As titled. upload-artifact v3 is deprecated and thus cause CI failing.  Move to v3 to solve. 
Details can be found here https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/