### PR TITLE
Fix Worker Registry and Add Documentation Notes

### DIFF
--- a/src/Client/Core/DependencyInjection/DefaultDurableTaskClientBuilder.cs
+++ b/src/Client/Core/DependencyInjection/DefaultDurableTaskClientBuilder.cs
@@ -50,6 +50,8 @@ public class DefaultDurableTaskClientBuilder(string? name, IServiceCollection se
                 + " 'UseBuildTarget(Type target)'. An example of a valid client is '.UseGrpc()'.");
         }
 
+        // Note: Modifying any logic in this section could introduce breaking changes.
+        // Do not alter the input parameter.
         return (DurableTaskClient)ActivatorUtilities.CreateInstance(serviceProvider, this.buildTarget, this.Name);
     }
 

--- a/src/Worker/Core/DependencyInjection/DefaultDurableTaskWorkerBuilder.cs
+++ b/src/Worker/Core/DependencyInjection/DefaultDurableTaskWorkerBuilder.cs
@@ -55,18 +55,9 @@ public class DefaultDurableTaskWorkerBuilder : IDurableTaskWorkerBuilder
 
         DurableTaskRegistry registry = serviceProvider.GetOptions<DurableTaskRegistry>(this.Name);
 
-        // Get the IExceptionPropertiesProvider from DI if registered
-        IExceptionPropertiesProvider? exceptionPropertiesProvider = serviceProvider.GetService<IExceptionPropertiesProvider>();
-
-        if (exceptionPropertiesProvider != null)
-        {
-            return (IHostedService)ActivatorUtilities.CreateInstance(
-                serviceProvider, this.buildTarget, this.Name, registry.BuildFactory(), exceptionPropertiesProvider);
-        }
-        else
-        {
-            return (IHostedService)ActivatorUtilities.CreateInstance(
-                serviceProvider, this.buildTarget, this.Name, registry.BuildFactory());
-        }
+        // Note: Modifying any logic in this section could introduce breaking changes.
+        // Do not alter the input parameter.
+        return (IHostedService)ActivatorUtilities.CreateInstance(
+            serviceProvider, this.buildTarget, this.Name, registry.BuildFactory());
     }
 }


### PR DESCRIPTION
The change at worker registry is unnecessary and a breaking change. Revert the change and add notes that we shouldn't update the logic .