### PR TITLE
Modify cancellation token behavior within `ProcessWorkItemsAsync`

### DIFF
--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -260,7 +260,7 @@ sealed partial class GrpcDurableTaskWorker
 
             while (!cancellation.IsCancellationRequested)
             {
-                await foreach (P.WorkItem workItem in stream.ResponseStream.ReadAllAsync(timeoutSource.Token))
+                await foreach (P.WorkItem workItem in stream.ResponseStream.ReadAllAsync(tokenSource.Token))
                 {
                     timeoutSource.CancelAfter(TimeSpan.FromSeconds(60));
                     var timeoutSourceToken = timeoutSource.Token;


### PR DESCRIPTION
We've been investigating an issue in `Dapr.Workflow` wherein the client is getting stuck in a loop in which it disconnects from the scheduler and reconnects perpetually. After looking through it and seeing what's changed between a version of `Dapr.Workflow` that works and what's in the client today, I believe the issue lies in the use of the cancellation tokens in [this method](https://github.com/microsoft/durabletask-dotnet/blob/c27770aad4a0a2b9a85eeef281682700cf9ac2cb/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs#L252).

In this method, we get access to the outer `CancellationToken` from the method arguments, but another 60-second `CancellationTokenSource` called `timeoutSource` and we have a linked token source between the two called `tokenSource`. However, I cannot find any support in [the documentation](https://learn.microsoft.com/en-us/aspnet/core/grpc/deadlines-cancellation?view=aspnetcore-9.0#cancellation) that suggests that cancellation tokens should be used in this way to cancel long-running operations or otherwise have these sort of health checks - presumably all that is supposed to be handled by the gRPC client itself. The only conflicting guidance to that I see in the docs is [regarding bidirectional streaming](https://learn.microsoft.com/en-us/aspnet/core/grpc/retries?view=aspnetcore-9.0#streaming-calls) which isn't applicable here.

Given then that reconnections and retries are handled by the client itself, I think the `while (!cancellation.IsCancellationRequested)` block is redundant and the outer `cancellation` token should be placed in the `ReadAllAsync` in order to signal that the `await foreach` operation should come to an end at some point without exclusively waiting on a completion signal from the server (which isn't forthcoming in this case). In other words, the `ReadAllAsync` method shouldn't cancel just because it doesn't receive messages for 60 seconds as that's entirely expected (because health checks and pings are done already by gRPC), so pointing to the new `timeoutSource` or `tokenSource` token shouldn't happen here.

But within the `await foreach` loop, I believe the cancellation tokens aren't set up quite right either. Each work item is being provided with the outer `cancellation` token, but within the loop, you're resetting the new `timeoutSource` token source (with its 60 second timeout), but nothing is really using it (though it's reset to 60 seconds again each loop). If the goal is that an outer cancellation or a failure to process everything within 60 seconds should cancel the operation, the internal tasks need to reference it. 

In this PR, I've refactored it to remove the redundant while loop, to have `ReadAllAsync` point only to the `cancellation` token so it only cancels because of a client request and to check for `tokenSourceToken` cancellation within the foreach loop so such request can be honored and logged outside said loop.

While I took a brief stab at adding a test to validate this new behavior, I don't see any tests for this today that don't involve a non-representative mock of this method, so I leave that as a future exercise.

I'm going to apply these same changes to a fork that we'll apply to `Dapr.Workflow` and see if it fixes our integration testing and will report back on our success there (or not).