### PR TITLE
Bump Microsoft.Extensions.DependencyInjection.Abstractions to 9.0.1 (fixes azure-functions-durable-extension#3433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Bump `Microsoft.Extensions.DependencyInjection.Abstractions` from 8.0.2 to 9.0.1 (and `Microsoft.Bcl.AsyncInterfaces` from 8.0.0 to 9.0.1, which the former transitively floors at 9.0.1) to align with the floor declared by `Microsoft.Azure.WebJobs 3.0.45 -> Microsoft.Extensions.Logging.Abstractions 9.0.1`. Fixes NU1605 in downstream Azure Functions Worker isolated apps consuming `Microsoft.DurableTask.Extensions.AzureBlobPayloads` ([Azure/azure-functions-durable-extension#3433](https://github.com/Azure/azure-functions-durable-extension/issues/3433)).
 - Validate explicit `UseWorkItemFilters(filters)` filter names against the worker's `DurableTaskRegistry`. Filters that reference an orchestration, activity, or entity name not registered with the worker now throw `OptionsValidationException` at worker startup instead of silently waiting for work items that will never arrive. No customer-side validation call is required. ([#719](https://github.com/microsoft/durabletask-dotnet/pull/719))
 
 ## 1.24.1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,16 +9,18 @@
 
   <!-- Microsoft.Extensions.* Packages
        IMPORTANT: These assemblies are part of the .NET shared framework and load into the
-       Azure Functions host process, which runs on net8.0. Package versions MUST stay at 8.x
-       so the assembly versions (8.0.0.0) match what the host provides. Using 10.x causes
-       FileNotFoundException at runtime because the host cannot satisfy Version=10.0.0.0.
-       DO NOT upgrade to 10.x+ until the Azure Functions host itself targets .NET 10.
-       See: https://github.com/Azure/azure-functions-host (WebJobs.Script.csproj -> net8.0) -->
+       Azure Functions host process. Historically the host ran on net8.0 and required the
+       package versions to stay at 8.x so the assembly versions (8.0.0.0) matched what the
+       host provided; using 10.x caused FileNotFoundException at runtime.
+       As of azure-functions-host v4.1049.x the host targets net10.0 and ships 9.x/10.x
+       shared-framework assemblies via runtimeassemblies-relaxed.json (minorMatchOrLower),
+       so 9.x package versions are now safe.
+       See: https://github.com/Azure/azure-functions-host (WebJobs.Script.csproj -> net10.0) -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
@@ -88,7 +90,7 @@
     <PackageVersion Include="DotNext" Version="4.13.1" Condition="'$(TargetFramework)' != 'net8.0' AND '$(TargetFramework)' != 'net10.0'" />
     <PackageVersion Include="DotNext" Version="5.19.0" Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />


### PR DESCRIPTION
## Summary
Fixes [Azure/azure-functions-durable-extension#3433](https://github.com/Azure/azure-functions-durable-extension/issues/3433): downstream Azure Functions Worker isolated apps consuming `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged` (which transitively pulls in `Microsoft.DurableTask.Extensions.AzureBlobPayloads`) hit `NU1605` on the auto-generated `WorkerExtensions.csproj`.

## Root cause
- `Microsoft.Azure.WebJobs 3.0.45` → `Microsoft.Extensions.Logging.Abstractions 9.0.1` transitively floors `Microsoft.Extensions.DependencyInjection.Abstractions` at **>= 9.0.1**.
- `Microsoft.DurableTask.Extensions.AzureBlobPayloads` (1.23.x / 1.24.x) directly pinned `DependencyInjection.Abstractions = 8.0.2`.
- NuGet "nearest wins" resolves the 8.0.2 direct reference for the auto-generated `WorkerExtensions.csproj`, then warns/errors that 8.0.2 was selected over 9.0.1 → `NU1605`.

## Why the original pin no longer applies
The 8.x pin landed in #698 because the Azure Functions host then targeted `net8.0` and could only resolve 8.x shared-framework assemblies. As of [`azure-functions-host` v4.1049.x](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/WebJobs.Script.csproj) the host targets `net10.0` and ships 9.x/10.x via `runtimeassemblies-relaxed.json`, so the pin is now stale.

## Changes
- `Microsoft.Extensions.DependencyInjection.Abstractions` 8.0.2 → **9.0.1**
- `Microsoft.Bcl.AsyncInterfaces` 8.0.0 → **9.0.1** (DI.Abstractions 9.0.1 transitively floors `Bcl.AsyncInterfaces` at 9.0.1, so this is required to avoid a cascading NU1605)
- Updated the explanatory comment in `Directory.Packages.props` to reflect the host's net10.0 transition
- `CHANGELOG.md` entry under Unreleased

## Validation
- `dotnet build` of all packable projects: ✅ succeeds (only pre-existing StyleCop warnings)
- Local-packed `AzureBlobPayloads.1.24.2-pre.fix3433.nupkg` nuspec confirms `DependencyInjection.Abstractions >= 9.0.1` direct dependency.
- Built downstream `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged` SDK against the locally-packed prereleases and a `DotNetIsolatedSmokeTest` that triggered the original NU1605: **`Build succeeded. 0 Warning(s) 0 Error(s)`**.

## Related
- Azure DevOps belt-and-suspenders workaround in AAPT-DTMB: PR 15650044 (adds direct `DI.Abstractions = 9.0.1` reference in `WebJobs.Extensions.DurableTask.AzureManaged.csproj`). It can stay or be reverted once a release containing this fix ships.
