### PR TITLE
Fix InProcessTestHost ContinueAsNew stuck-instance race condition

### DIFF
--- a/src/InProcessTestHost/InProcessTestHost.csproj
+++ b/src/InProcessTestHost/InProcessTestHost.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.DurableTask.Testing</RootNamespace>
     <AssemblyName>Microsoft.DurableTask.InProcessTestHost</AssemblyName>
     <PackageId>Microsoft.DurableTask.InProcessTestHost</PackageId>
-    <Version>0.2.2-preview.1</Version>
+    <Version>0.2.3-preview.1</Version>
     
     <!-- Suppress CA1848: Use LoggerMessage delegates for high-performance logging scenarios -->
     <NoWarn>$(NoWarn);CA1848</NoWarn>

--- a/src/InProcessTestHost/Sidecar/Dispatcher/TaskOrchestrationDispatcher.cs
+++ b/src/InProcessTestHost/Sidecar/Dispatcher/TaskOrchestrationDispatcher.cs
@@ -149,6 +149,16 @@ class TaskOrchestrationDispatcher : WorkItemDispatcher<TaskOrchestrationWorkItem
                 out bool continueAsNew);
             if (continueAsNew)
             {
+                // The previous execution is being replaced by a new one. Clear any
+                // accumulated messages from the old execution so they are not
+                // re-enqueued when the work item completes. Without this, stale
+                // activity/timer/orchestrator messages from prior iterations would
+                // be committed alongside the new execution, causing duplicate
+                // activities, stale timer fires, and ultimately stuck instances.
+                activityMessages.Clear();
+                timerMessages.Clear();
+                orchestratorMessages.Clear();
+
                 // Continue running the orchestration with a new history.
                 // Renew the lock if we're getting close to its expiration.
                 if (workItem.LockedUntilUtc != default && DateTime.UtcNow.AddMinutes(1) > workItem.LockedUntilUtc)

--- a/src/InProcessTestHost/Sidecar/Dispatcher/WorkItemDispatcher.cs
+++ b/src/InProcessTestHost/Sidecar/Dispatcher/WorkItemDispatcher.cs
@@ -156,8 +156,8 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
     {
         TimeSpan logInterval = TimeSpan.FromMinutes(1);
 
-        // IMPORTANT: This logic assumes only a single logical "thread" is executing the receive loop,
-        //            and that there's no possible race condition when comparing work-item counts.
+        // IMPORTANT: The receive loop is expected to have a single logical execution path, but the
+        //            work-item count can still change concurrently and must be read using thread-safe access.
         DateTime nextLogTime = DateTime.MinValue;
         while (Volatile.Read(ref this.currentWorkItems) >= this.MaxWorkItems)
         {

--- a/src/InProcessTestHost/Sidecar/Dispatcher/WorkItemDispatcher.cs
+++ b/src/InProcessTestHost/Sidecar/Dispatcher/WorkItemDispatcher.cs
@@ -159,7 +159,7 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
         // IMPORTANT: This logic assumes only a single logical "thread" is executing the receive loop,
         //            and that there's no possible race condition when comparing work-item counts.
         DateTime nextLogTime = DateTime.MinValue;
-        while (this.currentWorkItems >= this.MaxWorkItems)
+        while (Volatile.Read(ref this.currentWorkItems) >= this.MaxWorkItems)
         {
             // Periodically log that we're waiting for available concurrency.
             // No need to use UTC for this. Local time is a bit easier to debug.
@@ -169,7 +169,7 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
                 this.log.FetchingThrottled(
                     dispatcher: this.name,
                     details: "The current active work-item count has reached the allowed maximum.",
-                    this.currentWorkItems,
+                    Volatile.Read(ref this.currentWorkItems),
                     this.MaxWorkItems);
                 nextLogTime = now.Add(logInterval);
             }
@@ -192,14 +192,14 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
     async Task WaitForOutstandingWorkItems(CancellationToken cancellationToken)
     {
         DateTime nextLogTime = DateTime.MinValue;
-        while (this.currentWorkItems > 0)
+        while (Volatile.Read(ref this.currentWorkItems) > 0)
         {
             // Periodically log that we're waiting for outstanding work items to complete.
             // No need to use UTC for this. Local time is a bit easier to debug.
             DateTime now = DateTime.Now;
             if (now >= nextLogTime)
             {
-                this.log.DispatcherStopping(this.name, this.currentWorkItems);
+                this.log.DispatcherStopping(this.name, Volatile.Read(ref this.currentWorkItems));
                 nextLogTime = now.AddMinutes(1);
             }
 
@@ -265,7 +265,7 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
 
                     if (workItem != null)
                     {
-                        this.currentWorkItems++;
+                        Interlocked.Increment(ref this.currentWorkItems);
                         this.log.FetchWorkItemCompleted(
                             this.name,
                             this.GetWorkItemId(workItem),
@@ -334,7 +334,7 @@ abstract class WorkItemDispatcher<T> : IDisposable where T : class
                     details: ex.ToString());
             }
 
-            this.currentWorkItems--;
+            Interlocked.Decrement(ref this.currentWorkItems);
         }
     }
 }

--- a/src/InProcessTestHost/Sidecar/InMemoryOrchestrationService.cs
+++ b/src/InProcessTestHost/Sidecar/InMemoryOrchestrationService.cs
@@ -684,11 +684,14 @@ public class InMemoryOrchestrationService : IOrchestrationService, IOrchestratio
                 else if (state.IsCompleted)
                 {
                     // Drop the message since we're completed
-                    // GOOD: The user-provided the instanceId
-                    // logger.LogWarning(
-                    //     "Dropped {eventType} message for instance '{instanceId}' because the orchestration has already completed.",
-                    //     message.Event.EventType,
-                    //     instanceId);
+                    return;
+                }
+                else if (isRestart)
+                {
+                    // Drop messages that belong to a previous execution (stale activity
+                    // completions, timer fires, etc.). These can arrive when a
+                    // ContinueAsNew created a new execution but work items from the
+                    // old execution are still in flight.
                     return;
                 }
 

--- a/src/InProcessTestHost/Sidecar/InMemoryOrchestrationService.cs
+++ b/src/InProcessTestHost/Sidecar/InMemoryOrchestrationService.cs
@@ -653,7 +653,7 @@ public class InMemoryOrchestrationService : IOrchestrationService, IOrchestratio
             SerializedInstanceState state = this.store.GetOrAdd(instanceId, id => new SerializedInstanceState(id, executionId));
             lock (state)
             {
-                bool isRestart = state.ExecutionId != null && state.ExecutionId != executionId;
+                bool isRestart = executionId != null && state.ExecutionId != null && state.ExecutionId != executionId;
                 
                 if (message.Event is ExecutionStartedEvent startEvent)
                 {

--- a/test/InProcessTestHost.Tests/ContinueAsNewTests.cs
+++ b/test/InProcessTestHost.Tests/ContinueAsNewTests.cs
@@ -254,3 +254,253 @@ public class ContinueAsNewTests
 
     #endregion
 }
+
+/// <summary>
+/// Tests targeting the ContinueAsNew race condition fix where stale messages from
+/// prior ContinueAsNew iterations (activities, timers) could corrupt the new execution's
+/// message queue or cause instances to get permanently stuck.
+/// </summary>
+public class ContinueAsNewRaceConditionTests
+{
+    readonly ITestOutputHelper output;
+
+    public ContinueAsNewRaceConditionTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    /// <summary>
+    /// Reproduces the original stuck-instance scenario: 4+ orchestrations running
+    /// concurrently, each calling an activity, waiting on a timer, then ContinueAsNew,
+    /// repeated for multiple iterations. Without the fix, some instances would stop
+    /// making progress after 2-3 ContinueAsNew iterations because stale activity/timer
+    /// messages from prior iterations would corrupt the message queue.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ConcurrentContinueAsNew_MultipleIterations_NoneGetStuck()
+    {
+        const int instanceCount = 6;
+        const int targetIterations = 5;
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<int, int>("IteratingOrchestrator", async (context, iteration) =>
+            {
+                // Call activity
+                await context.CallActivityAsync<string>("NoOpActivity", iteration);
+
+                // Wait on timer (short delay to exercise timer message path)
+                await context.CreateTimer(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+
+                if (iteration < targetIterations)
+                {
+                    context.ContinueAsNew(iteration + 1);
+                    return -1; // unreachable
+                }
+
+                return iteration;
+            });
+
+            tasks.AddActivityFunc<int, string>("NoOpActivity", (context, iteration) =>
+            {
+                return $"done-{iteration}";
+            });
+        });
+
+        // Schedule all instances concurrently
+        string[] instanceIds = new string[instanceCount];
+        for (int i = 0; i < instanceCount; i++)
+        {
+            instanceIds[i] = await host.Client.ScheduleNewOrchestrationInstanceAsync(
+                "IteratingOrchestrator", 1);
+        }
+
+        this.output.WriteLine($"Scheduled {instanceCount} orchestrations, each targeting {targetIterations} iterations");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(90));
+
+        Task<OrchestrationMetadata>[] waitTasks = instanceIds
+            .Select(id => host.Client.WaitForInstanceCompletionAsync(
+                id, getInputsAndOutputs: true, cts.Token))
+            .ToArray();
+
+        OrchestrationMetadata[] results = await Task.WhenAll(waitTasks);
+
+        for (int i = 0; i < instanceCount; i++)
+        {
+            Assert.NotNull(results[i]);
+            Assert.Equal(OrchestrationRuntimeStatus.Completed, results[i].RuntimeStatus);
+            int output = results[i].ReadOutputAs<int>();
+            Assert.Equal(targetIterations, output);
+            this.output.WriteLine($"Instance[{i}] ({instanceIds[i]}): completed at iteration {output}");
+        }
+    }
+
+    /// <summary>
+    /// Tests that an orchestration performing many ContinueAsNew iterations with
+    /// both activities and timers on each iteration completes correctly. This exercises
+    /// the fix that clears accumulated message lists between iterations — without it,
+    /// stale timer/activity messages would accumulate and cause duplicate scheduling.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task SingleInstance_ManyContinueAsNewIterations_CompletesCorrectly()
+    {
+        const int targetIterations = 8;
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<int, int>("MultiIterationOrchestrator", async (context, iteration) =>
+            {
+                // Each iteration: activity + timer + ContinueAsNew
+                await context.CallActivityAsync<string>("EchoActivity", $"iter-{iteration}");
+                await context.CreateTimer(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+
+                if (iteration < targetIterations)
+                {
+                    context.ContinueAsNew(iteration + 1);
+                    return -1;
+                }
+
+                return iteration;
+            });
+
+            tasks.AddActivityFunc<string, string>("EchoActivity", (context, input) => $"echo:{input}");
+        });
+
+        string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(
+            "MultiIterationOrchestrator", 1);
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+        OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
+            instanceId, getInputsAndOutputs: true, cts.Token);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+        Assert.Equal(targetIterations, metadata.ReadOutputAs<int>());
+    }
+
+    /// <summary>
+    /// Verifies that ContinueAsNew works correctly when orchestrations call multiple
+    /// activities per iteration. This amplifies the stale-message problem because each
+    /// iteration generates more activity messages that must be properly discarded.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ContinueAsNew_MultipleActivitiesPerIteration_AllComplete()
+    {
+        const int instanceCount = 4;
+        const int activitiesPerIteration = 3;
+        const int targetIterations = 4;
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<int, int>("MultiActivityOrchestrator", async (context, iteration) =>
+            {
+                // Call multiple activities per iteration
+                List<Task<string>> activityTasks = new();
+                for (int i = 0; i < activitiesPerIteration; i++)
+                {
+                    activityTasks.Add(context.CallActivityAsync<string>(
+                        "IndexedActivity", $"iter{iteration}-act{i}"));
+                }
+
+                await Task.WhenAll(activityTasks);
+                await context.CreateTimer(TimeSpan.FromMilliseconds(200), CancellationToken.None);
+
+                if (iteration < targetIterations)
+                {
+                    context.ContinueAsNew(iteration + 1);
+                    return -1;
+                }
+
+                return iteration;
+            });
+
+            tasks.AddActivityFunc<string, string>("IndexedActivity", (context, input) => $"result:{input}");
+        });
+
+        string[] instanceIds = new string[instanceCount];
+        for (int i = 0; i < instanceCount; i++)
+        {
+            instanceIds[i] = await host.Client.ScheduleNewOrchestrationInstanceAsync(
+                "MultiActivityOrchestrator", 1);
+        }
+
+        this.output.WriteLine($"Scheduled {instanceCount} orchestrations with {activitiesPerIteration} activities per iteration");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(45));
+        Task<OrchestrationMetadata>[] waitTasks = instanceIds
+            .Select(id => host.Client.WaitForInstanceCompletionAsync(
+                id, getInputsAndOutputs: true, cts.Token))
+            .ToArray();
+
+        OrchestrationMetadata[] results = await Task.WhenAll(waitTasks);
+
+        for (int i = 0; i < instanceCount; i++)
+        {
+            Assert.NotNull(results[i]);
+            Assert.Equal(OrchestrationRuntimeStatus.Completed, results[i].RuntimeStatus);
+            Assert.Equal(targetIterations, results[i].ReadOutputAs<int>());
+        }
+    }
+
+    /// <summary>
+    /// Runs the reproduction scenario from the original bug report repeatedly to ensure
+    /// reliability: 4+ concurrent instances, each doing activity + 5s timer + ContinueAsNew,
+    /// across multiple independent rounds with fresh hosts.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ReproScenario_RepeatedRounds_AllComplete()
+    {
+        const int instanceCount = 4;
+        const int rounds = 3;
+        const int targetIterations = 3;
+
+        for (int round = 0; round < rounds; round++)
+        {
+            this.output.WriteLine($"=== Round {round + 1}/{rounds} ===");
+
+            await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+            {
+                tasks.AddOrchestratorFunc<int, int>("ReproOrchestrator", async (context, iteration) =>
+                {
+                    await context.CallActivityAsync<string>("ReproActivity", iteration);
+                    await context.CreateTimer(TimeSpan.FromSeconds(5), CancellationToken.None);
+
+                    if (iteration < targetIterations)
+                    {
+                        context.ContinueAsNew(iteration + 1);
+                        return -1;
+                    }
+
+                    return iteration;
+                });
+
+                tasks.AddActivityFunc<int, string>("ReproActivity", (context, input) => $"ok-{input}");
+            });
+
+            string[] instanceIds = new string[instanceCount];
+            for (int i = 0; i < instanceCount; i++)
+            {
+                instanceIds[i] = await host.Client.ScheduleNewOrchestrationInstanceAsync(
+                    "ReproOrchestrator", 1);
+            }
+
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(45)); 
+            Task<OrchestrationMetadata>[] waitTasks = instanceIds
+                .Select(id => host.Client.WaitForInstanceCompletionAsync(
+                    id, getInputsAndOutputs: true, cts.Token))
+                .ToArray();
+
+            OrchestrationMetadata[] results = await Task.WhenAll(waitTasks);
+
+            for (int i = 0; i < instanceCount; i++)
+            {
+                Assert.NotNull(results[i]);
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, results[i].RuntimeStatus);
+                Assert.Equal(targetIterations, results[i].ReadOutputAs<int>());
+            }
+
+            this.output.WriteLine($"Round {round + 1}: all {instanceCount} completed");
+        }
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
This pull request focuses on improving concurrency safety and correctness in the in-process test host, particularly around work item tracking and message handling during orchestration restarts. The most important changes are grouped below.

**Concurrency Safety Improvements:**

* Replaced direct access to the `currentWorkItems` field with thread-safe operations using `Interlocked.Increment`, `Interlocked.Decrement`, and `Volatile.Read` in `WorkItemDispatcher.cs`, ensuring accurate and race-free tracking of concurrent work items.

**Orchestration Restart and Message Handling Fixes:**

* In `TaskOrchestrationDispatcher.cs`, added logic to clear accumulated activity, timer, and orchestrator messages when a `ContinueAsNew` occurs, preventing stale messages from being re-enqueued and causing duplicate or stuck orchestrations.
* In `InMemoryOrchestrationService.cs`, added logic to drop messages from previous executions after a restart, preventing stale activity completions or timer fires from interfering with new orchestration runs.

**Version Update:**

* Bumped the package version in `InProcessTestHost.csproj` from `0.2.2-preview.1` to `0.2.3-preview.1` to reflect these changes.

---

# Project checklist
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code GitHub CoPilot (Claude Opus 4.6)
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
- 19/19 InProcessTestHost tests pass (15 existing + 4 new)
- New tests in `ContinueAsNewRaceConditionTests`:
  - `ConcurrentContinueAsNew_MultipleIterations_NoneGetStuck` — 6 concurrent instances, 5 ContinueAsNew iterations each with activity + 500ms timer
  - `SingleInstance_ManyContinueAsNewIterations_CompletesCorrectly` — 8 ContinueAsNew iterations with activity + timer per iteration
  - `ContinueAsNew_MultipleActivitiesPerIteration_AllComplete` — 4 concurrent instances with 3 parallel activities per iteration across 4 ContinueAsNew cycles
  - `ReproScenario_RepeatedRounds_AllComplete` — exact bug report scenario (4 instances, activity + 5s timer + ContinueAsNew) repeated across 3 fresh hosts
