### PR TITLE
Add ExportHistory package to NuGet publish pipeline

### DIFF
--- a/eng/publish/publish.yml
+++ b/eng/publish/publish.yml
@@ -350,6 +350,29 @@ extends:
             packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.ScheduledTasks.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
             packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
 
+      # NuGet release (Microsoft.DurableTask.ExportHistory)
+      - job: nugetRelease_Microsoft_DurableTask_ExportHistory
+        displayName: NuGet Release (Microsoft.DurableTask.ExportHistory)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval') # nuget packages need to be on ADO first
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialPipeline  # Pipeline reference as defined in the resources section
+            artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.DurableTask.ExportHistory)'
+          inputs:
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.ExportHistory.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
+
       # add it for Microsoft.DurableTask.Extensions.AzureBlobPayloads
       - job: nugetRelease_Microsoft_DurableTask_Extensions_AzureBlobPayloads
         displayName: NuGet Release (Microsoft.DurableTask.Extensions.AzureBlobPayloads)

--- a/list-nuget-packages-links.ps1
+++ b/list-nuget-packages-links.ps1
@@ -74,7 +74,8 @@ $packages = @(
     "Microsoft.DurableTask.Extensions.AzureBlobPayloads",
     "Microsoft.DurableTask.Client.AzureManaged",
     "Microsoft.DurableTask.Worker.AzureManaged",
-    "Microsoft.DurableTask.ScheduledTasks"
+    "Microsoft.DurableTask.ScheduledTasks",
+    "Microsoft.DurableTask.ExportHistory"
 )
 
 Write-Host "DurableTask .NET NuGet Packages (latest versions):" -ForegroundColor Green


### PR DESCRIPTION
What was changed (2 files):
[publish.yml](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added a nugetRelease_Microsoft_DurableTask_ExportHistory job that publishes [Microsoft.DurableTask.ExportHistory.*.nupkg](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to NuGet, following the same pattern as all other package publish jobs (e.g., ScheduledTasks, AzureBlobPayloads).

[list-nuget-packages-links.ps1](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added [Microsoft.DurableTask.ExportHistory](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the packages array.