### PR TITLE
Partial Purge Support

### DIFF
--- a/src/Client/Core/PurgeResult.cs
+++ b/src/Client/Core/PurgeResult.cs
@@ -12,11 +12,23 @@ public class PurgeResult
     /// Initializes a new instance of the <see cref="PurgeResult" /> class.
     /// </summary>
     /// <param name="count">The count of instances purged.</param>
-    /// <param name="isComplete">A value indicating whether the purge operation is complete. Default is null.</param>
-    public PurgeResult(int count, bool? isComplete = null)
+    public PurgeResult(int count)
     {
         Check.Argument(count >= 0, nameof(count), "Count must be non-negative");
         this.PurgedInstanceCount = count;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PurgeResult" /> class.
+    /// </summary>
+    /// <param name="count">The number of instances deleted.</param>
+    /// <param name="isComplete">A value indicating whether the purge operation is complete. 
+    /// If true, the purge operation is complete. All instances were purged.
+    /// If false, not all instances were purged. Please purge again.
+    /// If null, default to legacy purge behavior. All instances were purged.</param>
+    public PurgeResult(int count, bool? isComplete)
+        : this(count)
+    {
         this.IsComplete = isComplete;
     }
 

--- a/src/Client/Core/PurgeResult.cs
+++ b/src/Client/Core/PurgeResult.cs
@@ -22,7 +22,7 @@ public class PurgeResult
     /// Initializes a new instance of the <see cref="PurgeResult" /> class.
     /// </summary>
     /// <param name="count">The number of instances deleted.</param>
-    /// <param name="isComplete">A value indicating whether the purge operation is complete. 
+    /// <param name="isComplete">A value indicating whether the purge operation is complete.
     /// If true, the purge operation is complete. All instances were purged.
     /// If false, not all instances were purged. Please purge again.
     /// If null, whether or not all instances were purged is undefined.</param>

--- a/src/Client/Core/PurgeResult.cs
+++ b/src/Client/Core/PurgeResult.cs
@@ -25,7 +25,7 @@ public class PurgeResult
     /// <param name="isComplete">A value indicating whether the purge operation is complete. 
     /// If true, the purge operation is complete. All instances were purged.
     /// If false, not all instances were purged. Please purge again.
-    /// If null, default to legacy purge behavior. All instances were purged.</param>
+    /// If null, whether or not all instances were purged is undefined.</param>
     public PurgeResult(int count, bool? isComplete)
         : this(count)
     {

--- a/src/Client/Core/PurgeResult.cs
+++ b/src/Client/Core/PurgeResult.cs
@@ -12,10 +12,12 @@ public class PurgeResult
     /// Initializes a new instance of the <see cref="PurgeResult" /> class.
     /// </summary>
     /// <param name="count">The count of instances purged.</param>
-    public PurgeResult(int count)
+    /// <param name="isComplete">A value indicating whether the purge operation is complete. Default is null.</param>
+    public PurgeResult(int count, bool? isComplete = null)
     {
         Check.Argument(count >= 0, nameof(count), "Count must be non-negative");
         this.PurgedInstanceCount = count;
+        this.IsComplete = isComplete;
     }
 
     /// <summary>
@@ -23,4 +25,10 @@ public class PurgeResult
     /// </summary>
     /// <value>The number of purged instances.</value>
     public int PurgedInstanceCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the purge operation is complete.
+    /// </summary>
+    /// <value>A value indicating whether the purge operation is complete.</value>
+    public bool? IsComplete { get; }
 }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -446,7 +446,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         {
             P.PurgeInstancesResponse response = await this.sidecarClient.PurgeInstancesAsync(
                 request, cancellationToken: cancellation);
-            return new PurgeResult(response.DeletedInstanceCount);
+            return new PurgeResult(response.DeletedInstanceCount, response.IsComplete);
         }
         catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
         {

--- a/src/Grpc/orchestrator_service.proto
+++ b/src/Grpc/orchestrator_service.proto
@@ -463,6 +463,7 @@ message PurgeInstanceFilter {
 
 message PurgeInstancesResponse {
     int32 deletedInstanceCount = 1;
+    google.protobuf.BoolValue isComplete = 2;
 }
 
 message CreateTaskHubRequest {
@@ -617,6 +618,30 @@ message StartNewOrchestrationAction {
     google.protobuf.Timestamp scheduledTime = 5;
 }
 
+message AbandonActivityTaskRequest {
+    string completionToken = 1;
+}
+
+message AbandonActivityTaskResponse {
+    // Empty.
+}
+
+message AbandonOrchestrationTaskRequest {
+    string completionToken = 1;
+}
+
+message AbandonOrchestrationTaskResponse {
+    // Empty.
+}
+
+message AbandonEntityTaskRequest {
+    string completionToken = 1;
+}
+
+message AbandonEntityTaskResponse {
+    // Empty.
+}
+
 service TaskHubSidecarService {
     // Sends a hello request to the sidecar service.
     rpc Hello(google.protobuf.Empty) returns (google.protobuf.Empty);
@@ -678,6 +703,15 @@ service TaskHubSidecarService {
 
     // clean entity storage
     rpc CleanEntityStorage(CleanEntityStorageRequest) returns (CleanEntityStorageResponse);
+
+    // Abandons a single work item
+    rpc AbandonTaskActivityWorkItem(AbandonActivityTaskRequest) returns (AbandonActivityTaskResponse);
+
+    // Abandon an orchestration work item
+    rpc AbandonTaskOrchestratorWorkItem(AbandonOrchestrationTaskRequest) returns (AbandonOrchestrationTaskResponse);
+
+    // Abandon an entity work item
+    rpc AbandonTaskEntityWorkItem(AbandonEntityTaskRequest) returns (AbandonEntityTaskResponse);
 }
 
 message GetWorkItemsRequest {

--- a/src/Grpc/versions.txt
+++ b/src/Grpc/versions.txt
@@ -1,2 +1,2 @@
-# The following files were downloaded from branch main at 2025-03-19 19:55:31 UTC
-https://raw.githubusercontent.com/microsoft/durabletask-protobuf/4792f47019ab2b3e9ea979fb4af72427a4144c51/protos/orchestrator_service.proto
+# The following files were downloaded from branch main at 2025-03-24 23:37:31 UTC
+https://raw.githubusercontent.com/microsoft/durabletask-protobuf/c85ef11430ff8e10e21105abb545b0803bb86c66/protos/orchestrator_service.proto

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -174,6 +174,7 @@ public class ShimDurableTaskClientTests
         // assert
         this.orchestrationClient.VerifyAll();
         result.PurgedInstanceCount.Should().Be(1);
+        result.IsComplete.Should().BeNull();
     }
 
     [Fact]

--- a/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
+++ b/test/Grpc.IntegrationTests/GrpcDurableTaskClientIntegrationTests.cs
@@ -179,7 +179,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         // Assert
         result.Should().NotBeNull();
         result.PurgedInstanceCount.Should().Be(1);
-        result.IsComplete.Should().BeNull();
+        result.IsComplete.Should().NotBeFalse();
         // Verify instance no longer exists
         OrchestrationMetadata? instance = await server.Client.GetInstanceAsync(instanceId, false);
         instance.Should().BeNull();
@@ -215,7 +215,7 @@ public class DurableTaskGrpcClientIntegrationTests : IntegrationTestBase
         // Assert
         result.Should().NotBeNull();
         result.PurgedInstanceCount.Should().BeGreaterThan(3);
-        result.IsComplete.Should().BeNull();
+        result.IsComplete.Should().NotBeFalse();
         // Verify instances no longer exist
         foreach (string instanceId in instanceIds)
         {


### PR DESCRIPTION
This pull request add portable sdk support for partial purge to dts backend.  PurgeInstancesResponse will return an optional flag "Iscomplete" to indicate whether purge is fully done or done partially.

Enhancements to `PurgeResult` class and related client updates:

* [`src/Client/Core/PurgeResult.cs`](diffhunk://#diff-125be6ccd02823bcbe25929c5cf6cdd7cac4b8263995f6ec49525015c2fde7c1L15-R33): Added a new `isComplete` parameter to the `PurgeResult` constructor and a corresponding `IsComplete` property to indicate whether the purge operation is complete.
* [`src/Client/Grpc/GrpcDurableTaskClient.cs`](diffhunk://#diff-1cbc56f55c712147e9731872d3513aebfdd938d74874d59ab6ddea60e75586b4L449-R449): Updated the `PurgeInstancesCoreAsync` method to pass the `IsComplete` value from the response to the `PurgeResult` constructor.
* [`src/Grpc/orchestrator_service.proto`](diffhunk://#diff-1da44a507b5d92ecb779a36d1bffcf6974159609ba30a0470958b0250c7782abR466): Added a new `isComplete` field to the `PurgeInstancesResponse` message to support the new `IsComplete` property in the `PurgeResult` class.

