### PR TITLE
Basic orchestration and activity execution logs

### DIFF
--- a/src/Worker/Core/Logs.cs
+++ b/src/Worker/Core/Logs.cs
@@ -36,18 +36,18 @@ namespace Microsoft.DurableTask
         public static partial void ActivityFailed(this ILogger logger, Exception ex, string instanceId, string name);
 
         /// <summary>
-        /// Creates a logger named "Microsoft.DurableTask.Worker" with the specified subcategories.
+        /// Creates a logger named "Microsoft.DurableTask.Worker" with an optional subcategory.
         /// </summary>
         /// <param name="loggerFactory">The logger factory to use to create the logger.</param>
-        /// <param name="subcategories">The subcategory of the logger. For example, "Activities" or "Orchestrations".
+        /// <param name="subcategory">The subcategory of the logger. For example, "Activities" or "Orchestrations".
         /// </param>
         /// <returns>The generated <see cref="ILogger"/>.</returns>
-        internal static ILogger CreateWorkerLogger(ILoggerFactory loggerFactory, string? subcategories = null)
+        internal static ILogger CreateWorkerLogger(ILoggerFactory loggerFactory, string? subcategory = null)
         {
             string categoryName = "Microsoft.DurableTask.Worker";
-            if (!string.IsNullOrEmpty(subcategories))
+            if (!string.IsNullOrEmpty(subcategory))
             {
-                categoryName += "." + subcategories;
+                categoryName += "." + subcategory;
             }
 
             return loggerFactory.CreateLogger(categoryName);

--- a/src/Worker/Core/Logs.cs
+++ b/src/Worker/Core/Logs.cs
@@ -11,10 +11,16 @@ namespace Microsoft.DurableTask
     /// </summary>
     static partial class Logs
     {
-        /// <summary>
-        /// The common category name for worker logs.
-        /// </summary>
-        internal const string WorkerCategoryName = "Microsoft.DurableTask.Worker";
+        internal static ILogger CreateWorkerLogger(ILoggerFactory loggerFactory, params string[] subcategories)
+        {
+            string categoryName = "Microsoft.DurableTask.Worker";
+            if (subcategories.Length > 0)
+            {
+                categoryName += "." + string.Join(".", subcategories);
+            }
+
+            return loggerFactory.CreateLogger(categoryName);
+        }
 
         [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "Unhandled exception in entity operation {entityInstanceId}/{operationName}.")]
         public static partial void OperationError(this ILogger logger, Exception ex, EntityInstanceId entityInstanceId, string operationName);

--- a/src/Worker/Core/Logs.cs
+++ b/src/Worker/Core/Logs.cs
@@ -11,17 +11,6 @@ namespace Microsoft.DurableTask
     /// </summary>
     static partial class Logs
     {
-        internal static ILogger CreateWorkerLogger(ILoggerFactory loggerFactory, params string[] subcategories)
-        {
-            string categoryName = "Microsoft.DurableTask.Worker";
-            if (subcategories.Length > 0)
-            {
-                categoryName += "." + string.Join(".", subcategories);
-            }
-
-            return loggerFactory.CreateLogger(categoryName);
-        }
-
         [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "Unhandled exception in entity operation {entityInstanceId}/{operationName}.")]
         public static partial void OperationError(this ILogger logger, Exception ex, EntityInstanceId entityInstanceId, string operationName);
 
@@ -45,5 +34,23 @@ namespace Microsoft.DurableTask
 
         [LoggerMessage(EventId = 605, Level = LogLevel.Information, Message = "'{Name}' activity of orchestration ID '{InstanceId}' failed.")]
         public static partial void ActivityFailed(this ILogger logger, Exception ex, string instanceId, string name);
+
+        /// <summary>
+        /// Creates a logger named "Microsoft.DurableTask.Worker" with the specified subcategories.
+        /// </summary>
+        /// <param name="loggerFactory">The logger factory to use to create the logger.</param>
+        /// <param name="subcategories">The subcategory of the logger. For example, "Activities" or "Orchestrations".
+        /// </param>
+        /// <returns>The generated <see cref="ILogger"/>.</returns>
+        internal static ILogger CreateWorkerLogger(ILoggerFactory loggerFactory, string? subcategories = null)
+        {
+            string categoryName = "Microsoft.DurableTask.Worker";
+            if (!string.IsNullOrEmpty(subcategories))
+            {
+                categoryName += "." + subcategories;
+            }
+
+            return loggerFactory.CreateLogger(categoryName);
+        }
     }
 }

--- a/src/Worker/Core/Logs.cs
+++ b/src/Worker/Core/Logs.cs
@@ -9,15 +9,35 @@ namespace Microsoft.DurableTask
     /// <summary>
     /// Log messages.
     /// </summary>
-    /// <remarks>
-    /// NOTE: Trying to make logs consistent with https://github.com/Azure/durabletask/blob/main/src/DurableTask.Core/Logging/LogEvents.cs.
-    /// </remarks>
     static partial class Logs
     {
+        /// <summary>
+        /// The common category name for worker logs.
+        /// </summary>
+        internal const string WorkerCategoryName = "Microsoft.DurableTask.Worker";
+
         [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "Unhandled exception in entity operation {entityInstanceId}/{operationName}.")]
         public static partial void OperationError(this ILogger logger, Exception ex, EntityInstanceId entityInstanceId, string operationName);
 
         [LoggerMessage(EventId = 55, Level = LogLevel.Information, Message = "{instanceId}: Evaluating custom retry handler for failed '{name}' task. Attempt = {attempt}.")]
         public static partial void RetryingTask(this ILogger logger, string instanceId, string name, int attempt);
+
+        [LoggerMessage(EventId = 600, Level = LogLevel.Information, Message = "'{Name}' orchestration with ID '{InstanceId}' started.")]
+        public static partial void OrchestrationStarted(this ILogger logger, string instanceId, string name);
+
+        [LoggerMessage(EventId = 601, Level = LogLevel.Information, Message = "'{Name}' orchestration with ID '{InstanceId}' completed.")]
+        public static partial void OrchestrationCompleted(this ILogger logger, string instanceId, string name);
+
+        [LoggerMessage(EventId = 602, Level = LogLevel.Information, Message = "'{Name}' orchestration with ID '{InstanceId}' failed.")]
+        public static partial void OrchestrationFailed(this ILogger logger, Exception ex, string instanceId, string name);
+
+        [LoggerMessage(EventId = 603, Level = LogLevel.Information, Message = "'{Name}' activity of orchestration ID '{InstanceId}' started.")]
+        public static partial void ActivityStarted(this ILogger logger, string instanceId, string name);
+
+        [LoggerMessage(EventId = 604, Level = LogLevel.Information, Message = "'{Name}' activity of orchestration ID '{InstanceId}' completed.")]
+        public static partial void ActivityCompleted(this ILogger logger, string instanceId, string name);
+
+        [LoggerMessage(EventId = 605, Level = LogLevel.Information, Message = "'{Name}' activity of orchestration ID '{InstanceId}' failed.")]
+        public static partial void ActivityFailed(this ILogger logger, Exception ex, string instanceId, string name);
     }
 }

--- a/src/Worker/Core/Shims/DurableTaskShimFactory.cs
+++ b/src/Worker/Core/Shims/DurableTaskShimFactory.cs
@@ -50,7 +50,7 @@ public class DurableTaskShimFactory
     {
         Check.NotDefault(name);
         Check.NotNull(activity);
-        return new TaskActivityShim(this.options.DataConverter, name, activity);
+        return new TaskActivityShim(this.loggerFactory, this.options.DataConverter, name, activity);
     }
 
     /// <summary>

--- a/src/Worker/Core/Shims/TaskActivityShim.cs
+++ b/src/Worker/Core/Shims/TaskActivityShim.cs
@@ -29,7 +29,7 @@ class TaskActivityShim : TaskActivity
         TaskName name,
         ITaskActivity implementation)
     {
-        this.logger = Check.NotNull(loggerFactory).CreateLogger(Logs.WorkerCategoryName);
+        this.logger = Logs.CreateWorkerLogger(Check.NotNull(loggerFactory), "Activities");
         this.dataConverter = Check.NotNull(dataConverter);
         this.name = Check.NotDefault(name);
         this.implementation = Check.NotNull(implementation);
@@ -50,10 +50,10 @@ class TaskActivityShim : TaskActivity
         {
             object? output = await this.implementation.RunAsync(contextWrapper, deserializedInput);
 
-            this.logger.ActivityCompleted(instanceId, this.name);
-
             // Return the output (if any) as a serialized string.
             string? serializedOutput = this.dataConverter.Serialize(output);
+            this.logger.ActivityCompleted(instanceId, this.name);
+
             return serializedOutput;
         }
         catch (Exception e)

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -34,12 +34,10 @@ partial class TaskOrchestrationShim : TaskOrchestration
         this.invocationContext = Check.NotNull(invocationContext);
         this.implementation = Check.NotNull(implementation);
 
-        this.logger = this.invocationContext.LoggerFactory.CreateLogger(Logs.WorkerCategoryName);
+        this.logger = Logs.CreateWorkerLogger(this.invocationContext.LoggerFactory, "Orchestrations");
     }
 
     DataConverter DataConverter => this.invocationContext.Options.DataConverter;
-
-    ILoggerFactory LoggerFactory => this.invocationContext.LoggerFactory;
 
     /// <inheritdoc/>
     public override async Task<string?> Execute(OrchestrationContext innerContext, string rawInput)

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -18,6 +18,8 @@ partial class TaskOrchestrationShim : TaskOrchestration
 {
     readonly ITaskOrchestrator implementation;
     readonly OrchestrationInvocationContext invocationContext;
+    readonly ILogger logger;
+
     TaskOrchestrationContextWrapper? wrapperContext;
 
     /// <summary>
@@ -31,6 +33,8 @@ partial class TaskOrchestrationShim : TaskOrchestration
     {
         this.invocationContext = Check.NotNull(invocationContext);
         this.implementation = Check.NotNull(implementation);
+
+        this.logger = this.invocationContext.LoggerFactory.CreateLogger(Logs.WorkerCategoryName);
     }
 
     DataConverter DataConverter => this.invocationContext.Options.DataConverter;
@@ -48,15 +52,31 @@ partial class TaskOrchestrationShim : TaskOrchestration
         object? input = this.DataConverter.Deserialize(rawInput, this.implementation.InputType);
         this.wrapperContext = new(innerContext, this.invocationContext, input);
 
+        string instanceId = innerContext.OrchestrationInstance.InstanceId;
+        if (!innerContext.IsReplaying)
+        {
+            this.logger.OrchestrationStarted(instanceId, this.invocationContext.Name);
+        }
+
         try
         {
             object? output = await this.implementation.RunAsync(this.wrapperContext, input);
+
+            if (!innerContext.IsReplaying)
+            {
+                this.logger.OrchestrationCompleted(instanceId, this.invocationContext.Name);
+            }
 
             // Return the output (if any) as a serialized string.
             return this.DataConverter.Serialize(output);
         }
         catch (TaskFailedException e)
         {
+            if (!innerContext.IsReplaying)
+            {
+                this.logger.OrchestrationFailed(e.InnerException, instanceId, this.invocationContext.Name);
+            }
+
             // Convert back to something the Durable Task Framework natively understands so that
             // failure details are correctly propagated.
             throw new CoreTaskFailedException(e.Message, e.InnerException)

--- a/src/Worker/Core/Shims/TaskOrchestrationShim.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationShim.cs
@@ -74,7 +74,7 @@ partial class TaskOrchestrationShim : TaskOrchestration
         {
             if (!innerContext.IsReplaying)
             {
-                this.logger.OrchestrationFailed(e.InnerException, instanceId, this.invocationContext.Name);
+                this.logger.OrchestrationFailed(e, instanceId, this.invocationContext.Name);
             }
 
             // Convert back to something the Durable Task Framework natively understands so that

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -8,9 +8,6 @@ namespace Microsoft.DurableTask.Worker.Grpc
     /// <summary>
     /// Log messages.
     /// </summary>
-    /// <remarks>
-    /// NOTE: Trying to make logs consistent with https://github.com/Azure/durabletask/blob/main/src/DurableTask.Core/Logging/LogEvents.cs.
-    /// </remarks>
     static partial class Logs
     {
         [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Durable Task gRPC worker starting and connecting to {endpoint}.")]

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -90,9 +90,9 @@ public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposabl
         return logs;
     }
 
-    protected IReadOnlyCollection<LogEntry> GetLogs(string categoryName)
+    protected IReadOnlyCollection<LogEntry> GetLogs(string category)
     {
-        this.logProvider.TryGetLogs(categoryName, out IReadOnlyCollection<LogEntry> logs);
+        this.logProvider.TryGetLogs(category, out IReadOnlyCollection<LogEntry> logs);
         return logs ?? [];
     }
 

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -90,6 +90,61 @@ public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposabl
         return logs;
     }
 
+    protected IReadOnlyCollection<LogEntry> GetLogs(string categoryName)
+    {
+        this.logProvider.TryGetLogs(categoryName, out IReadOnlyCollection<LogEntry> logs);
+        return logs ?? [];
+    }
+
+    protected static bool MatchLog(
+        LogEntry log,
+        string logEventName,
+        (Type exceptionType, string exceptionMessage)? exception,
+        params (string key, string value)[] metadataPairs)
+    {
+        if (log.EventId.Name != logEventName)
+        {
+            return false;
+        }
+
+        if (log.Exception is null != exception is null)
+        {
+            return false;
+        }
+        else if (exception is not null)
+        {
+            if (log.Exception?.GetType() != exception.Value.exceptionType)
+            {
+                return false;
+            }
+            if (log.Exception?.Message != exception.Value.exceptionMessage)
+            {
+                return false;
+            }
+        }
+
+        if (log.State is not IReadOnlyCollection<KeyValuePair<string, object>> metadataList)
+        {
+            return false;
+        }
+
+        Dictionary<string, object> state = new(metadataList);
+        foreach ((string key, string value) in metadataPairs)
+        {
+            if (!state.TryGetValue(key, out object? stateValue))
+            {
+                return false;
+            }
+
+            if (stateValue is not string stateString || stateString != value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     protected struct HostTestLifetime : IAsyncDisposable
     {
         readonly IHost host;

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -76,7 +76,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.Equal(typeof(CustomException).FullName, failureDetails.InnerFailure.InnerFailure!.ErrorType);
         Assert.Equal("Inner!", failureDetails.InnerFailure.InnerFailure.ErrorMessage);
 
-        IReadOnlyCollection<LogEntry> workerLogs = this.GetLogs("Microsoft.DurableTask.Worker");
+        IReadOnlyCollection<LogEntry> workerLogs = this.GetLogs(category: "Microsoft.DurableTask.Worker");
         Assert.NotEmpty(workerLogs);
 
         // Check that the orchestrator and activity logs are present

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -104,7 +104,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.Single(workerLogs, log => MatchLog(
             log,
             logEventName: "OrchestrationFailed",
-            exception: (typeof(TaskFailedException), null),
+            exception: (typeof(TaskFailedException), $"Task '{activityName}' (#0) failed with an unhandled exception: {errorMessage}"),
             ("InstanceId", instanceId),
             ("Name", orchestratorName.Name)));
     }

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Serialization;
 using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Tests.Logging;
 using Microsoft.DurableTask.Worker;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -28,8 +29,11 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         TaskName activityName = "FaultyActivity";
 
         // Use local function definitions to simplify the validation of the call stacks
-        async Task MyOrchestrationImpl(TaskOrchestrationContext ctx) => await ctx.CallActivityAsync(activityName);
-        void MyActivityImpl(TaskActivityContext ctx) => throw new Exception(errorMessage, new CustomException("Inner!"));
+        async Task MyOrchestrationImpl(TaskOrchestrationContext ctx) =>
+            await ctx.CallActivityAsync(activityName);
+
+        void MyActivityImpl(TaskActivityContext ctx) =>
+            throw new InvalidOperationException(errorMessage, new CustomException("Inner!"));
 
         await using HostTestLifetime server = await this.StartWorkerAsync(b =>
         {
@@ -64,13 +68,45 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
 
         // Check that the inner exception - i.e. the exact exception that failed the orchestration - was populated correctly
         Assert.NotNull(failureDetails.InnerFailure);
-        Assert.Equal(typeof(Exception).FullName, failureDetails.InnerFailure!.ErrorType);
+        Assert.Equal(typeof(InvalidOperationException).FullName, failureDetails.InnerFailure!.ErrorType);
         Assert.Equal(errorMessage, failureDetails.InnerFailure.ErrorMessage);
 
         // Check that the inner-most exception was populated correctly too (the custom exception type)
         Assert.NotNull(failureDetails.InnerFailure.InnerFailure);
         Assert.Equal(typeof(CustomException).FullName, failureDetails.InnerFailure.InnerFailure!.ErrorType);
         Assert.Equal("Inner!", failureDetails.InnerFailure.InnerFailure.ErrorMessage);
+
+        IReadOnlyCollection<LogEntry> workerLogs = this.GetLogs("Microsoft.DurableTask.Worker");
+        Assert.NotEmpty(workerLogs);
+
+        // Check that the orchestrator and activity logs are present
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "OrchestrationStarted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", orchestratorName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "ActivityStarted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", activityName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "ActivityFailed",
+            exception: (typeof(InvalidOperationException), errorMessage),
+            ("InstanceId", instanceId),
+            ("Name", activityName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "OrchestrationFailed",
+            exception: (typeof(TaskFailedException), null),
+            ("InstanceId", instanceId),
+            ("Name", orchestratorName.Name)));
     }
 
     /// <summary>

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -211,6 +211,38 @@ public class OrchestrationPatterns : IntegrationTestBase
         Assert.NotNull(metadata);
         Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
         Assert.Equal("Hello, World!", metadata.ReadOutputAs<string>());
+
+        IReadOnlyCollection<LogEntry> workerLogs = this.GetLogs("Microsoft.DurableTask.Worker");
+        Assert.NotEmpty(workerLogs);
+            
+        // Validate logs.
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "OrchestrationStarted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", orchestratorName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "ActivityStarted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", sayHelloActivityName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "ActivityCompleted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", sayHelloActivityName.Name)));
+
+        Assert.Single(workerLogs, log => MatchLog(
+            log,
+            logEventName: "OrchestrationCompleted",
+            exception: null,
+            ("InstanceId", instanceId),
+            ("Name", orchestratorName.Name)));
     }
 
     [Fact]

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -655,11 +655,6 @@ public class OrchestrationPatterns : IntegrationTestBase
 
     }
 
-    // TODO: Test for multiple external events with the same name
-    // TODO: Test for ContinueAsNew with external events that carry over
-    // TODO: Test for catching activity exceptions of specific types
-}
-=======
     [Fact]
     public async Task OrchestrationVersioning_MatchTypeNotSpecified_NoVersionFailure()
     {
@@ -843,4 +838,3 @@ public class OrchestrationPatterns : IntegrationTestBase
     // TODO: Test for ContinueAsNew with external events that carry over
     // TODO: Test for catching activity exceptions of specific types
 }
->>>>>>> 022d567864eab14099a101b9ec9b08ecd6ac4017


### PR DESCRIPTION
We're missing some basic execution logs in this SDK. For Azure Functions, this was okay because the Functions host and worker layer would sufficiently take care of logging. However, for standalone use, the base logging was insufficient.

This PR adds basic execution starting, completion, and failure logs for orchestrations and activities.