### PR TITLE
Add default get_version to TaskOrchestrationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# Changelog
 
+## v1.9.1 (Unreleased)
+- Add default version in `TaskOrchestrationContext` by @halspang in ([#408](https://github.com/microsoft/durabletask-dotnet/pull/408))
+
 ## v1.9.0
 
 - Fix schedule sample logging setup by @YunchuWang in ([#392](https://github.com/microsoft/durabletask-dotnet/pull/392))

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -63,7 +63,7 @@ public abstract class TaskOrchestrationContext
     /// <summary>
     /// Gets the version of the current orchestration instance, which was set when the instance was created.
     /// </summary>
-    public abstract string Version { get; }
+    public virtual string Version => string.Empty;
 
     /// <summary>
     /// Gets the entity feature, for interacting with entities.


### PR DESCRIPTION
There are other classes that implement `TaskOrchestrationContext`, such as the [FunctionOrchestrationContext](https://github.com/Azure/azure-functions-durable-extension/blob/dev/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs). When updating to the 1.9.0 release, this causes a immediate code-incompatibility as the versioning path attempts to reference the `Version` which is unimplemented.