### PR TITLE
Allow version in TaskOrchestrationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add specific logging for NotFound error on worker connection by @halspang in ([#413](https://github.com/microsoft/durabletask-dotnet/pull/413))
 - Add user agent header to gRPC called in ([#417](https://github.com/microsoft/durabletask-dotnet/pull/417))
 - Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
+- Add ability to set the version in `TaskOrchestrationContext` by @halspang in ([#424](https://github.com/microsoft/durabletask-dotnet/pull/424))
+
 ## v1.10.0
 
 - Update DurableTask.Core to v3.1.0 and Bump version to v1.10.0 by @nytian in ([#411](https://github.com/microsoft/durabletask-dotnet/pull/411))

--- a/src/Abstractions/TaskOrchestrationContext.cs
+++ b/src/Abstractions/TaskOrchestrationContext.cs
@@ -61,9 +61,9 @@ public abstract class TaskOrchestrationContext
     public abstract bool IsReplaying { get; }
 
     /// <summary>
-    /// Gets the version of the current orchestration instance, which was set when the instance was created.
+    /// Gets or sets the version of the current orchestration instance, which was set when the instance was created.
     /// </summary>
-    public virtual string Version => string.Empty;
+    public virtual string Version { get; protected internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the configuration settings for the orchestration context.


### PR DESCRIPTION
This commit adds the ability to get/set the `Version` in `TaskOrchestrationContext`. Prior to this, it would always return `string.Empty`. This change allows contexts which implement `TaskOrchestrationContext` to actually use a version.