### PR TITLE
Updating pipelines for release testing of distributed tracing for entities

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -5,7 +5,7 @@ trigger:
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
     - vabachu/release-testing
-    - stevosyan/distributed-tracing-for-entities-isolated
+    - stevosyan/distributed-tracing-for-entities-isolated-with-dtcore-nuget
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -13,7 +13,7 @@ trigger:
         include:
             - main
             - vabachu/release-testing
-            - stevosyan/distributed-tracing-for-entities-isolated
+            - stevosyan/distributed-tracing-for-entities-isolated-with-dtcore-nuget
 
 # CI only, does not trigger on PRs.
 pr: none


### PR DESCRIPTION
Updating the pipelines to allow the branch stevosyan/distributed-tracing-for-entities-isolated-with-dtcore-nuget to run so we can test DurableTask.Core v3.2.0-test.1 (which contains the DT.Core distributed tracing for entities changes) with the distributed tracing for entities changes in this repo.