### PR TITLE
Add extension methods for registering entities by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add specific logging for NotFound error on worker connection by @halspang in ([#413](https://github.com/microsoft/durabletask-dotnet/pull/413))
 - Add user agent header to gRPC called in ([#417](https://github.com/microsoft/durabletask-dotnet/pull/417))
 - Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
+- Add extension methods for registering entities by type
+
 ## v1.10.0
 
 - Update DurableTask.Core to v3.1.0 and Bump version to v1.10.0 by @nytian in ([#411](https://github.com/microsoft/durabletask-dotnet/pull/411))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add specific logging for NotFound error on worker connection by @halspang in ([#413](https://github.com/microsoft/durabletask-dotnet/pull/413))
 - Add user agent header to gRPC called in ([#417](https://github.com/microsoft/durabletask-dotnet/pull/417))
 - Enrich User-Agent Header in gRPC Metadata to indicate Client or Worker as caller ([#421](https://github.com/microsoft/durabletask-dotnet/pull/421))
-- Add extension methods for registering entities by type
+- Add extension methods for registering entities by type ([#427](https://github.com/microsoft/durabletask-dotnet/pull/427))
 
 ## v1.10.0
 

--- a/src/Abstractions/DurableTaskRegistry.Activities.cs
+++ b/src/Abstractions/DurableTaskRegistry.Activities.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.DurableTask;
 
 /// <summary>
-/// Container for registered <see cref="ITaskOrchestrator" /> and <see cref="ITaskActivity" /> implementations.
+/// Container for registered <see cref="ITaskOrchestrator" />, <see cref="ITaskActivity" />,
+/// and <see cref="Microsoft.DurableTask.Entities.ITaskEntity"/> implementations.
 /// </summary>
 public sealed partial class DurableTaskRegistry
 {

--- a/src/Abstractions/DurableTaskRegistry.Entities.cs
+++ b/src/Abstractions/DurableTaskRegistry.Entities.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DurableTask;
+
+/// <summary>
+/// Container for registered <see cref="ITaskOrchestrator" />, <see cref="ITaskActivity" />,
+/// and <see cref="ITaskEntity"/> implementations.
+/// </summary>
+public partial class DurableTaskRegistry
+{
+    /// <summary>
+    /// Registers an entity factory.
+    /// </summary>
+    /// <param name="name">The name of the entity to register.</param>
+    /// <param name="type">The entity type.</param>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity(TaskName name, Type type)
+    {
+        // TODO: Compile a constructor expression for performance.
+        Check.ConcreteType<ITaskEntity>(type);
+        return this.AddEntity(name, sp => (ITaskEntity)ActivatorUtilities.CreateInstance(sp, type));
+    }
+
+    /// <summary>
+    /// Registers an entity factory. The TaskName used is derived from the provided type information.
+    /// </summary>
+    /// <param name="type">The entity type.</param>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity(Type type)
+        => this.AddEntity(type.GetTaskName(), type);
+
+    /// <summary>
+    /// Registers an entity factory.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of entity to register.</typeparam>
+    /// <param name="name">The name of the entity to register.</param>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity<TEntity>(TaskName name)
+        where TEntity : class, ITaskEntity
+        => this.AddEntity(name, typeof(TEntity));
+
+    /// <summary>
+    /// Registers an entity factory. The TaskName used is derived from the provided type information.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of entity to register.</typeparam>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity<TEntity>()
+        where TEntity : class, ITaskEntity
+        => this.AddEntity(typeof(TEntity));
+
+    /// <summary>
+    /// Registers an entity singleton.
+    /// </summary>
+    /// <param name="name">The name of the entity to register.</param>
+    /// <param name="entity">The entity instance to use.</param>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity(TaskName name, ITaskEntity entity)
+    {
+        Check.NotNull(entity);
+        return this.AddEntity(name, _ => entity);
+    }
+
+    /// <summary>
+    /// Registers an entity singleton.
+    /// </summary>
+    /// <param name="entity">The entity instance to use.</param>
+    /// <returns>The same registry, for call chaining.</returns>
+    public DurableTaskRegistry AddEntity(ITaskEntity entity)
+    {
+        Check.NotNull(entity);
+        return this.AddEntity(entity.GetType().GetTaskName(), entity);
+    }
+}

--- a/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
+++ b/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
@@ -4,7 +4,8 @@
 namespace Microsoft.DurableTask;
 
 /// <summary>
-/// Container for registered <see cref="ITaskOrchestrator" /> and <see cref="ITaskActivity" /> implementations.
+/// Container for registered <see cref="ITaskOrchestrator" />, <see cref="ITaskActivity" />,
+/// and <see cref="Microsoft.DurableTask.Entities.ITaskEntity"/> implementations.
 /// </summary>
 public partial class DurableTaskRegistry
 {

--- a/src/Abstractions/DurableTaskRegistry.cs
+++ b/src/Abstractions/DurableTaskRegistry.cs
@@ -6,7 +6,8 @@ using Microsoft.DurableTask.Entities;
 namespace Microsoft.DurableTask;
 
 /// <summary>
-/// Container for registered <see cref="ITaskOrchestrator" /> and <see cref="ITaskActivity" /> implementations.
+/// Container for registered <see cref="ITaskOrchestrator" />, <see cref="ITaskActivity" />,
+/// and <see cref="ITaskEntity"/> implementations.
 /// </summary>
 public sealed partial class DurableTaskRegistry
 {

--- a/src/ScheduledTasks/Extension/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/ScheduledTasks/Extension/DurableTaskWorkerBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.DurableTask.Worker;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DurableTask.ScheduledTasks;
 
@@ -18,7 +17,7 @@ public static class DurableTaskWorkerBuilderExtensions
     {
         builder.AddTasks(r =>
         {
-            r.AddEntity(nameof(Schedule), sp => ActivatorUtilities.CreateInstance<Schedule>(sp));
+            r.AddEntity<Schedule>();
             r.AddOrchestrator<ExecuteScheduleOperationOrchestrator>();
         });
     }


### PR DESCRIPTION
This PR introduces functionality for registering `ITaskEntity` implementations in the `DurableTaskRegistry`.

### Improved support for entity registration in `DurableTaskRegistry`:
* [`src/Abstractions/DurableTaskRegistry.Entities.cs`](diffhunk://#diff-9a292b16090e0a41d380420e949f390fe04bf62316886ead992f0b03177dc87fR1-R77): Added several methods to `DurableTaskRegistry` for registering entities by type, name, and instance, enabling more convenient entity registration.
* [`src/ScheduledTasks/Extension/DurableTaskWorkerBuilderExtensions.cs`](diffhunk://#diff-b89fc591cada9bd5657c1e1f41beaf925df78706c474aa7057ac50762b75f43aL21-R20): Simplified the `UseScheduledTasks` method by replacing a lambda-based entity registration with the new `AddEntity<Schedule>()` method.