### PR TITLE
v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## v1.17.2
+## v1.18.0
 - Add taskentity support to durabletasksourcegenerator by Copilot ([#517](https://github.com/microsoft/durabletask-dotnet/pull/517))
 - Bump azure.identity by dependabot[bot] ([#525](https://github.com/microsoft/durabletask-dotnet/pull/525))
 - Bump google.protobuf by dependabot[bot] ([#529](https://github.com/microsoft/durabletask-dotnet/pull/529))

--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.17.2</VersionPrefix>
+    <VersionPrefix>1.18.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the project version from `1.17.2` to `1.18.0`. The change is reflected in both the `CHANGELOG.md` and the release configuration file.

Version bump:

* Updated the version number in `CHANGELOG.md` to `v1.18.0` and in `eng/targets/Release.props` to `1.18.0`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3) [[2]](diffhunk://#diff-de56770725d2551281de27e0bc802c239c0b894637db9a6387e492b5b8e472a2L20-R20)