### PR TITLE
Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add automatic retry on gateway timeout in `GrpcDurableTaskClient.WaitForInstanceCompletionAsync` in ([#412](https://github.com/microsoft/durabletask-dotnet/pull/412))
 - Add specific logging for NotFound error on worker connection by @halspang in ([#413](https://github.com/microsoft/durabletask-dotnet/pull/413))
 - Add user agent header to gRPC called in ([#417](https://github.com/microsoft/durabletask-dotnet/pull/417))
-
+- Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
 ## v1.10.0
 
 - Update DurableTask.Core to v3.1.0 and Bump version to v1.10.0 by @nytian in ([#411](https://github.com/microsoft/durabletask-dotnet/pull/411))

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs
@@ -7,6 +7,7 @@ using Azure.Identity;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
 
 namespace Microsoft.DurableTask;
 
@@ -98,7 +99,7 @@ public class DurableTaskSchedulerClientOptions
                 metadata.Add("taskhub", taskHubName);
 
                 // Add user agent header with durabletask-dotnet and DLL version from util
-                metadata.Add("user-agent", $"{DurableTaskUserAgentUtil.GetUserAgent()}");
+                metadata.Add("user-agent", $"{DurableTaskUserAgentUtil.GetUserAgent(nameof(DurableTaskClient))}");
                 if (cache == null)
                 {
                     return;

--- a/src/Shared/AzureManaged/DurableTaskVersionUtil.cs
+++ b/src/Shared/AzureManaged/DurableTaskVersionUtil.cs
@@ -21,11 +21,12 @@ public static class DurableTaskUserAgentUtil
     static readonly string PackageVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskUserAgentUtil).Assembly.Location).FileVersion;
 
     /// <summary>
-    /// Generates the user agent string for the Durable Task SDK based on a fixed name and the package version.
+    /// Generates the user agent string for the Durable Task SDK based on a fixed name, the package version, and the component type.
     /// </summary>
+    /// <param name="componentType">The type of component (Client or Worker).</param>
     /// <returns>The user agent string.</returns>
-    public static string GetUserAgent()
+    public static string GetUserAgent(string componentType)
     {
-        return $"{SdkName}/{PackageVersion?.ToString() ?? "unknown"}";
+        return $"{SdkName}/{PackageVersion?.ToString() ?? "unknown"} ({componentType})";
     }
 }

--- a/src/Shared/AzureManaged/DurableTaskVersionUtil.cs
+++ b/src/Shared/AzureManaged/DurableTaskVersionUtil.cs
@@ -21,12 +21,12 @@ public static class DurableTaskUserAgentUtil
     static readonly string PackageVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskUserAgentUtil).Assembly.Location).FileVersion;
 
     /// <summary>
-    /// Generates the user agent string for the Durable Task SDK based on a fixed name, the package version, and the component type.
+    /// Generates the user agent string for the Durable Task SDK based on a fixed name, the package version, and the caller type.
     /// </summary>
-    /// <param name="componentType">The type of component (Client or Worker).</param>
+    /// <param name="callerType">The type of caller (Client or Worker).</param>
     /// <returns>The user agent string.</returns>
-    public static string GetUserAgent(string componentType)
+    public static string GetUserAgent(string callerType)
     {
-        return $"{SdkName}/{PackageVersion?.ToString() ?? "unknown"} ({componentType})";
+        return $"{SdkName}/{PackageVersion?.ToString() ?? "unknown"} ({callerType})";
     }
 }

--- a/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
+++ b/src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs
@@ -7,6 +7,7 @@ using Azure.Identity;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker.Hosting;
 
 namespace Microsoft.DurableTask;
 
@@ -103,7 +104,7 @@ public class DurableTaskSchedulerWorkerOptions
             {
                 metadata.Add("taskhub", taskHubName);
                 // Add user agent header with durabletask-dotnet and DLL version from util
-                metadata.Add("user-agent", $"{DurableTaskUserAgentUtil.GetUserAgent()}");
+                metadata.Add("user-agent", $"{DurableTaskUserAgentUtil.GetUserAgent(nameof(DurableTaskWorker))}");
                 metadata.Add("workerid", this.WorkerId);
                 if (cache == null)
                 {


### PR DESCRIPTION
This pull request introduces changes to improve the user agent string generation for the Durable Task SDK by including the component type (e.g., Client or Worker) in the string. Additionally, it updates imports in relevant files to ensure proper usage of namespaces. Below are the most significant changes:

### User Agent String Improvements:
* Updated the `GetUserAgent` method in `DurableTaskUserAgentUtil` to include a `componentType` parameter, allowing the user agent string to specify whether it pertains to a Client or Worker. (`src/Shared/AzureManaged/DurableTaskVersionUtil.cs`, [src/Shared/AzureManaged/DurableTaskVersionUtil.csL24-R30](diffhunk://#diff-eaa010b04d1df4b599644bc5af33e4f73f3be86b26eee80ebc9bd4756331b690L24-R30))
* Modified calls to `GetUserAgent` in `DurableTaskSchedulerClientOptions` and `DurableTaskSchedulerWorkerOptions` to pass the appropriate component type (`DurableTaskClient` or `DurableTaskWorker`). (`src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs`, [[1]](diffhunk://#diff-ce46f5c5201ad9a75c860d6c6ac558b5f1a83e634b631b09f82ae21281fc756bL101-R102); `src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs`, [[2]](diffhunk://#diff-3c4634be72788bc80433242b5b6f240de35385703293354152a437c7665dd7b3L106-R107)

### Namespace Updates:
* Added missing namespace imports for `Microsoft.DurableTask.Client` and `Microsoft.DurableTask.Worker.Hosting` in `DurableTaskSchedulerClientOptions` and `DurableTaskSchedulerWorkerOptions`, respectively, to ensure proper functionality. (`src/Client/AzureManaged/DurableTaskSchedulerClientOptions.cs`, [[1]](diffhunk://#diff-ce46f5c5201ad9a75c860d6c6ac558b5f1a83e634b631b09f82ae21281fc756bR10); `src/Worker/AzureManaged/DurableTaskSchedulerWorkerOptions.cs`, [[2]](diffhunk://#diff-3c4634be72788bc80433242b5b6f240de35385703293354152a437c7665dd7b3R10)