### PR TITLE
Halspang/v1 21 0

### DIFF
--- a/eng/targets/Release.props
+++ b/eng/targets/Release.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.20.1</VersionPrefix>
+    <VersionPrefix>1.21.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
# Summary
## What changed?
Update to `1.21.0`.

## Why is this change needed?
New release for the SDK.

