### PR TITLE
Expose gRPC client retry options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (Unreleased)
 
+- Expose gRPC retry options in Azure Managed extensions ([#447](https://github.com/microsoft/durabletask-dotnet/pull/447))
+
 ## v1.12.0
 
 - Activity tag support ([#426](https://github.com/microsoft/durabletask-dotnet/pull/426))

--- a/src/Client/AzureManaged/DurableTaskSchedulerClientExtensions.cs
+++ b/src/Client/AzureManaged/DurableTaskSchedulerClientExtensions.cs
@@ -41,35 +41,6 @@ public static class DurableTaskSchedulerClientExtensions
     }
 
     /// <summary>
-    /// Configures Durable Task client to use the Azure Durable Task Scheduler service.
-    /// </summary>
-    /// <param name="builder">The Durable Task client builder to configure.</param>
-    /// <param name="endpointAddress">The endpoint address of the Durable Task Scheduler resource. Expected to be in the format "https://{scheduler-name}.{region}.durabletask.io".</param>
-    /// <param name="taskHubName">The name of the task hub resource associated with the Durable Task Scheduler resource.</param>
-    /// <param name="credential">The credential used to authenticate with the Durable Task Scheduler task hub resource.</param>
-    /// <param name="retryOptions">The options that determine how and when a request will be retried.</param>
-    /// <param name="configure">Optional callback to dynamically configure DurableTaskSchedulerClientOptions.</param>
-    public static void UseDurableTaskScheduler(
-        this IDurableTaskClientBuilder builder,
-        string endpointAddress,
-        string taskHubName,
-        TokenCredential credential,
-        DurableTaskSchedulerClientOptions.ClientRetryOptions retryOptions,
-        Action<DurableTaskSchedulerClientOptions>? configure = null)
-    {
-        ConfigureSchedulerOptions(
-            builder,
-            options =>
-            {
-                options.EndpointAddress = endpointAddress;
-                options.TaskHubName = taskHubName;
-                options.Credential = credential;
-                options.RetryOptions = retryOptions;
-            },
-            configure);
-    }
-
-    /// <summary>
     /// Configures Durable Task client to use the Azure Durable Task Scheduler service using a connection string.
     /// </summary>
     /// <param name="builder">The Durable Task client builder to configure.</param>
@@ -89,33 +60,6 @@ public static class DurableTaskSchedulerClientExtensions
                 options.TaskHubName = connectionOptions.TaskHubName;
                 options.Credential = connectionOptions.Credential;
                 options.AllowInsecureCredentials = connectionOptions.AllowInsecureCredentials;
-            },
-            configure);
-    }
-
-    /// <summary>
-    /// Configures Durable Task client to use the Azure Durable Task Scheduler service using a connection string.
-    /// </summary>
-    /// <param name="builder">The Durable Task client builder to configure.</param>
-    /// <param name="connectionString">The connection string used to connect to the Durable Task Scheduler service.</param>
-    /// /// <param name="retryOptions">The options that determine how and when a request will be retried.</param>
-    /// <param name="configure">Optional callback to dynamically configure DurableTaskSchedulerClientOptions.</param>
-    public static void UseDurableTaskScheduler(
-        this IDurableTaskClientBuilder builder,
-        string connectionString,
-        DurableTaskSchedulerClientOptions.ClientRetryOptions retryOptions,
-        Action<DurableTaskSchedulerClientOptions>? configure = null)
-    {
-        var connectionOptions = DurableTaskSchedulerClientOptions.FromConnectionString(connectionString);
-        ConfigureSchedulerOptions(
-            builder,
-            options =>
-            {
-                options.EndpointAddress = connectionOptions.EndpointAddress;
-                options.TaskHubName = connectionOptions.TaskHubName;
-                options.Credential = connectionOptions.Credential;
-                options.AllowInsecureCredentials = connectionOptions.AllowInsecureCredentials;
-                options.RetryOptions = retryOptions;
             },
             configure);
     }

--- a/test/Client/AzureManaged.Tests/DurableTaskSchedulerClientExtensionsTests.cs
+++ b/test/Client/AzureManaged.Tests/DurableTaskSchedulerClientExtensionsTests.cs
@@ -205,15 +205,16 @@ public class DurableTaskSchedulerClientExtensionsTests
         DefaultAzureCredential credential = new DefaultAzureCredential();
 
         // Act
-        mockBuilder.Object.UseDurableTaskScheduler(ValidEndpoint, ValidTaskHub, credential,
-            new DurableTaskSchedulerClientOptions.ClientRetryOptions
-            {
-                MaxRetries = 5,
-                InitialBackoffMs = 100,
-                MaxBackoffMs = 1000,
-                BackoffMultiplier = 2.0,
-                RetryableStatusCodes = new List<StatusCode> { StatusCode.Unknown }
-            });
+        mockBuilder.Object.UseDurableTaskScheduler(ValidEndpoint, ValidTaskHub, credential, options =>
+                options.RetryOptions = new DurableTaskSchedulerClientOptions.ClientRetryOptions
+                {
+                    MaxRetries = 5,
+                    InitialBackoffMs = 100,
+                    MaxBackoffMs = 1000,
+                    BackoffMultiplier = 2.0,
+                    RetryableStatusCodes = new List<StatusCode> { StatusCode.Unknown }
+                }
+            );
 
         // Assert
         ServiceProvider provider = services.BuildServiceProvider();
@@ -247,15 +248,16 @@ public class DurableTaskSchedulerClientExtensionsTests
         string connectionString = $"Endpoint={ValidEndpoint};Authentication=DefaultAzure;TaskHub={ValidTaskHub}";
 
         // Act
-        mockBuilder.Object.UseDurableTaskScheduler(connectionString,
-            new DurableTaskSchedulerClientOptions.ClientRetryOptions
-            {
-                MaxRetries = 5,
-                InitialBackoffMs = 100,
-                MaxBackoffMs = 1000,
-                BackoffMultiplier = 2.0,
-                RetryableStatusCodes = new List<StatusCode> { StatusCode.Unknown }
-            });
+        mockBuilder.Object.UseDurableTaskScheduler(connectionString, options =>
+                options.RetryOptions = new DurableTaskSchedulerClientOptions.ClientRetryOptions
+                {
+                    MaxRetries = 5,
+                    InitialBackoffMs = 100,
+                    MaxBackoffMs = 1000,
+                    BackoffMultiplier = 2.0,
+                    RetryableStatusCodes = new List<StatusCode> { StatusCode.Unknown }
+                }
+            );
 
         // Assert
         ServiceProvider provider = services.BuildServiceProvider();


### PR DESCRIPTION
This commit allows for users to specify their own retry options instead of relying on the defaults we provide. The general use case here is to enable longer retry periods, more retries, and different status codes to retry on.