### PR TITLE
Add Timeout support to PurgeInstancesFilter for partial purge

### DIFF
--- a/src/Client/Core/PurgeInstancesFilter.cs
+++ b/src/Client/Core/PurgeInstancesFilter.cs
@@ -14,4 +14,12 @@ public record PurgeInstancesFilter(
     DateTimeOffset? CreatedTo = null,
     IEnumerable<OrchestrationRuntimeStatus>? Statuses = null)
 {
+    /// <summary>
+    /// Gets or sets the maximum amount of time to spend purging instances in a single call.
+    /// If <c>null</c>, all matching instances are purged regardless of how long it takes.
+    /// When set, the purge stops accepting new instances after this duration elapses
+    /// and returns with <see cref="PurgeResult.IsComplete"/> set to <c>false</c>.
+    /// Already-started instance deletions will complete before the method returns.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
 }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -488,6 +488,11 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
             request.PurgeInstanceFilter.RuntimeStatus.AddRange(filter.Statuses.Select(x => x.ToGrpcStatus()));
         }
 
+        if (filter?.Timeout is not null)
+        {
+            request.PurgeInstanceFilter.Timeout = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(filter.Timeout.Value);
+        }
+
         return this.PurgeInstancesCoreAsync(request, cancellation);
     }
 

--- a/src/Grpc/orchestrator_service.proto
+++ b/src/Grpc/orchestrator_service.proto
@@ -517,6 +517,7 @@ message PurgeInstanceFilter {
     google.protobuf.Timestamp createdTimeFrom = 1;
     google.protobuf.Timestamp createdTimeTo = 2;
     repeated OrchestrationStatus runtimeStatus = 3;
+    google.protobuf.Duration timeout = 4;
 }
 
 message PurgeInstancesResponse {


### PR DESCRIPTION
## Summary

Add `TimeSpan? Timeout` property to `PurgeInstancesFilter` and send it as `google.protobuf.Duration` in the gRPC proto request, enabling time-bounded partial purge operations.

## Motivation

When purging large numbers of orchestration instances through the isolated worker SDK, the gRPC call between worker and host times out before the purge completes. The caller receives `OperationCanceledException` while the host-side purge continues silently — making progress invisible and counts unreliable.

With this change, callers can set a timeout (e.g., 25 seconds) on each purge call. The operation returns within the timeout with accurate counts and an `IsComplete` flag, allowing the caller to loop until all instances are purged.

## Changes

- **`PurgeInstancesFilter`**: Add `TimeSpan? Timeout { get; init; }` property
- **`GrpcDurableTaskClient.PurgeAllInstancesAsync`**: Send timeout as `google.protobuf.Duration` in proto request
- **Proto**: Add `google.protobuf.Duration timeout = 4` to `PurgeInstanceFilter` message

## Usage

```csharp
var filter = new PurgeInstancesFilter(
    CreatedFrom: DateTimeOffset.MinValue,
    CreatedTo: DateTimeOffset.UtcNow.AddMinutes(-5))
{
    Timeout = TimeSpan.FromSeconds(25),
};

bool isComplete = false;
int totalPurged = 0;
while (!isComplete)
{
    PurgeResult result = await client.PurgeAllInstancesAsync(filter);
    totalPurged += result.PurgedInstanceCount;
    isComplete = result.IsComplete ?? true;
}
```

## Breaking Changes

None. The `Timeout` property is optional with a default of `null` (existing behavior unchanged).

## Dependencies

- Proto change: microsoft/durabletask-protobuf#66
- Host-side mapping: Azure/azure-functions-durable-extension (wangbill/agents branch)
- DTFx implementation: Azure/durabletask (wangbill/enpurge branch)