### PR TITLE
Add timeout to gRPC workitem streaming

### DIFF
--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -252,7 +252,7 @@ sealed partial class GrpcDurableTaskWorker
                     if (!cancellation.IsCancellationRequested)
                     {
                         // Since the cancellation came from the timeout, log a warning.
-                        this.Logger.ConnectionClosed();
+                        this.Logger.ConnectionTimeout();
                     }
 
                     return;

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -185,6 +185,8 @@ sealed partial class GrpcDurableTaskWorker
         async Task ProcessWorkItemsAsync(AsyncServerStreamingCall<P.WorkItem> stream, CancellationToken cancellation)
         {
             // Create a new token source for timing out and a final token source that keys off of them both.
+            // The timeout token is used to detect when we are no longer getting any messages, including health checks.
+            // If this is the case, it signifies the connection has been dropped silently and we need to reconnect.
             using var timeoutSource = new CancellationTokenSource();
             timeoutSource.CancelAfter(TimeSpan.FromSeconds(60));
             using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, timeoutSource.Token);
@@ -247,6 +249,12 @@ sealed partial class GrpcDurableTaskWorker
                     // The token has cancelled, this means either:
                     // 1. The broader 'cancellation' was triggered, return here to start a graceful shutdown.
                     // 2. The timeoutSource was triggered, return here to trigger a reconnect to the backend.
+                    if (!cancellation.IsCancellationRequested)
+                    {
+                        // Since the cancellation came from the timeout, log a warning.
+                        this.Logger.ConnectionClosed();
+                    }
+
                     return;
                 }
             }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -185,9 +185,9 @@ sealed partial class GrpcDurableTaskWorker
         async Task ProcessWorkItemsAsync(AsyncServerStreamingCall<P.WorkItem> stream, CancellationToken cancellation)
         {
             // Create a new token source for timing out and a final token source that keys off of them both.
-            var timeoutSource = new CancellationTokenSource();
+            using var timeoutSource = new CancellationTokenSource();
             timeoutSource.CancelAfter(TimeSpan.FromSeconds(60));
-            var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, timeoutSource.Token);
+            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, timeoutSource.Token);
 
             while (!cancellation.IsCancellationRequested)
             {

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -48,5 +48,8 @@ namespace Microsoft.DurableTask.Worker.Grpc
 
         [LoggerMessage(EventId = 55, Level = LogLevel.Information, Message = "{instanceId}: Evaluating custom retry handler for failed '{name}' task. Attempt = {attempt}.")]
         public static partial void RetryingTask(this ILogger logger, string instanceId, string name, int attempt);
+
+        [LoggerMessage(EventId = 56, Level = LogLevel.Warning, Message = "Channel to backend has stopped receiving traffic, will attempt to reconnect.")]
+        public static partial void ConnectionClosed(this ILogger logger);
     }
 }

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -50,6 +50,6 @@ namespace Microsoft.DurableTask.Worker.Grpc
         public static partial void RetryingTask(this ILogger logger, string instanceId, string name, int attempt);
 
         [LoggerMessage(EventId = 56, Level = LogLevel.Warning, Message = "Channel to backend has stopped receiving traffic, will attempt to reconnect.")]
-        public static partial void ConnectionClosed(this ILogger logger);
+        public static partial void ConnectionTimeout(this ILogger logger);
     }
 }


### PR DESCRIPTION
This commit adds a timeout to the gRPC stream used to communicate with the backend. This was done because the backend could restart and drop the connection and the worker would not know. This causes the worker to hang and not receive any new work items. The fix is to reset the connection if a long enough period of time has passed between receiving anything on the stream.