### PR TITLE
Add Exception Type `SubOrchestrationFailedException` 

### DIFF
--- a/src/Abstractions/SubOrchestrationFailedException.cs
+++ b/src/Abstractions/SubOrchestrationFailedException.cs
@@ -20,9 +20,8 @@ public sealed class SubOrchestrationFailedException : Exception
     /// <param name="taskName">The failed sub-orchestrationname.</param>
     /// <param name="taskId">The task ID.</param>
     /// <param name="failureDetails">The failure details.</param>
-    /// <param name="innerException">The inner exception.</param>
-    public SubOrchestrationFailedException(string taskName, int taskId, TaskFailureDetails failureDetails, Exception innerException)
-       : base(GetExceptionMessage(taskName, taskId, failureDetails, innerException), FromExceptionRecursive(innerException))
+    public SubOrchestrationFailedException(string taskName, int taskId, TaskFailureDetails failureDetails)
+       : base(GetExceptionMessage(taskName, taskId, failureDetails, null))
     {
         this.TaskName = taskName;
         this.TaskId = taskId;
@@ -72,21 +71,5 @@ public sealed class SubOrchestrationFailedException : Exception
         return subMessage is null
             ? $"Task '{taskName}' (#{taskId}) failed with an unhandled exception."
             : $"Task '{taskName}' (#{taskId}) failed with an unhandled exception: {subMessage}";
-    }
-
-    static Exception? FromExceptionRecursive(Exception? exception)
-    {
-        if (exception is null)
-        {
-            return null;
-        }
-
-        if (exception is CoreOrchestrationException)
-        {
-            // is always null!!!
-            return FromExceptionRecursive(exception.InnerException);
-        }
-
-        return exception;
     }
 }

--- a/src/Abstractions/SubOrchestrationFailedException.cs
+++ b/src/Abstractions/SubOrchestrationFailedException.cs
@@ -1,40 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using CoreOrchestrationException = DurableTask.Core.Exceptions.OrchestrationException;
 
 namespace Microsoft.DurableTask;
 
 /// <summary>
-/// Exception that gets thrown when a durable task, such as an activity , fails with an
+/// Exception that gets thrown when a durable task sub-orchestration, fails with an
 /// unhandled exception.
 /// </summary>
 /// <remarks>
 /// Detailed information associated with a particular task failure, including exception details, can be found in the
 /// <see cref="FailureDetails"/> property.
 /// </remarks>
-public sealed class TaskFailedException : Exception
+public sealed class SubOrchestrationFailedException : Exception
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="TaskFailedException"/> class.
+    /// Initializes a new instance of the <see cref="SubOrchestrationFailedException"/> class.
     /// </summary>
-    /// <param name="taskName">The task name.</param>
-    /// <param name="taskId">The task ID.</param>
-    /// <param name="innerException">The inner exception.</param>
-    public TaskFailedException(string taskName, int taskId, Exception innerException)
-        : base(GetExceptionMessage(taskName, taskId, null, innerException), innerException)
-    {
-        this.TaskName = taskName;
-        this.TaskId = taskId;
-        this.FailureDetails = TaskFailureDetails.FromException(innerException);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TaskFailedException"/> class.
-    /// </summary>
-    /// <param name="taskName">The task name.</param>
+    /// <param name="taskName">The failed sub-orchestrationname.</param>
     /// <param name="taskId">The task ID.</param>
     /// <param name="failureDetails">The failure details.</param>
-    public TaskFailedException(string taskName, int taskId, TaskFailureDetails failureDetails)
-        : base(GetExceptionMessage(taskName, taskId, failureDetails, null))
+    /// <param name="innerException">The inner exception.</param>
+    public SubOrchestrationFailedException(string taskName, int taskId, TaskFailureDetails failureDetails, Exception innerException)
+       : base(GetExceptionMessage(taskName, taskId, failureDetails, innerException), FromExceptionRecursive(innerException))
     {
         this.TaskName = taskName;
         this.TaskId = taskId;
@@ -42,12 +30,12 @@ public sealed class TaskFailedException : Exception
     }
 
     /// <summary>
-    /// Gets the name of the failed task.
+    /// Gets the name of the failed sub-orchestration.
     /// </summary>
     public string TaskName { get; }
 
     /// <summary>
-    /// Gets the ID of the failed task.
+    /// Gets the ID of the failed sub-orchestration.
     /// </summary>
     /// <remarks>
     /// Each durable task (activities, timers, sub-orchestrations, etc.) scheduled by a task orchestrator has an
@@ -62,23 +50,7 @@ public sealed class TaskFailedException : Exception
     /// </summary>
     public TaskFailureDetails FailureDetails { get; }
 
-    /// <summary>
-    /// Returns true if the task failure was provided by the specified exception type.
-    /// </summary>
-    /// <remarks>
-    /// This method allows checking if a task failed due to an exception of a specific type.
-    /// The comparison relies on a string comparison of the full type name (e.g., "System.InvalidOperationException")
-    /// and therefore doesn't support base types.
-    /// </remarks>
-    /// <typeparam name="T">The type of exception to test against.</typeparam>
-    /// <returns>
-    /// Returns <c>true</c> if the <see cref="FailureDetails"/>'s <see cref="TaskFailureDetails.ErrorType"/> value
-    /// matches <typeparamref name="T"/>; <c>false</c> otherwise.
-    /// </returns>
-    [Obsolete("Use the FailureDetails property and its IsCausedBy<T>() method")]
-    public bool IsCausedByException<T>() where T : Exception
-        => this.FailureDetails.ErrorType == typeof(T).FullName;
-
+    // This method is the same as the one in `TaskFailedException` to keep the exception message format consistent.
     static string GetExceptionMessage(string taskName, int taskId, TaskFailureDetails? details, Exception? cause)
     {
         // NOTE: Some integration tests depend on the format of this exception message.
@@ -100,5 +72,21 @@ public sealed class TaskFailedException : Exception
         return subMessage is null
             ? $"Task '{taskName}' (#{taskId}) failed with an unhandled exception."
             : $"Task '{taskName}' (#{taskId}) failed with an unhandled exception: {subMessage}";
+    }
+
+    static Exception? FromExceptionRecursive(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return null;
+        }
+
+        if (exception is CoreOrchestrationException)
+        {
+            // is always null!!!
+            return FromExceptionRecursive(exception.InnerException);
+        }
+
+        return exception;
     }
 }

--- a/src/Abstractions/TaskFailureDetails.cs
+++ b/src/Abstractions/TaskFailureDetails.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using CoreFailureDetails = DurableTask.Core.FailureDetails;
 using CoreOrchestrationException = DurableTask.Core.Exceptions.OrchestrationException;
-using CoreSubOrchestrationFailedException = DurableTask.Core.Exceptions.SubOrchestrationFailedException;
 
 namespace Microsoft.DurableTask;
 
@@ -157,15 +156,6 @@ public record TaskFailureDetails(string ErrorType, string ErrorMessage, string? 
 
         if (exception is CoreOrchestrationException coreEx)
         {
-            if (coreEx is CoreSubOrchestrationFailedException)
-            {
-                return new TaskFailureDetails(
-                    coreEx.GetType().ToString(),
-                    coreEx.Message,
-                    coreEx.StackTrace,
-                    FromCoreFailureDetailsRecursive(coreEx.FailureDetails?.InnerFailure) ?? FromExceptionRecursive(coreEx.InnerException));
-            }
-
             return new TaskFailureDetails(
                 coreEx.FailureDetails?.ErrorType ?? "(unknown)",
                 coreEx.FailureDetails?.ErrorMessage ?? "(unknown)",

--- a/src/Abstractions/TaskFailureDetails.cs
+++ b/src/Abstractions/TaskFailureDetails.cs
@@ -155,8 +155,17 @@ public record TaskFailureDetails(string ErrorType, string ErrorMessage, string? 
             return null;
         }
 
-        if (exception is CoreOrchestrationException coreEx && exception is not CoreSubOrchestrationFailedException)
+        if (exception is CoreOrchestrationException coreEx)
         {
+            if (coreEx is CoreSubOrchestrationFailedException)
+            {
+                return new TaskFailureDetails(
+                    coreEx.GetType().ToString(),
+                    coreEx.Message,
+                    coreEx.StackTrace,
+                    FromCoreFailureDetailsRecursive(coreEx.FailureDetails?.InnerFailure) ?? FromExceptionRecursive(coreEx.InnerException));
+            }
+
             return new TaskFailureDetails(
                 coreEx.FailureDetails?.ErrorType ?? "(unknown)",
                 coreEx.FailureDetails?.ErrorMessage ?? "(unknown)",

--- a/src/Abstractions/TaskFailureDetails.cs
+++ b/src/Abstractions/TaskFailureDetails.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using CoreFailureDetails = DurableTask.Core.FailureDetails;
 using CoreOrchestrationException = DurableTask.Core.Exceptions.OrchestrationException;
+using CoreSubOrchestrationFailedException = DurableTask.Core.Exceptions.SubOrchestrationFailedException;
 
 namespace Microsoft.DurableTask;
 
@@ -154,7 +155,7 @@ public record TaskFailureDetails(string ErrorType, string ErrorMessage, string? 
             return null;
         }
 
-        if (exception is CoreOrchestrationException coreEx)
+        if (exception is CoreOrchestrationException coreEx && exception is not CoreSubOrchestrationFailedException)
         {
             return new TaskFailureDetails(
                 coreEx.FailureDetails?.ErrorType ?? "(unknown)",

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.DurableTask.Abstractions;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 
@@ -332,9 +333,9 @@ public abstract class TaskOrchestrationContext
     /// <exception cref="InvalidOperationException">
     /// Thrown if the calling thread is anything other than the main orchestrator thread.
     /// </exception>
-    /// <exception cref="TaskFailedException">
+    /// <exception cref="SubOrchestrationFailedException">
     /// The sub-orchestration failed with an unhandled exception. The details of the failure can be found in the
-    /// <see cref="TaskFailedException.FailureDetails"/> property.
+    /// <see cref="SubOrchestrationFailedException.FailureDetails"/> property.
     /// </exception>
     public virtual Task CallSubOrchestratorAsync(
         TaskName orchestratorName, object? input = null, TaskOptions? options = null)

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -198,10 +198,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         catch (global::DurableTask.Core.Exceptions.SubOrchestrationFailedException e)
         {
             // Hide the core DTFx types and instead use our own
-            throw new TaskFailedException(
-                orchestratorName,
-                e.ScheduleId,
-                TaskFailureDetails.FromCoreFailureDetails(e.FailureDetails!));
+            throw new TaskFailedException(orchestratorName, e.ScheduleId, e);
         }
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -7,6 +7,7 @@ using System.Text;
 using DurableTask.Core;
 using DurableTask.Core.Entities.OperationFormat;
 using DurableTask.Core.Serializing.Internal;
+using Microsoft.DurableTask.Abstractions;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 
@@ -197,8 +198,12 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         }
         catch (global::DurableTask.Core.Exceptions.SubOrchestrationFailedException e)
         {
-            // Hide the core DTFx types and instead use our own
-            throw new TaskFailedException(orchestratorName, e.ScheduleId, e);
+            // Hide the core DTFx types and instead use our own SubOrchestrationFailedException
+            throw new SubOrchestrationFailedException(
+                orchestratorName,
+                e.ScheduleId,
+                TaskFailureDetails.FromCoreFailureDetails(e.FailureDetails!),
+                e);
         }
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -202,8 +202,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
             throw new SubOrchestrationFailedException(
                 orchestratorName,
                 e.ScheduleId,
-                TaskFailureDetails.FromCoreFailureDetails(e.FailureDetails!),
-                e);
+                TaskFailureDetails.FromCoreFailureDetails(e.FailureDetails!));
         }
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -64,6 +64,16 @@ partial class TaskOrchestrationShim : TaskOrchestration
                 FailureDetails = new FailureDetails(e, e.FailureDetails.ToCoreFailureDetails()),
             };
         }
+        catch (SubOrchestrationFailedException e)
+        {
+            // Convert back to something the Durable Task Framework natively understands so that
+            // failure details are correctly propagated.
+            // This has to be DurableTask.Core.TaskFailedException instead of DurableTask.Core.SubOrchestratorFailedException because of core logic.
+            throw new CoreTaskFailedException(e.Message, e.InnerException)
+            {
+                FailureDetails = new FailureDetails(e, e.FailureDetails.ToCoreFailureDetails()),
+            };
+        }
         finally
         {
             // if user code crashed inside a critical section, or did not exit it, do that now

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -7,6 +7,8 @@ using Microsoft.DurableTask.Worker;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
+using CoreSubOrchestrationFailedException = DurableTask.Core.Exceptions.SubOrchestrationFailedException;
+
 namespace Microsoft.DurableTask.Grpc.Tests;
 
 /// <summary>
@@ -427,7 +429,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
             }
 
             // This handler only works with CustomException
-            if (!retryContext.LastFailure.IsCausedBy(exceptionType))
+            if (!retryContext.LastFailure.IsCausedBy(typeof(CoreSubOrchestrationFailedException)))
             {
                 return false;
             }
@@ -543,8 +545,8 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
                     {
                         // Outer failure represents the orchestration failure
                         Assert.NotNull(ex.FailureDetails);
-                        Assert.True(ex.FailureDetails.IsCausedBy<TaskFailedException>());
-                        Assert.Contains("ThrowException", ex.FailureDetails.ErrorMessage);
+                        Assert.True(ex.FailureDetails.IsCausedBy<CoreSubOrchestrationFailedException>());
+                        Assert.Contains("Exception of type", ex.FailureDetails.ErrorMessage);
 
                         // Inner failure represents the original exception thrown by the activity
                         ValidateInnermostFailureDetailsChain(ex.FailureDetails.InnerFailure);
@@ -583,8 +585,8 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.True(metadata.FailureDetails!.IsCausedBy<TaskFailedException>());
         Assert.Contains("Sub", metadata.FailureDetails.ErrorMessage);
         Assert.NotNull(metadata.FailureDetails.InnerFailure);
-        Assert.True(metadata.FailureDetails.InnerFailure!.IsCausedBy<TaskFailedException>());
-        Assert.Contains("ThrowException", metadata.FailureDetails.InnerFailure.ErrorMessage);
+        Assert.True(metadata.FailureDetails.InnerFailure!.IsCausedBy<CoreSubOrchestrationFailedException>());
+        Assert.Contains("Exception of type", metadata.FailureDetails.InnerFailure.ErrorMessage);
 
         ValidateInnermostFailureDetailsChain(metadata.FailureDetails.InnerFailure.InnerFailure);
     }


### PR DESCRIPTION
This PR partially solves issue https://github.com/Azure/azure-functions-durable-extension/issues/2689

This PR adds a new exception type `Microsoft.DurableTask.SubOrchestrationFailedException`. Previously, `SubOrchestrationFailedException` was included with the `TaskFailedException`, and it's now handled separately with this new type.

For example, if cx want custom handling logic specifically for suborchestration failures, they should write a catch block for SubOrchestrationFailedException instead of the broader TaskFailedException.

```csharp
try
{
    await ctx.CallActivityAsync("myactivity");
    await ctx.CallSubOrchestratorAsync("mysuborch");
}
catch (SubOrchestrationFailedException ex)
{
    // Handle suborchestration-specific exceptions here
}
catch (TaskFailedException ex)
{
    // Handle other task failures here, including Activities, non-deterministic etc
}
```


