### PR TITLE
Add Microsoft.DurableTask.Extensions.AzureBlobPayloads to nuget publish

### DIFF
--- a/eng/publish/publish.yml
+++ b/eng/publish/publish.yml
@@ -349,3 +349,26 @@ extends:
             publishFeedCredentials: 'DurableTask org NuGet API Key'
             packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.ScheduledTasks.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
             packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
+
+      # add it for Microsoft.DurableTask.Extensions.AzureBlobPayloads
+      - job: nugetRelease_Microsoft_DurableTask_Extensions_AzureBlobPayloads
+        displayName: NuGet Release (Microsoft.DurableTask.Extensions.AzureBlobPayloads)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval') # nuget packages need to be on ADO first
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialPipeline  # Pipeline reference as defined in the resources section
+            artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.DurableTask.Extensions.AzureBlobPayloads)'
+          inputs:
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.Extensions.AzureBlobPayloads.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling

--- a/list-nuget-packages-links.ps1
+++ b/list-nuget-packages-links.ps1
@@ -1,0 +1,104 @@
+# # Simple script to list NuGet packages
+# $packages = @(
+#     "Microsoft.DurableTask.Abstractions",
+#     "Microsoft.DurableTask.Client", 
+#     "Microsoft.DurableTask.Worker",
+#     "Microsoft.DurableTask.Grpc",
+#     "Microsoft.DurableTask.Client.Grpc",
+#     "Microsoft.DurableTask.Worker.Grpc",
+#     "Microsoft.DurableTask.Client.OrchestrationServiceClientShim",
+#     "Microsoft.DurableTask.Extensions.AzureBlobPayloads",
+#     "Microsoft.DurableTask.Client.AzureManaged",
+#     "Microsoft.DurableTask.Worker.AzureManaged", 
+#     "Microsoft.DurableTask.ScheduledTasks"
+# )
+
+# Write-Host "DurableTask .NET NuGet Packages:" -ForegroundColor Green
+# Write-Host ""
+
+# foreach ($package in $packages) {
+#     $url = "https://www.nuget.org/packages/$package"
+#     Write-Host "- $package" -ForegroundColor White
+#     Write-Host "  URL: $url" -ForegroundColor Gray
+#     Write-Host ""
+# }
+
+
+# $packages = @(
+#     "Microsoft.DurableTask.Abstractions",
+#     "Microsoft.DurableTask.Client",
+#     "Microsoft.DurableTask.Worker",
+#     "Microsoft.DurableTask.Grpc",
+#     "Microsoft.DurableTask.Client.Grpc",
+#     "Microsoft.DurableTask.Worker.Grpc",
+#     "Microsoft.DurableTask.Client.OrchestrationServiceClientShim",
+#     "Microsoft.DurableTask.Extensions.AzureBlobPayloads",
+#     "Microsoft.DurableTask.Client.AzureManaged",
+#     "Microsoft.DurableTask.Worker.AzureManaged",
+#     "Microsoft.DurableTask.ScheduledTasks"
+# )
+
+# Write-Host "DurableTask .NET NuGet Packages (latest versions):" -ForegroundColor Green
+# Write-Host ""
+
+# foreach ($package in $packages) {
+#     $lowerName = $package.ToLower()
+#     $metadataUrl = "https://api.nuget.org/v3/registration5-semver1/$lowerName/index.json"
+#     try {
+#         $metadata = Invoke-RestMethod -Uri $metadataUrl -ErrorAction Stop
+#         $lastPage = $metadata.items[-1]
+#         $lastVersionEntry = $lastPage.items[-1]
+#         $latestVersion = $lastVersionEntry.catalogEntry.version
+#         $packageUrl = "https://www.nuget.org/packages/$package/$latestVersion"
+#         Write-Host "- $package" -ForegroundColor White
+#         Write-Host "  Latest version: $latestVersion" -ForegroundColor Yellow
+#         Write-Host "  URL: $packageUrl" -ForegroundColor Gray
+#         Write-Host ""
+#     }
+#     catch {
+#         Write-Host "- $package" -ForegroundColor White
+#         Write-Host "  ERROR retrieving metadata: $($_.Exception.Message)" -ForegroundColor Red
+#         Write-Host ""
+#     }
+# }
+
+
+$packages = @(
+    "Microsoft.DurableTask.Abstractions",
+    "Microsoft.DurableTask.Client",
+    "Microsoft.DurableTask.Worker",
+    "Microsoft.DurableTask.Grpc",
+    "Microsoft.DurableTask.Client.Grpc",
+    "Microsoft.DurableTask.Worker.Grpc",
+    "Microsoft.DurableTask.Client.OrchestrationServiceClientShim",
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads",
+    "Microsoft.DurableTask.Client.AzureManaged",
+    "Microsoft.DurableTask.Worker.AzureManaged",
+    "Microsoft.DurableTask.ScheduledTasks"
+)
+
+Write-Host "DurableTask .NET NuGet Packages (latest versions):" -ForegroundColor Green
+Write-Host ""
+
+foreach ($package in $packages) {
+    $lowerName = $package.ToLower()
+    $metadataUrl = "https://api.nuget.org/v3/registration5-semver1/$lowerName/index.json"
+    try {
+        $metadata = Invoke-RestMethod -Uri $metadataUrl -ErrorAction Stop
+        $lastPage = $metadata.items[-1]
+        $lastVersionEntry = $lastPage.items[-1]
+        $latestVersion = $lastVersionEntry.catalogEntry.version
+        $packageUrl = "https://www.nuget.org/packages/$package/$latestVersion"
+        Write-Host "- $package" -ForegroundColor White
+        Write-Host "  Latest version: $latestVersion" -ForegroundColor Yellow
+        Write-Host "  URL: $packageUrl" -ForegroundColor Gray
+        Write-Host ""
+    }
+    catch {
+        $fallbackUrl = "https://www.nuget.org/packages/$package"
+        Write-Host "- $package" -ForegroundColor White
+        Write-Host "  Version: (not found or preview-only)" -ForegroundColor DarkYellow
+        Write-Host "  URL: $fallbackUrl" -ForegroundColor Gray
+        Write-Host ""
+    }
+}


### PR DESCRIPTION
This pull request adds publishing support for the `Microsoft.DurableTask.Extensions.AzureBlobPayloads` NuGet package and introduces a new PowerShell script to list DurableTask NuGet packages and their latest versions. These updates enhance release automation and developer visibility into package versions.

**Release pipeline updates:**

* Added a new release job in `eng/publish/publish.yml` to push the `Microsoft.DurableTask.Extensions.AzureBlobPayloads` NuGet package to the external feed, following the same validation and tooling steps as other DurableTask packages.

**Developer tooling:**

* Added a new PowerShell script `list-nuget-packages-links.ps1` that lists DurableTask NuGet packages and displays their latest published versions and URLs by querying the NuGet API, improving discoverability for developers.