### PR TITLE
Distributing Tracing for Entities (Isolated)

### DIFF
--- a/src/Client/Grpc/GrpcDurableEntityClient.cs
+++ b/src/Client/Grpc/GrpcDurableEntityClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using Microsoft.DurableTask.Client.Entities;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
@@ -56,6 +57,17 @@ class GrpcDurableEntityClient : DurableEntityClient
             Input = this.dataConverter.Serialize(input),
             ScheduledTime = scheduledTime?.ToTimestamp(),
         };
+
+        if (Activity.Current?.Id != null)
+        {
+            if (request.ParentTraceContext == null)
+            {
+                request.ParentTraceContext = new P.TraceContext();
+            }
+
+            request.ParentTraceContext.TraceParent = Activity.Current.Id;
+            request.ParentTraceContext.TraceState = Activity.Current.TraceStateString;
+        }
 
         // TODO this.logger.LogSomething
         try

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableEntityClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableEntityClient.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using DurableTask.Core;
 using DurableTask.Core.Entities;
+using DurableTask.Core.Tracing;
 using Microsoft.DurableTask.Client.Entities;
 using Microsoft.DurableTask.Entities;
 
@@ -90,7 +92,8 @@ class ShimDurableEntityClient(string name, ShimDurableTaskClientOptions options)
             EntityMessageEvent.GetCappedScheduledTime(
                 DateTime.UtcNow,
                 this.options.Entities.MaxSignalDelayTimeOrDefault,
-                scheduledTime?.UtcDateTime));
+                scheduledTime?.UtcDateTime),
+            Activity.Current?.Id != null ? new DistributedTraceContext(Activity.Current.Id, Activity.Current.TraceStateString) : null);
 
         await this.options.Client!.SendTaskOrchestrationMessageAsync(eventToSend.AsTaskMessage());
     }

--- a/src/Grpc/orchestrator_service.proto
+++ b/src/Grpc/orchestrator_service.proto
@@ -75,6 +75,7 @@ message ExecutionStartedEvent {
     google.protobuf.Timestamp scheduledStartTimestamp = 6;
     TraceContext parentTraceContext = 7;
     google.protobuf.StringValue orchestrationSpanID = 8;
+    map<string, string> tags = 9;
 }
 
 message ExecutionCompletedEvent {
@@ -343,14 +344,8 @@ message CreateInstanceRequest {
 }
 
 message OrchestrationIdReusePolicy {
-    repeated OrchestrationStatus operationStatus = 1;
-    CreateOrchestrationAction action = 2;
-}
-
-enum CreateOrchestrationAction {
-    ERROR = 0;
-    IGNORE = 1;
-    TERMINATE = 2;
+    repeated OrchestrationStatus replaceableStatus = 1;
+    reserved 2;
 }
 
 message CreateInstanceResponse {
@@ -391,6 +386,7 @@ message OrchestrationState {
     google.protobuf.StringValue executionId = 12;
     google.protobuf.Timestamp completedTimestamp = 13;
     google.protobuf.StringValue parentInstanceId = 14;
+    map<string, string> tags = 15;
 }
 
 message RaiseEventRequest {
@@ -491,6 +487,7 @@ message SignalEntityRequest {
     google.protobuf.StringValue input = 3;
     string requestId = 4;
     google.protobuf.Timestamp scheduledTime = 5;
+    TraceContext parentTraceContext = 6;
 }
 
 message SignalEntityResponse {
@@ -576,6 +573,7 @@ message OperationRequest {
     string operation = 1;
     string requestId = 2;
     google.protobuf.StringValue input = 3;
+    TraceContext TraceContext = 4;
 }
 
 message OperationResult {
@@ -592,10 +590,12 @@ message OperationInfo {
 
 message OperationResultSuccess {
     google.protobuf.StringValue result = 1;
+    google.protobuf.Timestamp endTime = 2;
 }
 
 message OperationResultFailure {
     TaskFailureDetails failureDetails = 1;
+    google.protobuf.Timestamp endTime = 2;
 }
 
 message OperationAction {
@@ -611,6 +611,8 @@ message SendSignalAction {
     string name = 2;
     google.protobuf.StringValue input = 3;
     google.protobuf.Timestamp scheduledTime = 4;
+    google.protobuf.Timestamp requestTime = 5;
+    TraceContext parentTraceContext = 6;
 }
 
 message StartNewOrchestrationAction {
@@ -619,6 +621,8 @@ message StartNewOrchestrationAction {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledTime = 5;
+    google.protobuf.Timestamp requestTime = 6;
+    TraceContext parentTraceContext = 7;
 }
 
 service TaskHubSidecarService {

--- a/src/Grpc/orchestrator_service.proto
+++ b/src/Grpc/orchestrator_service.proto
@@ -573,7 +573,7 @@ message OperationRequest {
     string operation = 1;
     string requestId = 2;
     google.protobuf.StringValue input = 3;
-    TraceContext TraceContext = 4;
+    TraceContext traceContext = 4;
 }
 
 message OperationResult {

--- a/src/Grpc/versions.txt
+++ b/src/Grpc/versions.txt
@@ -1,2 +1,2 @@
-# The following files were downloaded from branch stevosyan/distributed-tracing-for-entities at 2025-03-24 23:02:20 UTC
-https://raw.githubusercontent.com/microsoft/durabletask-protobuf/36e201ae2972fe86d42c19c7bc463c52243e39d9/protos/orchestrator_service.proto
+# The following files were downloaded from branch stevosyan/distributed-tracing-for-entities-isolated at 2025-03-28 03:19:09 UTC
+https://raw.githubusercontent.com/microsoft/durabletask-protobuf/c3ba3cbd50904b16357ca747d0ab6f1b7aca7602/protos/orchestrator_service.proto

--- a/src/Grpc/versions.txt
+++ b/src/Grpc/versions.txt
@@ -1,2 +1,2 @@
-# The following files were downloaded from branch main at 2025-02-19 06:25:02 UTC
-https://raw.githubusercontent.com/microsoft/durabletask-protobuf/589cb5ecd9dd4b1fe463750defa3e2c84276b079/protos/orchestrator_service.proto
+# The following files were downloaded from branch stevosyan/distributed-tracing-for-entities at 2025-03-24 23:02:20 UTC
+https://raw.githubusercontent.com/microsoft/durabletask-protobuf/36e201ae2972fe86d42c19c7bc463c52243e39d9/protos/orchestrator_service.proto

--- a/src/Worker/Core/Shims/TaskEntityShim.cs
+++ b/src/Worker/Core/Shims/TaskEntityShim.cs
@@ -4,6 +4,7 @@
 using DurableTask.Core;
 using DurableTask.Core.Entities;
 using DurableTask.Core.Entities.OperationFormat;
+using DurableTask.Core.Tracing;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 using DTCore = DurableTask.Core;
@@ -59,12 +60,17 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
         foreach (OperationRequest current in operations.Operations!)
         {
             this.operation.SetNameAndInput(current.Operation!, current.Input);
+            this.context.ParentTraceContext = current.TraceContext;
 
             try
             {
                 object? result = await this.taskEntity.RunAsync(this.operation);
                 string? serializedResult = this.dataConverter.Serialize(result);
-                results.Add(new OperationResult() { Result = serializedResult });
+                results.Add(new OperationResult()
+                {
+                    Result = serializedResult,
+                    EndTime = DateTime.UtcNow,
+                });
 
                 // the user code completed without exception, so we commit the current state and actions.
                 this.state.Commit();
@@ -76,6 +82,7 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
                 results.Add(new OperationResult()
                 {
                     FailureDetails = new FailureDetails(applicationException),
+                    EndTime = DateTime.UtcNow,
                 });
 
                 // the user code threw an unhandled exception, so we roll back the state and the actions.
@@ -171,6 +178,8 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
         List<OperationAction> operationActions;
         int checkpointPosition;
 
+        DistributedTraceContext? parentTraceContext;
+
         public ContextShim(EntityInstanceId entityInstanceId, DataConverter dataConverter)
         {
             this.entityInstanceId = entityInstanceId;
@@ -183,6 +192,12 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
         public int CurrentPosition => this.operationActions.Count;
 
         public override EntityInstanceId Id => this.entityInstanceId;
+
+        public DistributedTraceContext? ParentTraceContext
+        {
+            get => this.parentTraceContext;
+            set => this.parentTraceContext = value;
+        }
 
         public void Commit()
         {
@@ -210,6 +225,8 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
                 Name = operationName,
                 Input = this.dataConverter.Serialize(input),
                 ScheduledTime = options?.SignalTime?.UtcDateTime,
+                RequestTime = DateTime.UtcNow,
+                ParentTraceContext = this.parentTraceContext,
             });
         }
 
@@ -225,6 +242,8 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
                 InstanceId = instanceId,
                 Input = this.dataConverter.Serialize(input),
                 ScheduledStartTime = options?.StartAt?.UtcDateTime,
+                RequestTime = DateTime.UtcNow,
+                ParentTraceContext = this.parentTraceContext,
             });
             return instanceId;
         }

--- a/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationEntityContext.cs
@@ -203,7 +203,9 @@ sealed partial class TaskOrchestrationContextWrapper
                     oneWay,
                     guid,
                     EntityMessageEvent.GetCappedScheduledTime(this.wrapper.innerContext.CurrentUtcDateTime, this.wrapper.invocationContext.Options.MaximumTimerInterval, scheduledTime?.UtcDateTime),
-                    serializedInput);
+                    serializedInput,
+                    createTrace: true,
+                    requestTime: DateTime.UtcNow);
 
             if (!this.wrapper.IsReplaying)
             {


### PR DESCRIPTION
This PR adds support for distributed tracing for entities in the .NET isolated framework. The actual tracing objects are created in the durabletask repo (see this [PR]()) but this repo is where the requests to entities are generated and executed in the isolated case. The changes in this PR are then mostly to propagate information correctly to the durabletask repo for the traces (for example, the time that a signal or call request to an entity was made, or the time that the request was accomplished, any associated error messages, etc.) Related to this propagation of information, the definition of proto objects related to signaling entities or entities starting orchestrations had to be populated with extra information (like the parent trace context of the request, or the time of the request, etc. For more details see this [PR](https://github.com/microsoft/durabletask-protobuf/pull/40) in the protobuf repo). The changes in the `ProtobufUtils` class focus on adding this extra information (similar changes occur in this [PR](https://github.com/Azure/azure-functions-durable-extension/pull/3076) in the WebJobs repo). 
- The changes in the `GrpcDurableEntityClient` and `ShimDurableEntityClient` classes are to propagate this additional information in the case of a client signaling an entity, 
- In `TaskEntityShim` they are for entities signaling other entities, entities starting orchestrations, and the actual execution of the entity requests, and 
- In `TaskOrchestrationEntityContext` for orchestrations signaling and calling entities