### PR TITLE
Support for local credential types for DTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.9.0 (unreleased)
 
 - Introduce default version setting to DurableTaskClient and expose to orchestrator ([#393](https://github.com/microsoft/durabletask-dotnet/pull/393))
-- Add support for local credential types in DTS libraries
+- Add support for local credential types in DTS libraries ([#396](https://github.com/microsoft/durabletask-dotnet/pull/396))
 
 ## v1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.9.0 (unreleased)
 
 - Introduce default version setting to DurableTaskClient and expose to orchestrator ([#393](https://github.com/microsoft/durabletask-dotnet/pull/393))
+- Add support for local credential types in DTS libraries
 
 ## v1.8.1
 

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.ComponentModel.DataAnnotations;
 using Azure.Core;
 using Azure.Identity;
@@ -152,6 +153,12 @@ public class DurableTaskSchedulerClientOptions
                 return new AzureCliCredential();
             case "azurepowershell":
                 return new AzurePowerShellCredential();
+            case "visualstudio":
+                return new VisualStudioCredential();
+            case "visualstudiocode":
+                return new VisualStudioCodeCredential();
+            case "interactivebrowser":
+                return new InteractiveBrowserCredential();
             case "none":
                 return null;
             default:

--- a/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
+++ b/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.ComponentModel.DataAnnotations;
 using Azure.Core;
 using Azure.Identity;
@@ -159,6 +160,12 @@ public class DurableTaskSchedulerWorkerOptions
                 return new AzureCliCredential();
             case "azurepowershell":
                 return new AzurePowerShellCredential();
+            case "visualstudio":
+                return new VisualStudioCredential();
+            case "visualstudiocode":
+                return new VisualStudioCodeCredential();
+            case "interactivebrowser":
+                return new InteractiveBrowserCredential();
             case "none":
                 return null;
             default:

--- a/test/Client/AzureManaged.Tests/DurableTaskSchedulerClientOptionsTests.cs
+++ b/test/Client/AzureManaged.Tests/DurableTaskSchedulerClientOptionsTests.cs
@@ -60,14 +60,12 @@ public class DurableTaskSchedulerClientOptionsTests
         options.Credential.Should().BeOfType<WorkloadIdentityCredential>();
     }
 
-    [Theory]
-    [InlineData("Environment")]
-    [InlineData("AzureCLI")]
-    [InlineData("AzurePowerShell")]
-    public void FromConnectionString_WithValidAuthTypes_ShouldCreateValidInstance(string authType)
+
+    [Fact]
+    public void FromConnectionString_WithEnvironmentCredential_ShouldCreateValidInstance()
     {
         // Arrange
-        string connectionString = $"Endpoint={ValidEndpoint};Authentication={authType};TaskHub={ValidTaskHub}";
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=Environment;TaskHub={ValidTaskHub}";
 
         // Act
         DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
@@ -75,7 +73,82 @@ public class DurableTaskSchedulerClientOptionsTests
         // Assert
         options.EndpointAddress.Should().Be(ValidEndpoint);
         options.TaskHubName.Should().Be(ValidTaskHub);
-        options.Credential.Should().NotBeNull();
+        options.Credential.Should().BeOfType<EnvironmentCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithAzureCliCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=AzureCLI;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<AzureCliCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithAzurePowerShellCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=AzurePowerShell;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<AzurePowerShellCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithVisualStudioCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=VisualStudio;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<VisualStudioCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithVisualStudioCodeCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=VisualStudioCode;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<VisualStudioCodeCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithInteractiveCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=InteractiveBrowser;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerClientOptions options = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<InteractiveBrowserCredential>();
     }
 
     [Fact]

--- a/test/Worker/AzureManaged.Tests/DurableTaskSchedulerWorkerOptionsTests.cs
+++ b/test/Worker/AzureManaged.Tests/DurableTaskSchedulerWorkerOptionsTests.cs
@@ -60,14 +60,11 @@ public class DurableTaskSchedulerWorkerOptionsTests
         options.Credential.Should().BeOfType<WorkloadIdentityCredential>();
     }
 
-    [Theory]
-    [InlineData("Environment")]
-    [InlineData("AzureCLI")]
-    [InlineData("AzurePowerShell")]
-    public void FromConnectionString_WithValidAuthTypes_ShouldCreateValidInstance(string authType)
+    [Fact]
+    public void FromConnectionString_WithEnvironmentCredential_ShouldCreateValidInstance()
     {
         // Arrange
-        string connectionString = $"Endpoint={ValidEndpoint};Authentication={authType};TaskHub={ValidTaskHub}";
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=Environment;TaskHub={ValidTaskHub}";
 
         // Act
         DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
@@ -75,7 +72,82 @@ public class DurableTaskSchedulerWorkerOptionsTests
         // Assert
         options.EndpointAddress.Should().Be(ValidEndpoint);
         options.TaskHubName.Should().Be(ValidTaskHub);
-        options.Credential.Should().NotBeNull();
+        options.Credential.Should().BeOfType<EnvironmentCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithAzureCliCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=AzureCLI;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<AzureCliCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithAzurePowerShellCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=AzurePowerShell;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<AzurePowerShellCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithVisualStudioCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=VisualStudio;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<VisualStudioCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithVisualStudioCodeCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=VisualStudioCode;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<VisualStudioCodeCredential>();
+    }
+
+    [Fact]
+    public void FromConnectionString_WithInteractiveCredential_ShouldCreateValidInstance()
+    {
+        // Arrange
+        string connectionString = $"Endpoint={ValidEndpoint};Authentication=InteractiveBrowser;TaskHub={ValidTaskHub}";
+
+        // Act
+        DurableTaskSchedulerWorkerOptions options = DurableTaskSchedulerWorkerOptions.FromConnectionString(connectionString);
+
+        // Assert
+        options.EndpointAddress.Should().Be(ValidEndpoint);
+        options.TaskHubName.Should().Be(ValidTaskHub);
+        options.Credential.Should().BeOfType<InteractiveBrowserCredential>();
     }
 
     [Fact]


### PR DESCRIPTION
Adds support for local credential types (VS, VS Code, and Interactive Browser) to the Durable Task Scheduler Client and Worker Options classes.

Addresses https://github.com/Azure/Azure-Functions-Durable-Task-Scheduler-Private-Preview/issues/102#issuecomment-2697041029