### PR TITLE
Fix build warnings and clean up exception message

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,6 @@
   <!-- Testing Frameworks & Analysis Packages -->
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/samples/ExportHistoryWebApp/ExportHistoryWebApp.csproj
+++ b/samples/ExportHistoryWebApp/ExportHistoryWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/InProcessTestHost/Sidecar/Grpc/TaskHubGrpcServer.cs
+++ b/src/InProcessTestHost/Sidecar/Grpc/TaskHubGrpcServer.cs
@@ -902,7 +902,7 @@ public class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBa
         {
             outputStream = this.workerToClientStream ??
                 // CA2201: Use specific exception types
-                throw new InvalidOperationException("TODO: No client is connected! Need to wait until a client connects before executing!");
+                throw new InvalidOperationException("No client is connected. Need to wait until a client connects before executing.");
         }
 
         // The gRPC channel can only handle one message at a time, so we need to serialize access to it.


### PR DESCRIPTION
- Remove duplicate BenchmarkDotNet 0.14.0 entry in Directory.Packages.props (fixes NU1506)
- Upgrade ExportHistoryWebApp from net6.0 to net8.0 (fixes NETSDK1138)
- Remove 'TODO' prefix from exception message in TaskHubGrpcServer

# Summary
## What changed?
-

## Why is this change needed?
-

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
