### PR TITLE
Update sub-orchestration default versioning

### DIFF
--- a/src/Abstractions/TaskOptions.cs
+++ b/src/Abstractions/TaskOptions.cs
@@ -94,7 +94,7 @@ public record SubOrchestrationOptions : TaskOptions
     /// <summary>
     /// Gets the version to associate with the sub-orchestration instance.
     /// </summary>
-    public TaskVersion Version { get; init; } = default!;
+    public TaskVersion? Version { get; init; }
 }
 
 /// <summary>

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -79,7 +79,7 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         Check.NotEntity(this.options.EnableEntitySupport, options?.InstanceId);
 
         // We're explicitly OK with an empty version from the options as that had to be explicitly set. It should take precedence over the default.
-        string version = string.Empty;
+        string? version = null;
         if (options?.Version is { } v)
         {
             version = v;


### PR DESCRIPTION
This commit updates the sub-orchestration default version handling to incorporate properties from TaskOrchestrationContext. These properties are generated and passed into the context by systems using Durable Functions.