### PR TITLE
PROBE: validate dispatcher fix resolves retry-handler flake (DO NOT MERGE)

### DIFF
--- a/src/InProcessTestHost/Sidecar/Grpc/TaskHubGrpcServer.cs
+++ b/src/InProcessTestHost/Sidecar/Grpc/TaskHubGrpcServer.cs
@@ -916,10 +916,19 @@ public class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBa
             // The client disconnected or canceled the GetWorkItems stream.
             // Reset the connection state so the dispatcher pauses naturally
             // (via the traffic signal) until a new client connects.
+            //
+            // IMPORTANT: only clear our cached stream/signal if it still refers to
+            // the stream that just failed. A new client may have already connected
+            // (and set workerToClientStream / signaled isConnectedSignal) between
+            // the failed WriteAsync and this catch block. Unconditionally clearing
+            // would silently kill that new connection's state, hanging the dispatcher.
             lock (this.isConnectedSignal)
             {
-                this.workerToClientStream = null;
-                this.isConnectedSignal.Reset();
+                if (ReferenceEquals(this.workerToClientStream, outputStream))
+                {
+                    this.workerToClientStream = null;
+                    this.isConnectedSignal.Reset();
+                }
             }
 
             // Must throw so callers (ExecuteOrchestrator/ExecuteActivity) can clean up

--- a/src/Worker/Grpc/Worker.Grpc.csproj
+++ b/src/Worker/Grpc/Worker.Grpc.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" VersionOverride="3.33.5" />
+    <PackageReference Include="Google.Protobuf" />
     <SharedSection Include="Core" />
     <SharedSection Include="DependencyInjection" />
     <SharedSection Include="Grpc" />

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DurableTask.Grpc.Tests;
 public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposable
 {
     readonly CancellationTokenSource testTimeoutSource
-        = new(Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30));
+        = new(Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(60));
 
     readonly TestLogProvider logProvider;
 

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DurableTask.Grpc.Tests;
 public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposable
 {
     readonly CancellationTokenSource testTimeoutSource
-        = new(Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(60));
+        = new(Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30));
 
     readonly TestLogProvider logProvider;
 

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -448,12 +448,20 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
     {
         string errorMessage = "Kah-BOOOOOM!!!"; // Use an obviously fake error message to avoid confusion when debugging
 
-        // NOTE: We don't track retry-handler invocation counts here. The sub-orchestration retry path
-        // currently invokes the user's retry handler more times than the documented attempt count
-        // (replay reaches the catch site after IsReplaying has flipped, so the handler runs again).
-        // That bug is tracked separately; until it's fixed we can only assert on activity-side counters.
+        int retryHandlerCalls = 0;
+
         TaskOptions retryOptions = TaskOptions.FromRetryHandler(retryContext =>
         {
+            // The sub-orchestration retry path currently invokes the user's retry handler more times
+            // than the documented attempt count (replay reaches the catch site after IsReplaying has
+            // flipped, so the handler runs again). Counting only non-replay invocations and asserting
+            // a lower bound below keeps coverage of "the handler was invoked" without flaking on the
+            // known over-invocation bug, which is tracked separately.
+            if (!retryContext.OrchestrationContext.IsReplaying)
+            {
+                retryHandlerCalls++;
+            }
+
             // IsCausedBy is supposed to handle exception inheritance; fail if it doesn't
             if (!retryContext.LastFailure.IsCausedBy<Exception>())
             {
@@ -495,6 +503,11 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(OrchestrationRuntimeStatus.Failed, metadata.RuntimeStatus);
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
+        // Lower-bound assertion: the handler must run at least once per documented attempt.
+        // Strict equality is unreliable due to the known over-invocation bug noted above.
+        Assert.True(
+            retryHandlerCalls >= expectedNumberOfAttempts,
+            $"Expected retry handler to be invoked at least {expectedNumberOfAttempts} time(s), but was invoked {retryHandlerCalls} time(s).");
 
         // The root orchestration failed due to a failure with the sub-orchestration, resulting in a TaskFailedException
         Assert.NotNull(metadata.FailureDetails);

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -497,7 +497,8 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(OrchestrationRuntimeStatus.Failed, metadata.RuntimeStatus);
-        Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
+        // More calls to retry handler than expected.
+        //Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
 
         // The root orchestration failed due to a failure with the sub-orchestration, resulting in a TaskFailedException

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -448,15 +448,12 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
     {
         string errorMessage = "Kah-BOOOOOM!!!"; // Use an obviously fake error message to avoid confusion when debugging
 
-        int retryHandlerCalls = 0;
+        // NOTE: We don't track retry-handler invocation counts here. The sub-orchestration retry path
+        // currently invokes the user's retry handler more times than the documented attempt count
+        // (replay reaches the catch site after IsReplaying has flipped, so the handler runs again).
+        // That bug is tracked separately; until it's fixed we can only assert on activity-side counters.
         TaskOptions retryOptions = TaskOptions.FromRetryHandler(retryContext =>
         {
-            // This is technically orchestrator code that gets replayed, like everything else
-            if (!retryContext.OrchestrationContext.IsReplaying)
-            {
-                retryHandlerCalls++;
-            }
-
             // IsCausedBy is supposed to handle exception inheritance; fail if it doesn't
             if (!retryContext.LastFailure.IsCausedBy<Exception>())
             {
@@ -497,8 +494,6 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(OrchestrationRuntimeStatus.Failed, metadata.RuntimeStatus);
-        // More calls to retry handler than expected.
-        //Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
 
         // The root orchestration failed due to a failure with the sub-orchestration, resulting in a TaskFailedException

--- a/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationErrorHandling.cs
@@ -316,8 +316,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(expRuntimeStatus, metadata.RuntimeStatus);
-        // More calls to retry handler than expected.
-        //Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
+        Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
     }
 
@@ -424,8 +423,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.NotNull(metadata);
         Assert.Equal(instanceId, metadata.InstanceId);
         Assert.Equal(expRuntimeStatus, metadata.RuntimeStatus);
-        // More calls to retry handler than expected.
-        //Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
+        Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
 
         // The root orchestration failed due to a failure with the sub-orchestration, resulting in a TaskFailedException
@@ -505,9 +503,7 @@ public class OrchestrationErrorHandling(ITestOutputHelper output, GrpcSidecarFix
         Assert.Equal(expectedNumberOfAttempts, actualNumberOfAttempts);
         // Lower-bound assertion: the handler must run at least once per documented attempt.
         // Strict equality is unreliable due to the known over-invocation bug noted above.
-        Assert.True(
-            retryHandlerCalls >= expectedNumberOfAttempts,
-            $"Expected retry handler to be invoked at least {expectedNumberOfAttempts} time(s), but was invoked {retryHandlerCalls} time(s).");
+        Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls);
 
         // The root orchestration failed due to a failure with the sub-orchestration, resulting in a TaskFailedException
         Assert.NotNull(metadata.FailureDetails);


### PR DESCRIPTION
Probe branch on top of #709's dispatcher fix to validate whether the strict `Assert.Equal(expectedNumberOfAttempts, retryHandlerCalls)` assertions are now stable on Windows CI.

If green across multiple runs → the dispatcher race was the real culprit and the SDK retry-handler design fix is hardening, not a release blocker.
If still flaky → the SDK retry path has its own bug to address.

**Do not merge.** Will be closed once we have signal.