### PR TITLE
Expose scheduled version on TaskActivityContext

### DIFF
--- a/src/Abstractions/TaskActivityContext.cs
+++ b/src/Abstractions/TaskActivityContext.cs
@@ -25,4 +25,10 @@ public abstract class TaskActivityContext
     /// Gets the unique ID of the current orchestration instance.
     /// </summary>
     public abstract string InstanceId { get; }
+
+    /// <summary>
+    /// Gets the version that the activity was scheduled with, or <see cref="string.Empty"/> if the activity is
+    /// unversioned.
+    /// </summary>
+    public virtual string Version => string.Empty;
 }

--- a/src/Worker/Core/Shims/TaskActivityShim.cs
+++ b/src/Worker/Core/Shims/TaskActivityShim.cs
@@ -92,5 +92,7 @@ class TaskActivityShim : TaskActivity
         public override TaskName Name => this.name;
 
         public override string InstanceId => this.innerContext.OrchestrationInstance.InstanceId;
+
+        public override string Version => this.innerContext.Version ?? string.Empty;
     }
 }

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -884,10 +884,10 @@ sealed partial class GrpcDurableTaskWorker
             this.Logger.ReceivedActivityRequest(request.Name, request.TaskId, instance.InstanceId, inputSize);
 
             P.TaskFailureDetails? failureDetails = null;
-            TaskContext innerContext = new(instance);
+            TaskName name = new(request.Name);
+            TaskContext innerContext = new(instance, request.Name, request.Version ?? string.Empty, request.TaskId);
             innerContext.ExceptionPropertiesProvider = this.exceptionPropertiesProvider;
 
-            TaskName name = new(request.Name);
             string? output = null;
 
             failureDetails = EvaluateOrchestrationVersioning(this.worker.workerOptions.Versioning, request.Version, out bool versioningFailed);

--- a/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
+++ b/test/Grpc.IntegrationTests/OrchestrationPatterns.cs
@@ -792,6 +792,34 @@ public class OrchestrationPatterns : IntegrationTestBase
     }
 
     [Fact]
+    public async Task ActivityVersionPassedThroughContext()
+    {
+        var version = "0.1";
+        await using HostTestLifetime server = await this.StartWorkerAsync(b =>
+        {
+            b.AddTasks(tasks => tasks
+                .AddOrchestratorFunc<string, string>("Versioned_Orchestration", (ctx, input) =>
+                {
+                    return ctx.CallActivityAsync<string>("Versioned_Activity", input);
+                })
+                .AddActivityFunc<string, string>("Versioned_Activity", (ctx, input) =>
+                {
+                    return $"Activity version: {ctx.Version}";
+                }));
+        }, c =>
+        {
+            c.UseDefaultVersion(version);
+        });
+
+        var instanceId = await server.Client.ScheduleNewOrchestrationInstanceAsync("Versioned_Orchestration", input: string.Empty);
+        var result = await server.Client.WaitForInstanceCompletionAsync(instanceId, getInputsAndOutputs: true, this.TimeoutToken);
+        var output = result.ReadOutputAs<string>();
+
+        Assert.NotNull(output);
+        Assert.Equal(output, $"Activity version: {version}");
+    }
+
+    [Fact]
     public async Task OrchestrationVersioning_MatchTypeNotSpecified_NoVersionFailure()
     {
         var workerVersion = "0.1";

--- a/test/Worker/Core.Tests/Shims/TaskActivityShimTests.cs
+++ b/test/Worker/Core.Tests/Shims/TaskActivityShimTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DurableTask.Core;
+using Microsoft.DurableTask.Converters;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.DurableTask.Worker.Shims;
+
+public class TaskActivityShimTests
+{
+    [Fact]
+    public async Task RunAsync_ScheduledWithVersion_ExposesVersionOnContext()
+    {
+        // Arrange
+        CapturingActivity activity = new();
+        TaskActivityShim shim = new(
+            NullLoggerFactory.Instance,
+            new JsonDataConverter(),
+            "TestActivity",
+            activity);
+        TaskContext coreContext = new(
+            new OrchestrationInstance { InstanceId = Guid.NewGuid().ToString() },
+            "TestActivity",
+            "v2",
+            taskId: 1);
+
+        // Act
+        await shim.RunAsync(coreContext, "null");
+
+        // Assert
+        activity.CapturedVersion.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task RunAsync_ScheduledWithoutVersion_ExposesEmptyVersionOnContext()
+    {
+        // Arrange
+        CapturingActivity activity = new();
+        TaskActivityShim shim = new(
+            NullLoggerFactory.Instance,
+            new JsonDataConverter(),
+            "TestActivity",
+            activity);
+        TaskContext coreContext = new(
+            new OrchestrationInstance { InstanceId = Guid.NewGuid().ToString() },
+            "TestActivity",
+            version: null,
+            taskId: 1);
+
+        // Act
+        await shim.RunAsync(coreContext, "null");
+
+        // Assert
+        activity.CapturedVersion.Should().Be(string.Empty);
+    }
+
+    sealed class CapturingActivity : TaskActivity<object?, object?>
+    {
+        public string? CapturedVersion { get; private set; }
+
+        public override Task<object?> RunAsync(TaskActivityContext context, object? input)
+        {
+            this.CapturedVersion = context.Version;
+            return Task.FromResult<object?>(null);
+        }
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
Adds a virtual Version property to TaskActivityContext (defaulting to string.Empty for backward compatibility) and overrides it in the worker's activity context wrapper to surface the version the activity was scheduled with, mirroring TaskOrchestrationContext.Version.

The gRPC worker's activity dispatch path previously constructed TaskContext with only the orchestration instance, leaving the version empty even though it travels on ActivityRequest. It now builds TaskContext with the request name, version, and task id so activities can read their scheduled version.

Includes a unit test for the shim wrapper and an end-to-end integration test asserting the activity observes its scheduled version.

## Why is this change needed?
We introduced activity versioning recently but did not give a way for users to interact with it in an activity.

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): Copilot
- AI-assisted areas/files: All
- What you changed after AI output: None

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1. Start an activity with a defined version
  2. Print version in the activity
  3. Do it again with a 2nd version (same orchestration)
  4. Validate the version changed
- Evidence (optional):

---

# Notes for reviewers
- N/A
