### PR TITLE
Dts Grpc client retry support

### DIFF
--- a/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
@@ -6,6 +6,7 @@ using Azure.Core;
 using Azure.Identity;
 using Grpc.Core;
 using Grpc.Net.Client;
+using Grpc.Net.Client.Configuration;
 
 namespace Microsoft.DurableTask;
 
@@ -112,6 +113,24 @@ public class DurableTaskSchedulerClientOptions
         {
             Credentials = ChannelCredentials.Create(channelCreds, managedBackendCreds),
             UnsafeUseInsecureChannelCallCredentials = this.AllowInsecureCredentials,
+            ServiceConfig = new ServiceConfig
+            {
+                MethodConfigs =
+                {
+                    new MethodConfig
+                    {
+                        Names = { MethodName.Default },
+                        RetryPolicy = new Grpc.Net.Client.Configuration.RetryPolicy()
+                        {
+                            MaxAttempts = 10,
+                            InitialBackoff = TimeSpan.FromMilliseconds(50),
+                            MaxBackoff = TimeSpan.FromMilliseconds(250),
+                            BackoffMultiplier = 2,
+                            RetryableStatusCodes = { StatusCode.Unavailable },
+                        },
+                    },
+                },
+            },
         });
     }
 
@@ -127,7 +146,7 @@ public class DurableTaskSchedulerClientOptions
             case "managedidentity":
                 return new ManagedIdentityCredential(connectionString.ClientId);
             case "workloadidentity":
-                var opts = new WorkloadIdentityCredentialOptions();
+                WorkloadIdentityCredentialOptions opts = new WorkloadIdentityCredentialOptions();
                 if (!string.IsNullOrEmpty(connectionString.ClientId))
                 {
                     opts.ClientId = connectionString.ClientId;

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
@@ -113,24 +113,7 @@ public class DurableTaskSchedulerClientOptions
         {
             Credentials = ChannelCredentials.Create(channelCreds, managedBackendCreds),
             UnsafeUseInsecureChannelCallCredentials = this.AllowInsecureCredentials,
-            ServiceConfig = new ServiceConfig
-            {
-                MethodConfigs =
-                {
-                    new MethodConfig
-                    {
-                        Names = { MethodName.Default },
-                        RetryPolicy = new Grpc.Net.Client.Configuration.RetryPolicy()
-                        {
-                            MaxAttempts = 10,
-                            InitialBackoff = TimeSpan.FromMilliseconds(50),
-                            MaxBackoff = TimeSpan.FromMilliseconds(250),
-                            BackoffMultiplier = 2,
-                            RetryableStatusCodes = { StatusCode.Unavailable },
-                        },
-                    },
-                },
-            },
+            ServiceConfig = GrpcRetryPolicyDefaults.DefaultServiceConfig,
         });
     }
 

--- a/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
+++ b/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
@@ -32,19 +32,21 @@ sealed class GrpcRetryPolicyDefaults
     public const double DefaultBackoffMultiplier = 2;
 
     /// <summary>
+    /// The default service configuration that includes the method configuration.
+    /// </summary>
+    /// <remarks>
+    /// This can be applied to a gRPC channel to enable automatic retries for all methods.
+    /// </remarks>
+    public static readonly ServiceConfig DefaultServiceConfig;
+
+
+    /// <summary>
     /// The default retry policy for gRPC operations.
     /// </summary>
     /// <remarks>
     /// - Retries only for Unavailable status codes (typically connection issues).
     /// </remarks>
-    static readonly Grpc.Net.Client.Configuration.RetryPolicy Default = new()
-    {
-        MaxAttempts = DefaultMaxAttempts,
-        InitialBackoff = TimeSpan.FromMilliseconds(DefaultInitialBackoffMs),
-        MaxBackoff = TimeSpan.FromMilliseconds(DefaultMaxBackoffMs),
-        BackoffMultiplier = DefaultBackoffMultiplier,
-        RetryableStatusCodes = { StatusCode.Unavailable },
-    };
+    static readonly Grpc.Net.Client.Configuration.RetryPolicy Default;
 
     /// <summary>
     /// The default method configuration that applies the retry policy to all methods.
@@ -52,22 +54,28 @@ sealed class GrpcRetryPolicyDefaults
     /// <remarks>
     /// Uses MethodName.Default to apply the retry policy to all gRPC methods.
     /// </remarks>
-    static readonly MethodConfig DefaultMethodConfig = new()
-    {
-        Names = { MethodName.Default },
-        RetryPolicy = Default,
-    };
+    static readonly MethodConfig DefaultMethodConfig;
 
-    /// <summary>
-    /// The default service configuration that includes the method configuration.
-    /// </summary>
-    /// <remarks>
-    /// This can be applied to a gRPC channel to enable automatic retries for all methods.
-    /// </remarks>
-#pragma warning disable SA1202 // Elements should be ordered by access
-    public static readonly ServiceConfig DefaultServiceConfig = new()
-#pragma warning restore SA1202 // Elements should be ordered by access
+    static GrpcRetryPolicyDefaults()
     {
-        MethodConfigs = { DefaultMethodConfig },
-    };
+        Default = new Grpc.Net.Client.Configuration.RetryPolicy
+        {
+            MaxAttempts = DefaultMaxAttempts,
+            InitialBackoff = TimeSpan.FromMilliseconds(DefaultInitialBackoffMs),
+            MaxBackoff = TimeSpan.FromMilliseconds(DefaultMaxBackoffMs),
+            BackoffMultiplier = DefaultBackoffMultiplier,
+            RetryableStatusCodes = { StatusCode.Unavailable },
+        };
+
+        DefaultMethodConfig = new MethodConfig
+        {
+            Names = { MethodName.Default },
+            RetryPolicy = Default,
+        };
+
+        DefaultServiceConfig = new ServiceConfig
+        {
+            MethodConfigs = { DefaultMethodConfig },
+        };
+    }
 }

--- a/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
+++ b/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
@@ -35,11 +35,6 @@ sealed class GrpcRetryPolicyDefaults
     /// The default retry policy for gRPC operations.
     /// </summary>
     /// <remarks>
-    /// This policy configures:
-    /// - Up to 10 retry attempts
-    /// - Initial backoff of 50ms
-    /// - Maximum backoff of 250ms
-    /// - Exponential backoff with multiplier of 2
     /// - Retries only for Unavailable status codes (typically connection issues).
     /// </remarks>
     static readonly Grpc.Net.Client.Configuration.RetryPolicy Default = new()

--- a/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
+++ b/src/Shared/AzureManaged/GrpcRetryPolicyDefaults.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Grpc.Core;
+using Grpc.Net.Client.Configuration;
+
+namespace Microsoft.DurableTask;
+
+/// <summary>
+/// Provides default retry policy configurations for gRPC client connections.
+/// </summary>
+sealed class GrpcRetryPolicyDefaults
+{
+    /// <summary>
+    /// Default maximum number of retry attempts.
+    /// </summary>
+    public const int DefaultMaxAttempts = 10;
+
+    /// <summary>
+    /// Default initial backoff in milliseconds.
+    /// </summary>
+    public const int DefaultInitialBackoffMs = 50;
+
+    /// <summary>
+    /// Default maximum backoff in milliseconds.
+    /// </summary>
+    public const int DefaultMaxBackoffMs = 250;
+
+    /// <summary>
+    /// Default backoff multiplier for exponential backoff.
+    /// </summary>
+    public const double DefaultBackoffMultiplier = 2;
+
+    /// <summary>
+    /// The default retry policy for gRPC operations.
+    /// </summary>
+    /// <remarks>
+    /// This policy configures:
+    /// - Up to 10 retry attempts
+    /// - Initial backoff of 50ms
+    /// - Maximum backoff of 250ms
+    /// - Exponential backoff with multiplier of 2
+    /// - Retries only for Unavailable status codes (typically connection issues).
+    /// </remarks>
+    static readonly Grpc.Net.Client.Configuration.RetryPolicy Default = new()
+    {
+        MaxAttempts = DefaultMaxAttempts,
+        InitialBackoff = TimeSpan.FromMilliseconds(DefaultInitialBackoffMs),
+        MaxBackoff = TimeSpan.FromMilliseconds(DefaultMaxBackoffMs),
+        BackoffMultiplier = DefaultBackoffMultiplier,
+        RetryableStatusCodes = { StatusCode.Unavailable },
+    };
+
+    /// <summary>
+    /// The default method configuration that applies the retry policy to all methods.
+    /// </summary>
+    /// <remarks>
+    /// Uses MethodName.Default to apply the retry policy to all gRPC methods.
+    /// </remarks>
+    static readonly MethodConfig DefaultMethodConfig = new()
+    {
+        Names = { MethodName.Default },
+        RetryPolicy = Default,
+    };
+
+    /// <summary>
+    /// The default service configuration that includes the method configuration.
+    /// </summary>
+    /// <remarks>
+    /// This can be applied to a gRPC channel to enable automatic retries for all methods.
+    /// </remarks>
+#pragma warning disable SA1202 // Elements should be ordered by access
+    public static readonly ServiceConfig DefaultServiceConfig = new()
+#pragma warning restore SA1202 // Elements should be ordered by access
+    {
+        MethodConfigs = { DefaultMethodConfig },
+    };
+}

--- a/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
+++ b/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
@@ -120,24 +120,7 @@ public class DurableTaskSchedulerWorkerOptions
         {
             Credentials = ChannelCredentials.Create(channelCreds, managedBackendCreds),
             UnsafeUseInsecureChannelCallCredentials = this.AllowInsecureCredentials,
-            ServiceConfig = new ServiceConfig
-            {
-                MethodConfigs =
-                {
-                    new MethodConfig
-                    {
-                        Names = { MethodName.Default },
-                        RetryPolicy = new Grpc.Net.Client.Configuration.RetryPolicy()
-                        {
-                            MaxAttempts = 10,
-                            InitialBackoff = TimeSpan.FromMilliseconds(50),
-                            MaxBackoff = TimeSpan.FromMilliseconds(250),
-                            BackoffMultiplier = 2,
-                            RetryableStatusCodes = { StatusCode.Unavailable },
-                        },
-                    },
-                },
-            },
+            ServiceConfig = GrpcRetryPolicyDefaults.DefaultServiceConfig,
         });
     }
 

--- a/test/Shared/AzureManaged.Tests/GrpcRetryPolicyDefaultsTests.cs
+++ b/test/Shared/AzureManaged.Tests/GrpcRetryPolicyDefaultsTests.cs
@@ -11,22 +11,10 @@ namespace Microsoft.DurableTask.Tests;
 public class GrpcRetryPolicyDefaultsTests
 {
     [Fact]
-    public void DefaultConstants_ShouldHaveExpectedValues()
-    {
-        // Assert
-        GrpcRetryPolicyDefaults.DefaultMaxAttempts.Should().Be(10);
-        GrpcRetryPolicyDefaults.DefaultInitialBackoffMs.Should().Be(50);
-        GrpcRetryPolicyDefaults.DefaultMaxBackoffMs.Should().Be(250);
-        GrpcRetryPolicyDefaults.DefaultBackoffMultiplier.Should().Be(2);
-    }
-
-    [Fact]
     public void DefaultServiceConfig_ShouldHaveExpectedConfiguration()
     {
-        // Arrange & Act
         ServiceConfig serviceConfig = GrpcRetryPolicyDefaults.DefaultServiceConfig;
 
-        // Assert
         serviceConfig.Should().NotBeNull();
         serviceConfig.MethodConfigs.Should().HaveCount(1);
 

--- a/test/Shared/AzureManaged.Tests/GrpcRetryPolicyDefaultsTests.cs
+++ b/test/Shared/AzureManaged.Tests/GrpcRetryPolicyDefaultsTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client.Configuration;
+using Xunit;
+
+namespace Microsoft.DurableTask.Tests;
+
+public class GrpcRetryPolicyDefaultsTests
+{
+    [Fact]
+    public void DefaultConstants_ShouldHaveExpectedValues()
+    {
+        // Assert
+        GrpcRetryPolicyDefaults.DefaultMaxAttempts.Should().Be(10);
+        GrpcRetryPolicyDefaults.DefaultInitialBackoffMs.Should().Be(50);
+        GrpcRetryPolicyDefaults.DefaultMaxBackoffMs.Should().Be(250);
+        GrpcRetryPolicyDefaults.DefaultBackoffMultiplier.Should().Be(2);
+    }
+
+    [Fact]
+    public void DefaultServiceConfig_ShouldHaveExpectedConfiguration()
+    {
+        // Arrange & Act
+        ServiceConfig serviceConfig = GrpcRetryPolicyDefaults.DefaultServiceConfig;
+
+        // Assert
+        serviceConfig.Should().NotBeNull();
+        serviceConfig.MethodConfigs.Should().HaveCount(1);
+
+        MethodConfig methodConfig = serviceConfig.MethodConfigs[0];
+        methodConfig.Names.Should().Contain(MethodName.Default);
+        methodConfig.RetryPolicy.Should().NotBeNull();
+
+        RetryPolicy? retryPolicy = methodConfig.RetryPolicy;
+        retryPolicy.Should().NotBeNull();
+        _ = retryPolicy!.MaxAttempts.Should().Be(GrpcRetryPolicyDefaults.DefaultMaxAttempts);
+        retryPolicy.InitialBackoff.Should().Be(TimeSpan.FromMilliseconds(GrpcRetryPolicyDefaults.DefaultInitialBackoffMs));
+        retryPolicy.MaxBackoff.Should().Be(TimeSpan.FromMilliseconds(GrpcRetryPolicyDefaults.DefaultMaxBackoffMs));
+        retryPolicy.BackoffMultiplier.Should().Be(GrpcRetryPolicyDefaults.DefaultBackoffMultiplier);
+        retryPolicy.RetryableStatusCodes.Should().ContainSingle()
+            .Which.Should().Be(StatusCode.Unavailable);
+    }
+} 

--- a/test/Shared/AzureManaged.Tests/Shared.AzureManaged.Tests.csproj
+++ b/test/Shared/AzureManaged.Tests/Shared.AzureManaged.Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Grpc.Core" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the `DurableTaskSchedulerClientOptions` and `DurableTaskSchedulerWorkerOptions` classes to enhance retry policies and improve code clarity. The most important changes include adding a retry policy configuration for gRPC calls and refining the instantiation of `WorkloadIdentityCredentialOptions`.

Enhancements to retry policies:

* [`src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs`](diffhunk://#diff-ce46f5c5201ad9a75c860d6c6ac558b5f1a83e634b631b09f82ae21281fc756bR116-R133): Added a `ServiceConfig` with a `RetryPolicy` to configure retry behavior for gRPC calls. This includes setting maximum attempts, backoff intervals, and retryable status codes.
* [`src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs`](diffhunk://#diff-3c4634be72788bc80433242b5b6f240de35385703293354152a437c7665dd7b3R123-R140): Added a similar `ServiceConfig` with a `RetryPolicy` to configure retry behavior for gRPC calls in the worker options.

Code clarity improvements:

* [`src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs`](diffhunk://#diff-ce46f5c5201ad9a75c860d6c6ac558b5f1a83e634b631b09f82ae21281fc756bL130-R149): Changed the instantiation of `WorkloadIdentityCredentialOptions` to use explicit type declaration for better readability.
* [`src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs`](diffhunk://#diff-3c4634be72788bc80433242b5b6f240de35385703293354152a437c7665dd7b3L137-R156): Made the same change to the instantiation of `WorkloadIdentityCredentialOptions` for consistency and readability.