### PR TITLE
Update pipelines for release testing

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -4,6 +4,7 @@ trigger:
     # These are the branches we'll mirror to our internal ADO instance
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
+    - vabachu/release-testing
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -12,6 +12,7 @@ trigger:
     branches:
         include:
             - main
+            - vabachu/release-testing
 
 # CI only, does not trigger on PRs.
 pr: none


### PR DESCRIPTION
Updating the pipelines to allow the branch `vabachu/release-testing` to run in the pipelines so we can test DurableTask.Core v3.2.0-test.1 with the current changes in this repo.