### PR TITLE
Add version to TaskName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
 - Add extension methods for registering entities by type ([#427](https://github.com/microsoft/durabletask-dotnet/pull/427))
 
+>>>>>>> 766fa69 (Add version to TaskName)
+
 ## v1.10.0
 
 - Update DurableTask.Core to v3.1.0 and Bump version to v1.10.0 by @nytian in ([#411](https://github.com/microsoft/durabletask-dotnet/pull/411))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 - Add user agent header to gRPC called in ([#417](https://github.com/microsoft/durabletask-dotnet/pull/417))
 - Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
 - Add extension methods for registering entities by type ([#427](https://github.com/microsoft/durabletask-dotnet/pull/427))
-
->>>>>>> 766fa69 (Add version to TaskName)
+- Add TaskVersion and utilize it for version overrides when starting orchestrations ([#416](https://github.com/microsoft/durabletask-dotnet/pull/416))
 
 ## v1.10.0
 

--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-
 namespace Microsoft.DurableTask;
 
 /// <summary>
@@ -27,31 +25,7 @@ public readonly struct TaskName : IEquatable<TaskName>
         else
         {
             this.Name = name;
-            this.Version = string.Empty;
-        }
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TaskName"/> struct.
-    /// </summary>
-    /// <remarks>
-    /// This <c>TaskName</c> is explicitly versioned, as compared to the default value.
-    /// </remarks>
-    /// <param name="name">The name of the task. Providing <c>null</c> will yield the default struct, ignoring the version.</param>
-    /// <param name="version">Optional. The version of the task. Providing <c>null</c> will yield the default value.</param>
-    public TaskName(string name, string version)
-    {
-        if (name is null)
-        {
-            // Force the default struct when null is passed in.
-            this.Name = null!;
-            this.Version = null!;
-        }
-        else
-        {
-            this.IsVersioned = true;
-            this.Name = name;
-            this.Version = version == null ? null! : version;
+            this.Version = string.Empty; // expose setting Version only when we actually consume it.
         }
     }
 
@@ -70,15 +44,8 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// Task versions is currently locked to <see cref="string.Empty" /> as it is not yet integrated into task
     /// identification. This is being left here as we intend to support it soon.
     /// </remarks>
+    [Obsolete("Refer to TaskVersion instead.")]
     public string Version { get; }
-
-    /// <summary>
-    /// Gets the flag denoting if this TaskName is versioned.
-    /// </summary>
-    /// <remarks>
-    /// This flag is used to distinguish between the default (empty version) and a Task with an explicit empty version.
-    /// </remarks>
-    public bool IsVersioned { get; } = false;
 
     /// <summary>
     /// Implicitly converts a <see cref="TaskName"/> into a <see cref="string"/> of the <see cref="Name"/> property value.

--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.DurableTask;
 
 /// <summary>
@@ -25,7 +27,31 @@ public readonly struct TaskName : IEquatable<TaskName>
         else
         {
             this.Name = name;
-            this.Version = string.Empty; // expose setting Version only when we actually consume it.
+            this.Version = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskName"/> struct.
+    /// </summary>
+    /// <remarks>
+    /// This <c>TaskName</c> is explicitly versioned, as compared to the default value.
+    /// </remarks>
+    /// <param name="name">The name of the task. Providing <c>null</c> will yield the default struct, ignoring the version.</param>
+    /// <param name="version">Optional. The version of the task. Providing <c>null</c> will yield the default value.</param>
+    public TaskName(string name, string version)
+    {
+        if (name is null)
+        {
+            // Force the default struct when null is passed in.
+            this.Name = null!;
+            this.Version = null!;
+        }
+        else
+        {
+            this.IsVersioned = true;
+            this.Name = name;
+            this.Version = version == null ? null! : version;
         }
     }
 
@@ -45,6 +71,14 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// identification. This is being left here as we intend to support it soon.
     /// </remarks>
     public string Version { get; }
+
+    /// <summary>
+    /// Gets the flag denoting if this TaskName is versioned.
+    /// </summary>
+    /// <remarks>
+    /// This flag is used to distinguish between the default (empty version) and a Task with an explicit empty version.
+    /// </remarks>
+    public bool IsVersioned { get; } = false;
 
     /// <summary>
     /// Implicitly converts a <see cref="TaskName"/> into a <see cref="string"/> of the <see cref="Name"/> property value.

--- a/src/Abstractions/TaskName.cs
+++ b/src/Abstractions/TaskName.cs
@@ -16,6 +16,7 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// <param name="name">The name of the task. Providing <c>null</c> will yield the default struct.</param>
     public TaskName(string name)
     {
+#pragma warning disable 0618
         if (name is null)
         {
             // Force the default struct when null is passed in.
@@ -27,6 +28,7 @@ public readonly struct TaskName : IEquatable<TaskName>
             this.Name = name;
             this.Version = string.Empty; // expose setting Version only when we actually consume it.
         }
+#pragma warning restore 0618
     }
 
     /// <summary>
@@ -123,6 +125,7 @@ public readonly struct TaskName : IEquatable<TaskName>
     /// <returns>The name and optional version of the current <see cref="TaskName"/> instance.</returns>
     public override string ToString()
     {
+#pragma warning disable 0618
         if (string.IsNullOrEmpty(this.Version))
         {
             return this.Name;
@@ -131,5 +134,6 @@ public readonly struct TaskName : IEquatable<TaskName>
         {
             return this.Name + ":" + this.Version;
         }
+#pragma warning restore 0618
     }
 }

--- a/src/Abstractions/TaskOptions.cs
+++ b/src/Abstractions/TaskOptions.cs
@@ -90,6 +90,11 @@ public record SubOrchestrationOptions : TaskOptions
     /// Gets the orchestration instance ID.
     /// </summary>
     public string? InstanceId { get; init; }
+
+    /// <summary>
+    /// Gets the version to associate with the sub-orchestration instance.
+    /// </summary>
+    public TaskVersion Version { get; init; } = default!;
 }
 
 /// <summary>
@@ -108,4 +113,9 @@ public record StartOrchestrationOptions(string? InstanceId = null, DateTimeOffse
     /// Gets the tags to associate with the orchestration instance.
     /// </summary>
     public IReadOnlyDictionary<string, string> Tags { get; init; } = ImmutableDictionary.Create<string, string>();
+
+    /// <summary>
+    /// Gets the version to associate with the orchestration instance.
+    /// </summary>
+    public TaskVersion? Version { get; init; }
 }

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -61,9 +61,9 @@ public abstract class TaskOrchestrationContext
     public abstract bool IsReplaying { get; }
 
     /// <summary>
-    /// Gets the version of the current orchestration instance, which was set when the instance was created.
+    /// Gets or sets the version of the current orchestration instance, which was set when the instance was created.
     /// </summary>
-    public virtual string Version => string.Empty;
+    public virtual string Version { get; protected internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the configuration settings for the orchestration context.

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -61,9 +61,9 @@ public abstract class TaskOrchestrationContext
     public abstract bool IsReplaying { get; }
 
     /// <summary>
-    /// Gets or sets the version of the current orchestration instance, which was set when the instance was created.
+    /// Gets the version of the current orchestration instance, which was set when the instance was created.
     /// </summary>
-    public virtual string Version { get; protected internal set; } = string.Empty;
+    public virtual string Version => string.Empty;
 
     /// <summary>
     /// Gets the configuration settings for the orchestration context.

--- a/src/Abstractions/TaskVersion.cs
+++ b/src/Abstractions/TaskVersion.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask;
+
+/// <summary>
+/// The version of a durable task.
+/// </summary>
+public readonly struct TaskVersion : IEquatable<TaskVersion>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskVersion"/> struct.
+    /// </summary>
+    /// <param name="version">The version of the task. Providing <c>null</c> will result in the default struct.</param>
+    public TaskVersion(string version)
+    {
+        if (version == null)
+        {
+            this.Version = null!;
+        }
+        else
+        {
+            this.Version = version;
+        }
+    }
+
+    /// <summary>
+    /// Gets the version of a task.
+    /// </summary>
+    public string Version { get; }
+
+    /// <summary>
+    /// Implicitly converts a <see cref="TaskVersion"/> into a <see cref="string"/> of the <see cref="Version"/> property value.
+    /// </summary>
+    /// <param name="value">The <see cref="TaskVersion"/> to be converted into a <see cref="string"/>.</param>
+    public static implicit operator string(TaskVersion value) => value.Version;
+
+    /// <summary>
+    /// Implicitly converts a <see cref="string"/> into a <see cref="TaskVersion"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> to convert into a <see cref="TaskVersion"/>.</param>
+    public static implicit operator TaskVersion(string value) => new TaskVersion(value);
+
+    /// <summary>
+    /// Compares two <see cref="TaskVersion"/> structs for equality.
+    /// </summary>
+    /// <param name="a">The first <see cref="TaskVersion"/> to compare.</param>
+    /// <param name="b">The second <see cref="TaskVersion"/> to compare.</param>
+    /// <returns><c>true</c> if the two <see cref="TaskVersion"/> objects are equal; otherwise <c>false</c>.</returns>
+    public static bool operator ==(TaskVersion a, TaskVersion b)
+    {
+        return a.Equals(b);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="TaskVersion"/> structs for inequality.
+    /// </summary>
+    /// <param name="a">The first <see cref="TaskVersion"/> to compare.</param>
+    /// <param name="b">The second <see cref="TaskVersion"/> to compare.</param>
+    /// <returns><c>false</c> if the two <see cref="TaskVersion"/> objects are equal; otherwise <c>true</c>.</returns>
+    public static bool operator !=(TaskVersion a, TaskVersion b)
+    {
+        return !a.Equals(b);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether to <see cref="TaskVersion"/> objects
+    /// are equal using value semantics.
+    /// </summary>
+    /// <param name="other">The other <see cref="TaskVersion"/> to compare to.</param>
+    /// <returns><c>true</c> if the two <see cref="TaskVersion"/> are equal using value semantics; otherwise <c>false</c>.</returns>
+    public bool Equals(TaskVersion other)
+    {
+        return string.Equals(this.Version, other.Version, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether to <see cref="TaskVersion"/> objects
+    /// are equal using value semantics.
+    /// </summary>
+    /// <param name="obj">The other object to compare to.</param>
+    /// <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
+    public override bool Equals(object? obj)
+    {
+        if (obj is not TaskVersion other)
+        {
+            return false;
+        }
+
+        return this.Equals(other);
+    }
+
+    /// <summary>
+    /// Calculates a hash code value for the current <see cref="TaskVersion"/> instance.
+    /// </summary>
+    /// <returns>A 32-bit hash code value.</returns>
+    public override int GetHashCode()
+    {
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(this.Version);
+    }
+}

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -80,9 +80,9 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
         // We're explicitly OK with an empty version from the options as that had to be explicitly set. It should take precedence over the default.
         string version = string.Empty;
-        if (options != null && options.Version != null)
+        if (options?.Version is { } v)
         {
-            version = options.Version;
+            version = v;
         }
         else if (!string.IsNullOrEmpty(this.options.DefaultVersion))
         {

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -78,10 +78,11 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
     {
         Check.NotEntity(this.options.EnableEntitySupport, options?.InstanceId);
 
+        // We're explicitly OK with an empty version from the options as that had to be explicitly set. It should take precedence over the default.
         string version = string.Empty;
-        if (!string.IsNullOrEmpty(orchestratorName.Version))
+        if (options != null && options.Version != null)
         {
-            version = orchestratorName.Version;
+            version = options.Version;
         }
         else if (!string.IsNullOrEmpty(this.options.DefaultVersion))
         {

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -172,7 +172,7 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
             Event = new ExecutionStartedEvent(-1, serializedInput)
             {
                 Name = orchestratorName.Name,
-                Version = orchestratorName.Version,
+                Version = options?.Version ?? string.Empty,
                 OrchestrationInstance = instance,
                 ScheduledStartTime = options?.StartAt?.UtcDateTime,
                 Tags = options?.Tags != null ? options.Tags.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) : null,

--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -102,6 +102,7 @@ public static class DurableTaskWorkerBuilderExtensions
             options.Versioning = new VersioningOptions
             {
                 Version = versionOptions.Version,
+                DefaultVersion = versionOptions.DefaultVersion,
                 MatchStrategy = versionOptions.MatchStrategy,
                 FailureStrategy = versionOptions.FailureStrategy,
             };

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -204,6 +204,11 @@ public class DurableTaskWorkerOptions
         public string Version { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the default version that will be used for starting new orchestrations.
+        /// </summary>
+        public string DefaultVersion { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the versioning strategy for the Durable Task worker.
         /// </summary>
         public VersionMatchStrategy MatchStrategy { get; set; } = VersionMatchStrategy.None;

--- a/src/Worker/Core/Shims/TaskEntityShim.cs
+++ b/src/Worker/Core/Shims/TaskEntityShim.cs
@@ -221,7 +221,7 @@ class TaskEntityShim : DTCore.Entities.TaskEntity
             this.operationActions.Add(new StartNewOrchestrationOperationAction()
             {
                 Name = name.Name,
-                Version = name.Version,
+                Version = options?.Version ?? string.Empty,
                 InstanceId = instanceId,
                 Input = this.dataConverter.Serialize(input),
                 ScheduledStartTime = options?.StartAt?.UtcDateTime,

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -139,6 +139,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         try
         {
             // TODO: Cancellation (https://github.com/microsoft/durabletask-dotnet/issues/7)
+#pragma warning disable 0618
             if (options?.Retry?.Policy is RetryPolicy policy)
             {
                 return await this.innerContext.ScheduleWithRetry<T>(
@@ -165,6 +166,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
             // Hide the core DTFx types and instead use our own
             throw new TaskFailedException(name, e.ScheduleId, e);
         }
+#pragma warning restore 0618
     }
 
     /// <inheritdoc/>
@@ -177,10 +179,8 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         static string? GetInstanceId(TaskOptions? options)
             => options is SubOrchestrationOptions derived ? derived.InstanceId : null;
         string instanceId = GetInstanceId(options) ?? this.NewGuid().ToString("N");
-        string defaultVersion = this.invocationContext.Options != null && this.invocationContext.Options.Versioning != null
-            ? this.invocationContext.Options.Versioning.DefaultVersion
-            : string.Empty;
-        string version = options != null && options is SubOrchestrationOptions subOptions ? subOptions.Version : defaultVersion;
+        string defaultVersion = this.invocationContext.Options?.Versioning?.DefaultVersion ?? string.Empty;
+        string version = options is SubOrchestrationOptions subOptions ? subOptions.Version : defaultVersion;
 
         Check.NotEntity(this.invocationContext.Options.EnableEntitySupport, instanceId);
 

--- a/test/Abstractions.Tests/TaskNameTests.cs
+++ b/test/Abstractions.Tests/TaskNameTests.cs
@@ -17,7 +17,9 @@ public class TaskNameTests
     {
         TaskName name = new(string.Empty);
         name.Name.Should().Be(string.Empty);
+#pragma warning disable 0618
         name.Version.Should().Be(string.Empty);
+#pragma warning restore 0618
     }
 
     [Theory]

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -400,7 +400,7 @@ public class ShimDurableTaskClientTests
             }
 
             return Guid.TryParse(m.OrchestrationInstance.ExecutionId, out _)
-                && @event.Name == name.Name && @event.Version == name.Version
+                && @event.Name == name.Name && @event.Version == (options?.Version ?? string.Empty)
                 && @event.OrchestrationInstance == m.OrchestrationInstance
                 && @event.EventId == -1
                 && @event.Input == JsonDataConverter.Default.Serialize(input);


### PR DESCRIPTION
This commit adds an explict set for Version in TaskName. It also includes a flag that is set so other code can determine if the TaskName is intended to be versioned. Finally, it updates the Version property in the TaskOrchestrationContext as that was always set to empty instead of being able to be used.