### PR TITLE
Use released packages in on-demand sandbox sample

### DIFF
--- a/samples/on-demand-sandbox/main-app/main-app.csproj
+++ b/samples/on-demand-sandbox/main-app/main-app.csproj
@@ -10,16 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" VersionOverride="1.25.0-preview.2" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged.Sandboxes" VersionOverride="1.25.0-preview.2" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" VersionOverride="1.25.0-preview.2" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" VersionOverride="2.1.0-preview.2" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)Client/AzureManaged/Client.AzureManaged.csproj" />
-    <ProjectReference Include="$(SrcRoot)Client/AzureManaged.Sandboxes/Client.AzureManaged.Sandboxes.csproj" />
-    <ProjectReference Include="$(SrcRoot)Worker/AzureManaged/Worker.AzureManaged.csproj" />
-    <ProjectReference Include="$(SrcRoot)Worker/AzureManaged.Sandboxes/Worker.AzureManaged.Sandboxes.csproj" />
     <ProjectReference Include="..\shared\shared.csproj" />
-    <ProjectReference Include="$(SrcRoot)Analyzers/Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(SrcRoot)Generators/Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/samples/on-demand-sandbox/remote-worker/Containerfile
+++ b/samples/on-demand-sandbox/remote-worker/Containerfile
@@ -4,7 +4,9 @@ FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 ARG TARGETARCH
 
-COPY . /src/durabletask-dotnet
+COPY samples/Directory.Build.props samples/Directory.Packages.props /src/durabletask-dotnet/samples/
+COPY Directory.Build.props Directory.Packages.props global.json nuget.config /src/durabletask-dotnet/
+COPY samples/on-demand-sandbox /src/durabletask-dotnet/samples/on-demand-sandbox
 
 WORKDIR /src/durabletask-dotnet/samples/on-demand-sandbox/remote-worker
 RUN case "$TARGETARCH" in \
@@ -18,6 +20,7 @@ RUN case "$TARGETARCH" in \
     --self-contained false \
     -o /app/publish \
     --configfile /src/durabletask-dotnet/nuget.config \
+    /p:SignAssembly=false \
     /p:DebugSymbols=false \
     /p:DebugType=None \
     && find /app/publish -type f \( -name '*.xml' -o -name '*.pdb' \) -delete

--- a/samples/on-demand-sandbox/remote-worker/remote-worker.csproj
+++ b/samples/on-demand-sandbox/remote-worker/remote-worker.csproj
@@ -10,13 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" VersionOverride="1.25.0-preview.2" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged.Sandboxes" VersionOverride="1.25.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)Worker/AzureManaged/Worker.AzureManaged.csproj" />
-    <ProjectReference Include="$(SrcRoot)Worker/AzureManaged.Sandboxes/Worker.AzureManaged.Sandboxes.csproj" />
     <ProjectReference Include="..\shared\shared.csproj" />
-    <ProjectReference Include="$(SrcRoot)Analyzers/Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Update the on-demand sandbox sample projects to consume the released `1.25.0-preview.2` Azure Managed packages instead of SDK project references.
- Remove the unnecessary `Microsoft.DurableTask.Worker.AzureManaged.Sandboxes` dependency from the main app sample.
- Change the remote worker container build to copy only the sample files and restore released NuGet packages, instead of copying the full durabletask-dotnet source tree.

## Validation
- `dotnet build .\samples\on-demand-sandbox\main-app\main-app.csproj`
- `dotnet build .\samples\on-demand-sandbox\remote-worker\remote-worker.csproj`
- Built and pushed sample worker image: `wbdtspoc76f6bd.azurecr.io/dts-ondemand-sandbox-dotnet-sample:releasedpkg-20260617153611`
- Ran the .NET on-demand sample against `wbserverless34san / ondemandsandbox`; orchestration `89b9255469f24e3a8ff04e79bb356e5e` completed and executed the remote activity in ADC sandbox.