### PR TITLE
Preserve late events after continue-as-new

### DIFF
--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -374,7 +374,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
             // Send all the buffered external events to ourself.
             foreach ((string eventName, string eventPayload) in this.externalEventBuffer.TakeAll())
             {
-                this.ForwardBufferedExternalEvent(eventName, eventPayload);
+                this.ForwardRawExternalEvent(eventName, eventPayload);
             }
         }
     }
@@ -490,7 +490,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
                 // ContinueAsNew has already been scheduled with event preservation enabled.
                 // Forward late-arriving events directly to the next execution instead of buffering
                 // them on the current wrapper instance, which is about to be discarded.
-                this.ForwardBufferedExternalEvent(eventName, rawEventPayload);
+                this.ForwardRawExternalEvent(eventName, rawEventPayload);
             }
             else
             {
@@ -501,11 +501,11 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         }
     }
 
-    void ForwardBufferedExternalEvent(string eventName, string eventPayload)
+    void ForwardRawExternalEvent(string eventName, string rawEventPayload)
     {
         OrchestrationInstance instance = new() { InstanceId = this.InstanceId };
 #pragma warning disable CS0618 // Type or member is obsolete -- 'internal' usage.
-        this.innerContext.SendEvent(instance, eventName, new RawInput(eventPayload));
+        this.innerContext.SendEvent(instance, eventName, new RawInput(rawEventPayload));
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -30,6 +30,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
 
     int newGuidCounter;
     object? customStatus;
+    bool preserveUnprocessedEventsOnContinueAsNew;
     TaskOrchestrationEntityContext? entityFeature;
 
     /// <summary>
@@ -349,24 +350,31 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     {
         Check.NotNull(options);
 
-        if (!string.IsNullOrWhiteSpace(options.NewVersion))
+        this.preserveUnprocessedEventsOnContinueAsNew = options.PreserveUnprocessedEvents;
+
+        try
         {
-            this.innerContext.ContinueAsNew(options.NewVersion, options.NewInput);
+            if (!string.IsNullOrWhiteSpace(options.NewVersion))
+            {
+                this.innerContext.ContinueAsNew(options.NewVersion, options.NewInput);
+            }
+            else
+            {
+                this.innerContext.ContinueAsNew(options.NewInput);
+            }
         }
-        else
+        catch
         {
-            this.innerContext.ContinueAsNew(options.NewInput);
+            this.preserveUnprocessedEventsOnContinueAsNew = false;
+            throw;
         }
 
         if (options.PreserveUnprocessedEvents)
         {
             // Send all the buffered external events to ourself.
-            OrchestrationInstance instance = new() { InstanceId = this.InstanceId };
             foreach ((string eventName, string eventPayload) in this.externalEventBuffer.TakeAll())
             {
-#pragma warning disable CS0618 // Type or member is obsolete -- 'internal' usage.
-                this.innerContext.SendEvent(instance, eventName, new RawInput(eventPayload));
-#pragma warning restore CS0618 // Type or member is obsolete
+                this.ForwardBufferedExternalEvent(eventName, eventPayload);
             }
         }
     }
@@ -477,10 +485,28 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         }
         else
         {
-            // The orchestrator isn't waiting for this event (yet?). Save it in case
-            // the orchestrator wants it later.
-            this.externalEventBuffer.Add(eventName, rawEventPayload);
+            if (this.preserveUnprocessedEventsOnContinueAsNew)
+            {
+                // ContinueAsNew has already been scheduled with event preservation enabled.
+                // Forward late-arriving events directly to the next execution instead of buffering
+                // them on the current wrapper instance, which is about to be discarded.
+                this.ForwardBufferedExternalEvent(eventName, rawEventPayload);
+            }
+            else
+            {
+                // The orchestrator isn't waiting for this event (yet?). Save it in case
+                // the orchestrator wants it later.
+                this.externalEventBuffer.Add(eventName, rawEventPayload);
+            }
         }
+    }
+
+    void ForwardBufferedExternalEvent(string eventName, string eventPayload)
+    {
+        OrchestrationInstance instance = new() { InstanceId = this.InstanceId };
+#pragma warning disable CS0618 // Type or member is obsolete -- 'internal' usage.
+        this.innerContext.SendEvent(instance, eventName, new RawInput(eventPayload));
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     /// <summary>

--- a/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
+++ b/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using DurableTask.Core;
+using DurableTask.Core.Serializing.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DurableTask.Worker.Shims;
@@ -10,7 +11,8 @@ namespace Microsoft.DurableTask.Worker.Shims;
 public class TaskOrchestrationContextWrapperTests
 {
     static readonly MethodInfo CompleteExternalEventMethod = typeof(TaskOrchestrationContextWrapper)
-        .GetMethod("CompleteExternalEvent", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        .GetMethod(nameof(TaskOrchestrationContextWrapper.CompleteExternalEvent), BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException($"{nameof(TaskOrchestrationContextWrapper)}.{nameof(TaskOrchestrationContextWrapper.CompleteExternalEvent)} was not found.");
 
     [Fact]
     public void Ctor_NullParent_Populates()
@@ -123,6 +125,7 @@ public class TaskOrchestrationContextWrapperTests
         innerContext.SentEvents.Should().ContainSingle();
         innerContext.SentEvents[0].InstanceId.Should().Be(wrapper.InstanceId);
         innerContext.SentEvents[0].EventName.Should().Be("Event");
+        innerContext.SentEvents[0].EventData.Should().BeOfType<RawInput>().Which.Value.Should().Be("\"payload\"");
         innerContext.LastContinueAsNewInput.Should().Be("new-input");
     }
 

--- a/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
+++ b/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Reflection;
 using DurableTask.Core;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -8,6 +9,9 @@ namespace Microsoft.DurableTask.Worker.Shims;
 
 public class TaskOrchestrationContextWrapperTests
 {
+    static readonly MethodInfo CompleteExternalEventMethod = typeof(TaskOrchestrationContextWrapper)
+        .GetMethod("CompleteExternalEvent", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     [Fact]
     public void Ctor_NullParent_Populates()
     {
@@ -103,6 +107,30 @@ public class TaskOrchestrationContextWrapperTests
         innerContext.LastContinueAsNewVersion.Should().BeNull();
     }
 
+    [Fact]
+    public void ContinueAsNew_WithPreserveUnprocessedEvents_ForwardsLateArrivingEventsToNextExecution()
+    {
+        // Arrange
+        TrackingOrchestrationContext innerContext = new();
+        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
+
+        // Act
+        wrapper.ContinueAsNew("new-input", preserveUnprocessedEvents: true);
+        InvokeCompleteExternalEvent(wrapper, "Event", "\"payload\"");
+
+        // Assert
+        innerContext.SentEvents.Should().ContainSingle();
+        innerContext.SentEvents[0].InstanceId.Should().Be(wrapper.InstanceId);
+        innerContext.SentEvents[0].EventName.Should().Be("Event");
+        innerContext.LastContinueAsNewInput.Should().Be("new-input");
+    }
+
+    static void InvokeCompleteExternalEvent(TaskOrchestrationContextWrapper wrapper, string eventName, string rawEventPayload)
+    {
+        CompleteExternalEventMethod.Invoke(wrapper, [eventName, rawEventPayload]);
+    }
+
     sealed class TrackingOrchestrationContext : OrchestrationContext
     {
         public TrackingOrchestrationContext()
@@ -117,6 +145,8 @@ public class TaskOrchestrationContextWrapperTests
         public object? LastContinueAsNewInput { get; private set; }
 
         public string? LastContinueAsNewVersion { get; private set; }
+
+        public List<(string InstanceId, string EventName, object EventData)> SentEvents { get; } = [];
 
         public override void ContinueAsNew(object input)
         {
@@ -149,7 +179,9 @@ public class TaskOrchestrationContextWrapperTests
             => throw new NotImplementedException();
 
         public override void SendEvent(OrchestrationInstance orchestrationInstance, string eventName, object eventData)
-            => throw new NotImplementedException();
+        {
+            this.SentEvents.Add((orchestrationInstance.InstanceId, eventName, eventData));
+        }
     }
 
     class TestOrchestrationContext : OrchestrationContext


### PR DESCRIPTION
## Summary
- extract the TaskOrchestrationContextWrapper late-external-event forwarding change from #708 into its own PR
- preserve late-arriving external events when ContinueAsNew has already been scheduled with preserveUnprocessedEvents enabled
- add focused wrapper tests for the ContinueAsNew forwarding behavior

## Why
After ContinueAsNew is scheduled with event preservation enabled, late external events should be forwarded to the next execution instead of being buffered on the current wrapper instance that is about to be discarded.

## Validation
- dotnet test .\\test\\Worker\\Core.Tests\\Worker.Tests.csproj --filter "TaskOrchestrationContextWrapperTests"