### PR TITLE
Move from net6 to net8 target

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v3
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Setup .NET from global.json
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,15 +9,15 @@
 
   <!-- Microsoft.Extensions.* Packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48'" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
   </ItemGroup>
 
   <!-- Azure.* Packages -->
@@ -73,10 +73,10 @@
   <ItemGroup>
     <PackageVersion Include="DotNext" Version="4.13.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
-    <PackageVersion Include="System.Collections.Immutable" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
+++ b/samples/AzureFunctionsApp/AzureFunctionsApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/samples/ScheduleWebApp/ScheduleWebApp.csproj
+++ b/samples/ScheduleWebApp/ScheduleWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/samples/WebAPI/WebAPI.csproj
+++ b/samples/WebAPI/WebAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/Client/AzureManaged/Client.AzureManaged.csproj
+++ b/src/Client/AzureManaged/Client.AzureManaged.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageDescription>Azure Managed extensions for the Durable Task Framework client.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
     <VersionSuffix>preview.1</VersionSuffix>

--- a/src/Client/Grpc/Client.Grpc.csproj
+++ b/src/Client/Grpc/Client.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageDescription>The gRPC client for the Durable Task Framework.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
   </PropertyGroup>

--- a/src/Grpc/Grpc.csproj
+++ b/src/Grpc/Grpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageDescription>The gRPC Protobuf .NET services for Durable Task Framework.</PackageDescription>
   </PropertyGroup>
   <ItemGroup>
@@ -13,7 +13,7 @@
     <PackageReference Include="Grpc.Core" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 

--- a/src/ScheduledTasks/ScheduledTasks.csproj
+++ b/src/ScheduledTasks/ScheduledTasks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageDescription>Durable Task Scheduled Tasks Client</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
     <VersionSuffix>preview.1</VersionSuffix>

--- a/src/Worker/AzureManaged/Worker.AzureManaged.csproj
+++ b/src/Worker/AzureManaged/Worker.AzureManaged.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageDescription>Azure Managed extensions for the Durable Task Framework worker.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
     <VersionSuffix>preview.1</VersionSuffix>

--- a/src/Worker/Grpc/Worker.Grpc.csproj
+++ b/src/Worker/Grpc/Worker.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageDescription>The gRPC worker for the Durable Task Framework.</PackageDescription>
     <EnableStyleCop>true</EnableStyleCop>
   </PropertyGroup>

--- a/test/Abstractions.Tests/Abstractions.Tests.csproj
+++ b/test/Abstractions.Tests/Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Analyzers.Tests/Analyzers.Tests.csproj
+++ b/test/Analyzers.Tests/Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>Benchmarks</AssemblyName>
  </PropertyGroup>

--- a/test/Client/AzureManaged.Tests/Client.AzureManaged.Tests.csproj
+++ b/test/Client/AzureManaged.Tests/Client.AzureManaged.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Client/Core.Tests/Client.Tests.csproj
+++ b/test/Client/Core.Tests/Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Client/Grpc.Tests/Client.Grpc.Tests.csproj
+++ b/test/Client/Grpc.Tests/Client.Grpc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Client/OrchestrationServiceClientShim.Tests/Client.OrchestrationServiceClientShim.Tests.csproj
+++ b/test/Client/OrchestrationServiceClientShim.Tests/Client.OrchestrationServiceClientShim.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Generators.Tests/Generators.Tests.csproj
+++ b/test/Generators.Tests/Generators.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grpc.IntegrationTests/Grpc.IntegrationTests.csproj
+++ b/test/Grpc.IntegrationTests/Grpc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ScheduledTasks.Tests/ScheduledTasks.Tests.csproj
+++ b/test/ScheduledTasks.Tests/ScheduledTasks.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -18,4 +18,4 @@
     <ProjectReference Include="..\Abstractions.Tests\Abstractions.Tests.csproj" />
   </ItemGroup>
 
-</Project> 
+</Project>

--- a/test/Shared/AzureManaged.Tests/Shared.AzureManaged.Tests.csproj
+++ b/test/Shared/AzureManaged.Tests/Shared.AzureManaged.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestHelpers/TestHelpers.csproj
+++ b/test/TestHelpers/TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Worker/AzureManaged.Tests/Worker.AzureManaged.Tests.csproj
+++ b/test/Worker/AzureManaged.Tests/Worker.AzureManaged.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Worker/Core.Tests/Worker.Tests.csproj
+++ b/test/Worker/Core.Tests/Worker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Worker/Grpc.Tests/Worker.Grpc.Tests.csproj
+++ b/test/Worker/Grpc.Tests/Worker.Grpc.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 6 reached end of life in November of 2024. Updating the target frameworks to reference .NET 8.