### PR TITLE
Add System.Text.Json to Shared.csproj

### DIFF
--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -17,8 +17,6 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <!-- For some reason, this project resolves this at 6.0.0 instead of the centrally defined 8.0.6. 
-         Since 6.0.0 has known vulnerabilities, we override to 6.0.11 to avoid major version changes here. -->
     <PackageReference Include="System.Text.Json"/>
   </ItemGroup>
 

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <!-- For some reason, this project resolves this at 6.0.0 instead of the centrally defined 8.0.6. 
+         Since 6.0.0 has known vulnerabilities, we override to 6.0.11 to avoid major version changes here. -->
+    <PackageReference Include="System.Text.Json" VersionOverride="6.0.11"/>
   </ItemGroup>
 
 </Project>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <!-- For some reason, this project resolves this at 6.0.0 instead of the centrally defined 8.0.6. 
          Since 6.0.0 has known vulnerabilities, we override to 6.0.11 to avoid major version changes here. -->
-    <PackageReference Include="System.Text.Json" VersionOverride="6.0.11"/>
+    <PackageReference Include="System.Text.Json"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet dynamically resolves System.Text.Json to 6.0.0 in Shared.csproj even though it is defined at 8.0.6 in CPM. 
This causes flags in S360 even though this projects dependencies are not built into any of the released components. 
This change intentionally resolves the CPM version of this dependency for this project