### PR TITLE
Add ability to filter orchestrations at worker

### DIFF
--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -109,4 +109,21 @@ public static class DurableTaskWorkerBuilderExtensions
         });
         return builder;
     }
+
+    /// <summary>
+    /// Adds an orchestration filter to the specified <see cref="IDurableTaskWorkerBuilder"/>.
+    /// </summary>
+    /// <param name="builder">The builder to set the builder target for.</param>
+    /// <param name="orchestrationFilter">The filter function that determines whether an orchestration should be processed.</param>
+    /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
+    public static IDurableTaskWorkerBuilder UseOrchestrationFilter(this IDurableTaskWorkerBuilder builder, Func<OrchestrationInfo, bool> orchestrationFilter)
+    {
+        Check.NotNull(builder);
+        Check.NotNull(orchestrationFilter);
+        builder.Services.Configure<DurableTaskWorkerOptions>(builder.Name, options =>
+        {
+            options.OrchestrationFilter = orchestrationFilter;
+        });
+        return builder;
+    }
 }

--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -116,7 +116,6 @@ public static class DurableTaskWorkerBuilderExtensions
     /// <param name="builder">The builder to set the builder target for.</param>
     /// <typeparam name="TOrchestrationFilter">The implementation of a <see cref="IOrchestrationFilter"/> that will be bound.</typeparam>
     /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
-
     [Obsolete("Experimental")]
     public static IDurableTaskWorkerBuilder UseOrchestrationFilter<TOrchestrationFilter>(this IDurableTaskWorkerBuilder builder) where TOrchestrationFilter : class, IOrchestrationFilter
     {

--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -116,6 +116,8 @@ public static class DurableTaskWorkerBuilderExtensions
     /// <param name="builder">The builder to set the builder target for.</param>
     /// <typeparam name="TOrchestrationFilter">The implementation of a <see cref="IOrchestrationFilter"/> that will be bound.</typeparam>
     /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
+
+    [Obsolete("Experimental")]
     public static IDurableTaskWorkerBuilder UseOrchestrationFilter<TOrchestrationFilter>(this IDurableTaskWorkerBuilder builder) where TOrchestrationFilter : class, IOrchestrationFilter
     {
         Check.NotNull(builder);
@@ -129,6 +131,7 @@ public static class DurableTaskWorkerBuilderExtensions
     /// <param name="builder">The builder to set the builder target for.</param>
     /// <param name="filter">The instance of an <see cref="IOrchestrationFilter"/> to use.</param>
     /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
+    [Obsolete("Experimental")]
     public static IDurableTaskWorkerBuilder UseOrchestrationFilter(this IDurableTaskWorkerBuilder builder, IOrchestrationFilter filter)
     {
         Check.NotNull(builder);

--- a/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
+++ b/src/Worker/Core/DependencyInjection/DurableTaskWorkerBuilderExtensions.cs
@@ -114,16 +114,25 @@ public static class DurableTaskWorkerBuilderExtensions
     /// Adds an orchestration filter to the specified <see cref="IDurableTaskWorkerBuilder"/>.
     /// </summary>
     /// <param name="builder">The builder to set the builder target for.</param>
-    /// <param name="orchestrationFilter">The filter function that determines whether an orchestration should be processed.</param>
+    /// <typeparam name="TOrchestrationFilter">The implementation of a <see cref="IOrchestrationFilter"/> that will be bound.</typeparam>
     /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
-    public static IDurableTaskWorkerBuilder UseOrchestrationFilter(this IDurableTaskWorkerBuilder builder, Func<OrchestrationInfo, bool> orchestrationFilter)
+    public static IDurableTaskWorkerBuilder UseOrchestrationFilter<TOrchestrationFilter>(this IDurableTaskWorkerBuilder builder) where TOrchestrationFilter : class, IOrchestrationFilter
     {
         Check.NotNull(builder);
-        Check.NotNull(orchestrationFilter);
-        builder.Services.Configure<DurableTaskWorkerOptions>(builder.Name, options =>
-        {
-            options.OrchestrationFilter = orchestrationFilter;
-        });
+        builder.Services.AddSingleton<IOrchestrationFilter, TOrchestrationFilter>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an orchestration filter to the specified <see cref="IDurableTaskWorkerBuilder"/>.
+    /// </summary>
+    /// <param name="builder">The builder to set the builder target for.</param>
+    /// <param name="filter">The instance of an <see cref="IOrchestrationFilter"/> to use.</param>
+    /// <returns>The same <see cref="IDurableTaskWorkerBuilder"/> instance, allowing for method chaining.</returns>
+    public static IDurableTaskWorkerBuilder UseOrchestrationFilter(this IDurableTaskWorkerBuilder builder, IOrchestrationFilter filter)
+    {
+        Check.NotNull(builder);
+        builder.Services.AddSingleton(filter);
         return builder;
     }
 }

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -50,6 +50,22 @@ public class DurableTaskWorkerOptions
     }
 
     /// <summary>
+    /// Struct representation of orchestration information.
+    /// </summary>
+    public struct OrchestrationInfo
+    {
+        /// <summary>
+        /// Gets the name of the orchestration.
+        /// </summary>
+        public string Name { get; init; }
+
+        /// <summary>
+        /// Gets the tags associated with the orchestration.
+        /// </summary>
+        public Dictionary<string, string> Tags { get; init; }
+    }
+
+    /// <summary>
     /// Gets or sets the data converter. Default value is <see cref="JsonDataConverter.Default" />.
     /// </summary>
     /// <remarks>
@@ -157,6 +173,11 @@ public class DurableTaskWorkerOptions
     internal bool DataConverterExplicitlySet { get; private set; }
 
     /// <summary>
+    /// Gets or sets a callback function that determines whether an orchestration should be accepted for work.
+    /// </summary>
+    public Func<OrchestrationInfo, bool>? OrchestrationFilter { get; set; }
+
+    /// <summary>
     /// Applies these option values to another.
     /// </summary>
     /// <param name="other">The other options object to apply to.</param>
@@ -169,6 +190,7 @@ public class DurableTaskWorkerOptions
             other.MaximumTimerInterval = this.MaximumTimerInterval;
             other.EnableEntitySupport = this.EnableEntitySupport;
             other.Versioning = this.Versioning;
+            other.OrchestrationFilter = this.OrchestrationFilter;
         }
     }
 

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -148,6 +148,7 @@ public class DurableTaskWorkerOptions
     /// <summary>
     /// Gets or sets a callback function that determines whether an orchestration should be accepted for work.
     /// </summary>
+    [Obsolete("Experimental")]
     public IOrchestrationFilter? OrchestrationFilter { get; set; }
 
     /// <summary>

--- a/src/Worker/Core/DurableTaskWorkerOptions.cs
+++ b/src/Worker/Core/DurableTaskWorkerOptions.cs
@@ -50,22 +50,6 @@ public class DurableTaskWorkerOptions
     }
 
     /// <summary>
-    /// Struct representation of orchestration information.
-    /// </summary>
-    public struct OrchestrationInfo
-    {
-        /// <summary>
-        /// Gets the name of the orchestration.
-        /// </summary>
-        public string Name { get; init; }
-
-        /// <summary>
-        /// Gets the tags associated with the orchestration.
-        /// </summary>
-        public Dictionary<string, string> Tags { get; init; }
-    }
-
-    /// <summary>
     /// Gets or sets the data converter. Default value is <see cref="JsonDataConverter.Default" />.
     /// </summary>
     /// <remarks>
@@ -162,6 +146,11 @@ public class DurableTaskWorkerOptions
     public bool IsVersioningSet { get; internal set; }
 
     /// <summary>
+    /// Gets or sets a callback function that determines whether an orchestration should be accepted for work.
+    /// </summary>
+    public IOrchestrationFilter? OrchestrationFilter { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether <see cref="DataConverter" /> was explicitly set or not.
     /// </summary>
     /// <remarks>
@@ -172,10 +161,6 @@ public class DurableTaskWorkerOptions
     /// </remarks>
     internal bool DataConverterExplicitlySet { get; private set; }
 
-    /// <summary>
-    /// Gets or sets a callback function that determines whether an orchestration should be accepted for work.
-    /// </summary>
-    public Func<OrchestrationInfo, bool>? OrchestrationFilter { get; set; }
 
     /// <summary>
     /// Applies these option values to another.

--- a/src/Worker/Core/IOrchestrationFilter.cs
+++ b/src/Worker/Core/IOrchestrationFilter.cs
@@ -6,6 +6,7 @@ namespace Microsoft.DurableTask.Worker;
 /// <summary>
 /// Defines a filter for validating orchestrations.
 /// </summary>
+[Obsolete("Experimental")]
 public interface IOrchestrationFilter
 {
     /// <summary>
@@ -14,21 +15,21 @@ public interface IOrchestrationFilter
     /// <param name="info">The information on the orchestration to validate.</param>
     /// <param name="cancellationToken">The cancellation token for the request to timeout.</param>
     /// <returns><code>true</code> if the orchestration is valid <code>false</code> otherwise.</returns>
-    Task<bool> IsOrchestrationValidAsync(OrchestrationInfo info, CancellationToken cancellationToken = default);
+    ValueTask<bool> IsOrchestrationValidAsync(OrchestrationFilterParameters info, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
 /// Struct representation of orchestration information.
 /// </summary>
-public struct OrchestrationInfo
+public struct OrchestrationFilterParameters
 {
     /// <summary>
     /// Gets the name of the orchestration.
     /// </summary>
-    public string Name { get; init; }
+    public string? Name { get; init; }
 
     /// <summary>
     /// Gets the tags associated with the orchestration.
     /// </summary>
-    public Dictionary<string, string> Tags { get; init; }
+    public IReadOnlyDictionary<string, string>? Tags { get; init; }
 }

--- a/src/Worker/Core/IOrchestrationFilter.cs
+++ b/src/Worker/Core/IOrchestrationFilter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Worker;
+
+/// <summary>
+/// Defines a filter for validating orchestrations.
+/// </summary>
+public interface IOrchestrationFilter
+{
+    /// <summary>
+    /// Validate the orchestration against the filter represented by this interface.
+    /// </summary>
+    /// <param name="info">The information on the orchestration to validate.</param>
+    /// <param name="cancellationToken">The cancellation token for the request to timeout.</param>
+    /// <returns><code>true</code> if the orchestration is valid <code>false</code> otherwise.</returns>
+    Task<bool> IsOrchestrationValidAsync(OrchestrationInfo info, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Struct representation of orchestration information.
+/// </summary>
+public struct OrchestrationInfo
+{
+    /// <summary>
+    /// Gets the name of the orchestration.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Gets the tags associated with the orchestration.
+    /// </summary>
+    public Dictionary<string, string> Tags { get; init; }
+}

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Immutable;
 using System.Text;
 using DurableTask.Core;
 using DurableTask.Core.Entities;
@@ -31,7 +30,8 @@ sealed partial class GrpcDurableTaskWorker
         readonly TaskHubSidecarServiceClient client;
         readonly DurableTaskShimFactory shimFactory;
         readonly GrpcDurableTaskWorkerOptions.InternalOptions internalOptions;
-        readonly IOrchestrationFilter? orchestrationFilter = null;
+        [Obsolete("Experimental")]
+        readonly IOrchestrationFilter? orchestrationFilter;
 
         public Processor(GrpcDurableTaskWorker worker, TaskHubSidecarServiceClient client, IOrchestrationFilter? orchestrationFilter = null)
         {
@@ -381,10 +381,10 @@ sealed partial class GrpcDurableTaskWorker
                 if (this.orchestrationFilter != null)
                 {
                     filterPassed = await this.orchestrationFilter.IsOrchestrationValidAsync(
-                        new OrchestrationInfo
+                        new OrchestrationFilterParameters
                         {
                             Name = runtimeState.Name,
-                            Tags = new Dictionary<string, string>(runtimeState.Tags ?? ImmutableDictionary<string, string>.Empty),
+                            Tags = runtimeState.Tags != null ? new Dictionary<string, string>(runtimeState.Tags) : null,
                         },
                         cancellationToken);
                 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.DurableTask.Worker.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -48,7 +49,8 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
     {
         await using AsyncDisposable disposable = this.GetCallInvoker(out CallInvoker callInvoker, out string address);
         this.logger.StartingTaskHubWorker(address);
-        await new Processor(this, new(callInvoker)).ExecuteAsync(stoppingToken);
+        IOrchestrationFilter? filter = this.services.GetService<IOrchestrationFilter>();
+        await new Processor(this, new(callInvoker), filter).ExecuteAsync(stoppingToken);
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Worker/Grpc/Logs.cs
+++ b/src/Worker/Grpc/Logs.cs
@@ -57,5 +57,8 @@ namespace Microsoft.DurableTask.Worker.Grpc
 
         [LoggerMessage(EventId = 58, Level = LogLevel.Information, Message = "Abandoning orchestration. InstanceId = '{instanceId}'. Completion token = '{completionToken}'")]
         public static partial void AbandoningOrchestrationDueToVersioning(this ILogger logger, string instanceId, string completionToken);
+
+        [LoggerMessage(EventId = 59, Level = LogLevel.Information, Message = "Abandoning orchestration due to filtering. InstanceId = '{instanceId}'. Completion token = '{completionToken}'")]
+        public static partial void AbandoningOrchestrationDueToOrchestrationFilter(this ILogger logger, string instanceId, string completionToken);
     }
 }

--- a/test/Grpc.IntegrationTests/GrpcSidecar/Grpc/TaskHubGrpcServer.cs
+++ b/test/Grpc.IntegrationTests/GrpcSidecar/Grpc/TaskHubGrpcServer.cs
@@ -6,9 +6,9 @@ using System.Diagnostics;
 using DurableTask.Core;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
-using Microsoft.DurableTask.Sidecar.Dispatcher;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Microsoft.DurableTask.Sidecar.Dispatcher;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -587,6 +587,16 @@ public class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBa
     static string GetTaskIdKey(string instanceId, int taskId)
     {
         return string.Concat(instanceId, "__", taskId.ToString());
+    }
+
+    public override Task<P.AbandonActivityTaskResponse> AbandonTaskActivityWorkItem(P.AbandonActivityTaskRequest request, ServerCallContext context)
+    {
+        return Task.FromResult<P.AbandonActivityTaskResponse>(new());
+    }
+
+    public override Task<P.AbandonOrchestrationTaskResponse> AbandonTaskOrchestratorWorkItem(P.AbandonOrchestrationTaskRequest request, ServerCallContext context)
+    {
+        return Task.FromResult<P.AbandonOrchestrationTaskResponse>(new());
     }
 
     /// <summary>

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -1006,7 +1006,43 @@ public class OrchestrationPatterns : IntegrationTestBase
 
         // This should throw as the work is denied.
         instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await server.Client.WaitForInstanceCompletionAsync(instanceId, new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token));
+        using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await server.Client.WaitForInstanceCompletionAsync(instanceId, cts.Token));
+    }
+
+    [Obsolete("Experimental")]
+    [Fact]
+    public async Task FilterOrchestrationsByNamePassesWhenNotMatching()
+    {
+        // Setup a worker with an Orchestration Filter.
+        TaskName orchestratorName = nameof(EmptyOrchestration);
+        var orchestrationFilter = new OrchestrationFilter();
+        await using HostTestLifetime server = await this.StartWorkerAsync(b =>
+        {
+            b.AddTasks(tasks => tasks.AddOrchestratorFunc(orchestratorName, ctx => Task.FromResult<object?>(null)));
+            b.UseOrchestrationFilter(orchestrationFilter);
+        });
+
+        // Nothing in the filter set, the orchestration should complete.
+        string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
+        OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
+            instanceId, this.TimeoutToken);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(instanceId, metadata.InstanceId);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+
+        // Update the filter and re-enqueue. The name doesn't match so the filter should be OK.
+        orchestrationFilter.NameDenySet.Add($"not-{orchestratorName}");
+
+        // This should throw as the work is denied.
+        instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
+        metadata = await server.Client.WaitForInstanceCompletionAsync(
+            instanceId, this.TimeoutToken);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(instanceId, metadata.InstanceId);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
     }
 
     [Obsolete("Experimental")]
@@ -1046,19 +1082,66 @@ public class OrchestrationPatterns : IntegrationTestBase
         {
             Tags = orchestratorTags,
         });
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await server.Client.WaitForInstanceCompletionAsync(instanceId, new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token));
+        using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await server.Client.WaitForInstanceCompletionAsync(instanceId, cts.Token));
     }
 
+    [Obsolete("Experimental")]
+    [Fact]
+    public async Task FilterOrchestrationsByTagPassesWithNoMatch()
+    {
+        // Setup a worker with an Orchestration Filter.
+        TaskName orchestratorName = nameof(EmptyOrchestration);
+        IReadOnlyDictionary<string, string> orchestratorTags = new Dictionary<string, string>
+        {
+            { "test", "true" }
+        };
+        var orchestrationFilter = new OrchestrationFilter();
+        await using HostTestLifetime server = await this.StartWorkerAsync(b =>
+        {
+            b.AddTasks(tasks => tasks.AddOrchestratorFunc(orchestratorName, ctx => Task.FromResult<object?>(null)));
+            b.UseOrchestrationFilter(orchestrationFilter);
+        });
+
+        // Nothing in the filter set, the orchestration should complete.
+        string instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, new StartOrchestrationOptions
+        {
+            Tags = orchestratorTags,
+        });
+        OrchestrationMetadata metadata = await server.Client.WaitForInstanceCompletionAsync(
+            instanceId, this.TimeoutToken);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(instanceId, metadata.InstanceId);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+
+        // Update the filter and re-enqueue. The tags don't match so the orchestration should be OK.
+        orchestrationFilter.TagDenyDict.Add("test", "false");
+
+        // This should throw as the work is denied.
+        instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName, new StartOrchestrationOptions
+        {
+            Tags = orchestratorTags,
+        });
+        metadata = await server.Client.WaitForInstanceCompletionAsync(
+            instanceId, this.TimeoutToken);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(instanceId, metadata.InstanceId);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+    }
+
+    [Obsolete("Experimental")]
     class OrchestrationFilter : IOrchestrationFilter
     {
         public ISet<string> NameDenySet { get; set; } = new HashSet<string>();
         public IDictionary<string, string> TagDenyDict = new Dictionary<string, string>();
 
-        public Task<bool> IsOrchestrationValidAsync(OrchestrationInfo info, CancellationToken cancellationToken = default)
+        public ValueTask<bool> IsOrchestrationValidAsync(OrchestrationFilterParameters info, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(
+            return ValueTask.FromResult(
                 !this.NameDenySet.Contains(info.Name)
-                && !this.TagDenyDict.Any(kvp => info.Tags.ContainsKey(kvp.Key) && info.Tags[kvp.Key] == kvp.Value));
+                && !this.TagDenyDict.Any(kvp => info.Tags != null && info.Tags.ContainsKey(kvp.Key) && info.Tags[kvp.Key] == kvp.Value));
         }
     }
 

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -979,6 +979,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         Assert.Equal("Hello from tagged activity, World!", metadata.ReadOutputAs<string>());
     }
 
+    [Obsolete("Experimental")]
     [Fact]
     public async Task FilterOrchestrationsByName()
     {
@@ -1008,6 +1009,7 @@ public class OrchestrationPatterns : IntegrationTestBase
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await server.Client.WaitForInstanceCompletionAsync(instanceId, new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token));
     }
 
+    [Obsolete("Experimental")]
     [Fact]
     public async Task FilterOrchestrationsByTag()
     {


### PR DESCRIPTION
This change allows a user to set a lambda that acts a filter for orchestrations. If the lambda returns false, the orchestration will be abandoned, leaving it to be attempted again later.

In this initial commit, the filter can work off of the orchestration name and the orchestration tags.