### PR TITLE
Add Check for Non-accessible Code at Analyzer

### DIFF
--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -323,6 +323,13 @@ public class MethodProbeOrchestrationVisitor : OrchestrationVisitor
             IEnumerable<MethodDeclarationSyntax> calleeSyntaxes = calleeMethodSymbol.GetSyntaxNodes();
             foreach (MethodDeclarationSyntax calleeSyntax in calleeSyntaxes)
             {
+                // Check if the syntax tree is part of the current compilation before trying to get its semantic model.
+                // Extension methods from external assemblies won't be in the compilation, so skip them.
+                if (!semanticModel.Compilation.ContainsSyntaxTree(calleeSyntax.SyntaxTree))
+                {
+                    continue;
+                }
+
                 // Since the syntax tree of the callee method might be different from the caller method, we need to get the correct semantic model,
                 // avoiding the exception 'Syntax node is not within syntax tree'.
                 SemanticModel sm = semanticModel.SyntaxTree == calleeSyntax.SyntaxTree ?

--- a/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
+++ b/src/Analyzers/Orchestration/OrchestrationAnalyzer.cs
@@ -141,7 +141,14 @@ public abstract class OrchestrationAnalyzer<TOrchestrationVisitor> : DiagnosticA
                     case IMethodReferenceOperation methodReferenceOperation:
                         // use the method reference as the method symbol
                         methodSymbol = methodReferenceOperation.Method;
-                        methodSyntax = methodReferenceOperation.Method.DeclaringSyntaxReferences.First().GetSyntax();
+
+                        // Only get syntax for methods in the current project (skip external assemblies)
+                        // If IsEmpty (external method), methodSyntax stays null and we skip analysis below
+                        if (!methodReferenceOperation.Method.DeclaringSyntaxReferences.IsEmpty)
+                        {
+                            methodSyntax = methodReferenceOperation.Method.DeclaringSyntaxReferences.First().GetSyntax();
+                        }
+
                         break;
                     default:
                         break;

--- a/src/Analyzers/RoslynExtensions.cs
+++ b/src/Analyzers/RoslynExtensions.cs
@@ -162,13 +162,6 @@ static class RoslynExtensions
     /// <returns>The Diagnostic based on the symbol location.</returns>
     public static Diagnostic BuildDiagnostic(DiagnosticDescriptor descriptor, ISymbol symbol, params string[] messageArgs)
     {
-        // If the symbol has no syntax references (e.g., symbols from external assemblies),
-        // fall back to using the symbol's location directly.
-        if (symbol.DeclaringSyntaxReferences.IsEmpty)
-        {
-            return Diagnostic.Create(descriptor, symbol.Locations.FirstOrDefault() ?? Location.None, messageArgs);
-        }
-
         return BuildDiagnostic(descriptor, symbol.DeclaringSyntaxReferences.First().GetSyntax(), messageArgs);
     }
 


### PR DESCRIPTION
fix https://github.com/Azure/azure-functions-durable-extension/issues/3173


Analyzer threw `ArgumentException` and `AD0001` warning when encountering extension methods defined in separate projects/assemblies.

This PR add checks to skip analyzing methods for non-accessible source code