### PR TITLE
Introduce versioning to the DurableTaskClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## v1.9.0 (unreleased)
+
+- Introduce default version setting to DurableTaskClient and expose to orchestrator ([#393](https://github.com/microsoft/durabletask-dotnet/pull/393))
+
 ## v1.8.1
 
 - Add timeout to gRPC workitem streaming ([#390](https://github.com/microsoft/durabletask-dotnet/pull/390))

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -60,6 +60,11 @@ public abstract class TaskOrchestrationContext
     public abstract bool IsReplaying { get; }
 
     /// <summary>
+    /// Gets the version of the current orchestration instance, which was set when the instance was created.
+    /// </summary>
+    public abstract string Version { get; }
+
+    /// <summary>
     /// Gets the entity feature, for interacting with entities.
     /// </summary>
     public virtual TaskOrchestrationEntityFeature Entities =>

--- a/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
+++ b/src/Client/Core/DependencyInjection/DurableTaskClientBuilderExtensions.cs
@@ -89,4 +89,16 @@ public static class DurableTaskBuilderExtensions
             });
         return builder;
     }
+
+    /// <summary>
+    /// Sets the default version for this builder. This version will be applied by default to all orchestrations if set.
+    /// </summary>
+    /// <param name="builder">The builder to set the version for.</param>
+    /// <param name="version">The version that will be used as the default version.</param>
+    /// <returns>The original builder, for call chaining.</returns>
+    public static IDurableTaskClientBuilder UseDefaultVersion(this IDurableTaskClientBuilder builder, string version)
+    {
+        builder.Configure(options => options.DefaultVersion = version);
+        return builder;
+    }
 }

--- a/src/Client/Core/DurableTaskClientOptions.cs
+++ b/src/Client/Core/DurableTaskClientOptions.cs
@@ -14,6 +14,14 @@ public class DurableTaskClientOptions
     bool enableEntitySupport;
 
     /// <summary>
+    /// Gets or sets the version of orchestrations that will be created.
+    /// </summary>
+    /// <remarks>
+    /// Currently, this is sourced from the AzureManaged client options.
+    /// </remarks>
+    public string DefaultVersion { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the data converter. Default value is <see cref="JsonDataConverter.Default" />.
     /// </summary>
     /// <remarks>
@@ -94,6 +102,11 @@ public class DurableTaskClientOptions
             if (!other.EntitySupportExplicitlySet)
             {
                 other.EnableEntitySupport = this.EnableEntitySupport;
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.DefaultVersion))
+            {
+                other.DefaultVersion = this.DefaultVersion;
             }
         }
     }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -78,10 +78,20 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     {
         Check.NotEntity(this.options.EnableEntitySupport, options?.InstanceId);
 
+        string version = string.Empty;
+        if (!string.IsNullOrEmpty(orchestratorName.Version))
+        {
+            version = orchestratorName.Version;
+        }
+        else if (!string.IsNullOrEmpty(this.options.DefaultVersion))
+        {
+            version = this.options.DefaultVersion;
+        }
+
         var request = new P.CreateInstanceRequest
         {
             Name = orchestratorName.Name,
-            Version = orchestratorName.Version,
+            Version = version,
             InstanceId = options?.InstanceId ?? Guid.NewGuid().ToString("N"),
             Input = this.DataConverter.Serialize(input),
         };

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -81,6 +81,9 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         }
     }
 
+    /// <inheritdoc/>
+    public override string Version => this.innerContext.Version;
+
     /// <summary>
     /// Gets the DataConverter to use for inputs, outputs, and entity states.
     /// </summary>

--- a/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Grpc.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -67,6 +67,20 @@ public class DurableTaskClientBuilderExtensionsTests
         options.Address.Should().BeNull();
     }
 
+    [Fact]
+    public void UseDefaultVersion_DefaultVersion_Sets()
+    {
+        ServiceCollection services = new();
+        DefaultDurableTaskClientBuilder builder = new(null, services);
+        builder.UseDefaultVersion("0.1")
+            .UseGrpc();
+
+        IServiceProvider provider = services.BuildServiceProvider();
+        GrpcDurableTaskClientOptions options = provider.GetOptions<GrpcDurableTaskClientOptions>();
+
+        options.DefaultVersion.Should().Be("0.1");
+    }
+
 #if NET6_0_OR_GREATER
     static GrpcChannel GetChannel() => GrpcChannel.ForAddress("http://localhost:9001");
 #endif


### PR DESCRIPTION
This change adds a DefaultVersion to the DurableTaskClient builder options. When no other version is set, which is currently always the case, this value is used as the version of any new orchestration started. The value is then passed down to workers via the TaskOrchestrationContext.

This allows users to specify a version during their app setup and then key off of the version during orchestration. Using conditional logic, changes can then be made to the orchestration without harming in-progress orchestrations.