### PR TITLE
Enable localhost connection strings w/no auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Added new preview packages, `Microsoft.DurableTask.Client.AzureManaged` and `Microsoft.DurableTask.Worker.AzureManaged`
+
 ### Microsoft.DurableTask.Client
 
 - Add new `IDurableTaskClientBuilder AddDurableTaskClient(IServiceCollection, string?)` API

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientExtensions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientExtensions.cs
@@ -59,6 +59,7 @@ public static class DurableTaskSchedulerClientExtensions
                 options.EndpointAddress = connectionOptions.EndpointAddress;
                 options.TaskHubName = connectionOptions.TaskHubName;
                 options.Credential = connectionOptions.Credential;
+                options.AllowInsecureCredentials = connectionOptions.AllowInsecureCredentials;
             },
             configure);
     }

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
@@ -59,12 +59,17 @@ public class DurableTaskSchedulerClientOptions
     /// <param name="connectionString">The connection string to parse.</param>
     /// <returns>A new instance of <see cref="DurableTaskSchedulerClientOptions"/>.</returns>
     internal static DurableTaskSchedulerClientOptions FromConnectionString(
-        DurableTaskSchedulerConnectionString connectionString) => new()
+        DurableTaskSchedulerConnectionString connectionString)
+    {
+        TokenCredential? credential = GetCredentialFromConnectionString(connectionString);
+        return new DurableTaskSchedulerClientOptions()
         {
             EndpointAddress = connectionString.Endpoint,
             TaskHubName = connectionString.TaskHubName,
-            Credential = GetCredentialFromConnectionString(connectionString),
+            Credential = credential,
+            AllowInsecureCredentials = credential is null,
         };
+    }
 
     /// <summary>
     /// Creates a gRPC channel for communicating with the Durable Task Scheduler service.

--- a/src/Worker/AzureManaged/DurableTaskSchedulerWorkerExtensions.cs
+++ b/src/Worker/AzureManaged/DurableTaskSchedulerWorkerExtensions.cs
@@ -60,6 +60,7 @@ public static class DurableTaskSchedulerWorkerExtensions
                 options.EndpointAddress = connectionOptions.EndpointAddress;
                 options.TaskHubName = connectionOptions.TaskHubName;
                 options.Credential = connectionOptions.Credential;
+                options.AllowInsecureCredentials = connectionOptions.AllowInsecureCredentials;
             },
             configure);
     }

--- a/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
+++ b/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
@@ -65,12 +65,17 @@ public class DurableTaskSchedulerWorkerOptions
     /// <param name="connectionString">The connection string to parse.</param>
     /// <returns>A new instance of <see cref="DurableTaskSchedulerWorkerOptions"/>.</returns>
     internal static DurableTaskSchedulerWorkerOptions FromConnectionString(
-        DurableTaskSchedulerConnectionString connectionString) => new()
+        DurableTaskSchedulerConnectionString connectionString)
+    {
+        TokenCredential? credential = GetCredentialFromConnectionString(connectionString);
+        return new DurableTaskSchedulerWorkerOptions()
         {
             EndpointAddress = connectionString.Endpoint,
             TaskHubName = connectionString.TaskHubName,
-            Credential = GetCredentialFromConnectionString(connectionString),
+            Credential = credential,
+            AllowInsecureCredentials = credential is null,
         };
+    }
 
     /// <summary>
     /// Creates a gRPC channel for communicating with the Durable Task Scheduler service.

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DurableTask.Worker.Grpc
     /// </remarks>
     static partial class Logs
     {
-        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Durable Task gRPC worker starting.")]
-        public static partial void StartingTaskHubWorker(this ILogger logger);
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Durable Task gRPC worker starting and connecting to {endpoint}.")]
+        public static partial void StartingTaskHubWorker(this ILogger logger, string endpoint);
 
         [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Durable Task gRPC worker has disconnected from gRPC server.")]
         public static partial void SidecarDisconnected(this ILogger logger);


### PR DESCRIPTION
Updates the `DurableTaskScheduler*Extensions` and `DurableTaskScheduler*Options` classes to allow insecure credentials when using a localhost connection string. This is to enable local development using connection strings against a local emulator.

This PR also adds the endpoint address to the "worker connected" log message.