### PR TITLE
Add multi-version support to [DurableTask] annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Add support for multiple versions in DurableTask attribute ([#751](https://github.com/microsoft/durabletask-dotnet/pull/751))
 
 ## v1.25.0-preview.2
 - On-demand sandbox ([#736](https://github.com/microsoft/durabletask-dotnet/pull/736))

--- a/src/Abstractions/DurableTaskAttribute.cs
+++ b/src/Abstractions/DurableTaskAttribute.cs
@@ -34,7 +34,7 @@ public sealed class DurableTaskAttribute : Attribute
     public TaskName Name { get; }
 
     /// <summary>
-    /// Gets or sets the version of the durable task. Multiple classes may declare the same
+    /// Gets or sets the version(s) of the durable task. Multiple classes may declare the same
     /// <see cref="Name"/> as long as each declares a unique <see cref="Version"/>.
     /// </summary>
     /// <remarks>
@@ -42,6 +42,13 @@ public sealed class DurableTaskAttribute : Attribute
     /// Leave unset (or set to <c>null</c> / <see cref="string.Empty"/>) for an unversioned task.
     /// Whitespace-only values are rejected at compile time by source generator diagnostic
     /// <c>DURABLE3005</c> and at registration time by the <see cref="TaskVersion"/> constructor.
+    /// </para>
+    /// <para>
+    /// A single class may declare multiple versions by supplying a comma-separated list (for example
+    /// <c>"v1,v2"</c>). Each listed version is plumbed through exactly as a single version is: the type is
+    /// registered under every declared version, and the source generator emits version-aware call helpers
+    /// for them. Empty entries (such as a trailing comma) are ignored, whitespace-only entries are rejected,
+    /// and duplicate entries are coalesced (case-insensitive).
     /// </para>
     /// <para>
     /// Entities ignore this property.

--- a/src/Abstractions/DurableTaskRegistry.Activities.cs
+++ b/src/Abstractions/DurableTaskRegistry.Activities.cs
@@ -62,9 +62,9 @@ public sealed partial class DurableTaskRegistry
     public DurableTaskRegistry AddActivity(TaskName name, Type type)
     {
         Check.ConcreteType<ITaskActivity>(type);
-        return this.AddActivity(
+        return this.AddActivityAllVersions(
             name,
-            type.GetDurableTaskVersion(),
+            type.GetDurableTaskVersions(),
             sp => (ITaskActivity)ActivatorUtilities.GetServiceOrCreateInstance(sp, type));
     }
 
@@ -77,9 +77,9 @@ public sealed partial class DurableTaskRegistry
     public DurableTaskRegistry AddActivity(Type type)
     {
         Check.ConcreteType<ITaskActivity>(type);
-        return this.AddActivity(
+        return this.AddActivityAllVersions(
             type.GetTaskName(),
-            type.GetDurableTaskVersion(),
+            type.GetDurableTaskVersions(),
             sp => (ITaskActivity)ActivatorUtilities.GetServiceOrCreateInstance(sp, type));
     }
 
@@ -112,7 +112,7 @@ public sealed partial class DurableTaskRegistry
     public DurableTaskRegistry AddActivity(TaskName name, ITaskActivity activity)
     {
         Check.NotNull(activity);
-        return this.AddActivity(name, activity.GetType().GetDurableTaskVersion(), () => activity);
+        return this.AddActivityAllVersions(name, activity.GetType().GetDurableTaskVersions(), _ => activity);
     }
 
     /// <summary>
@@ -123,10 +123,10 @@ public sealed partial class DurableTaskRegistry
     public DurableTaskRegistry AddActivity(ITaskActivity activity)
     {
         Check.NotNull(activity);
-        return this.AddActivity(
+        return this.AddActivityAllVersions(
             activity.GetType().GetTaskName(),
-            activity.GetType().GetDurableTaskVersion(),
-            () => activity);
+            activity.GetType().GetDurableTaskVersions(),
+            _ => activity);
     }
 
     /// <summary>

--- a/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
+++ b/src/Abstractions/DurableTaskRegistry.Orchestrators.cs
@@ -95,9 +95,9 @@ public partial class DurableTaskRegistry
     {
         // TODO: Compile a constructor expression for performance.
         Check.ConcreteType<ITaskOrchestrator>(type);
-        return this.AddOrchestrator(
+        return this.AddOrchestratorAllVersions(
             name,
-            type.GetDurableTaskVersion(),
+            type.GetDurableTaskVersions(),
             () => (ITaskOrchestrator)Activator.CreateInstance(type));
     }
 
@@ -109,7 +109,8 @@ public partial class DurableTaskRegistry
     public DurableTaskRegistry AddOrchestrator(Type type)
     {
         Check.ConcreteType<ITaskOrchestrator>(type);
-        return this.AddOrchestrator(type.GetTaskName(), type.GetDurableTaskVersion(), () => (ITaskOrchestrator)Activator.CreateInstance(type));
+        return this.AddOrchestratorAllVersions(
+            type.GetTaskName(), type.GetDurableTaskVersions(), () => (ITaskOrchestrator)Activator.CreateInstance(type));
     }
 
     /// <summary>
@@ -140,7 +141,7 @@ public partial class DurableTaskRegistry
     public DurableTaskRegistry AddOrchestrator(TaskName name, ITaskOrchestrator orchestrator)
     {
         Check.NotNull(orchestrator);
-        return this.AddOrchestrator(name, orchestrator.GetType().GetDurableTaskVersion(), () => orchestrator);
+        return this.AddOrchestratorAllVersions(name, orchestrator.GetType().GetDurableTaskVersions(), () => orchestrator);
     }
 
     /// <summary>
@@ -151,9 +152,9 @@ public partial class DurableTaskRegistry
     public DurableTaskRegistry AddOrchestrator(ITaskOrchestrator orchestrator)
     {
         Check.NotNull(orchestrator);
-        return this.AddOrchestrator(
+        return this.AddOrchestratorAllVersions(
             orchestrator.GetType().GetTaskName(),
-            orchestrator.GetType().GetDurableTaskVersion(),
+            orchestrator.GetType().GetDurableTaskVersions(),
             () => orchestrator);
     }
 
@@ -301,5 +302,21 @@ public partial class DurableTaskRegistry
             orchestrator(context);
             return CompletedNullTask;
         });
+    }
+
+    /// <summary>
+    /// Registers an orchestrator factory under every supplied version. This is the shared fan-out used by the
+    /// type- and singleton-based registration overloads so that a class declaring multiple versions via
+    /// <see cref="DurableTaskAttribute.Version"/> is registered once per declared version.
+    /// </summary>
+    DurableTaskRegistry AddOrchestratorAllVersions(
+        TaskName name, IReadOnlyList<TaskVersion> versions, Func<ITaskOrchestrator> factory)
+    {
+        foreach (TaskVersion version in versions)
+        {
+            this.AddOrchestrator(name, version, factory);
+        }
+
+        return this;
     }
 }

--- a/src/Abstractions/DurableTaskRegistry.cs
+++ b/src/Abstractions/DurableTaskRegistry.cs
@@ -161,4 +161,20 @@ public sealed partial class DurableTaskRegistry
         this.ActivitiesByVersion.Add(key, factory);
         return this;
     }
+
+    /// <summary>
+    /// Registers an activity factory under every supplied version. This is the shared fan-out used by the
+    /// type- and singleton-based registration overloads so that a class declaring multiple versions via
+    /// <see cref="DurableTaskAttribute.Version"/> is registered once per declared version.
+    /// </summary>
+    DurableTaskRegistry AddActivityAllVersions(
+        TaskName name, IReadOnlyList<TaskVersion> versions, Func<IServiceProvider, ITaskActivity> factory)
+    {
+        foreach (TaskVersion version in versions)
+        {
+            this.AddActivity(name, version, factory);
+        }
+
+        return this;
+    }
 }

--- a/src/Abstractions/TypeExtensions.cs
+++ b/src/Abstractions/TypeExtensions.cs
@@ -29,14 +29,70 @@ static class TypeExtensions
     /// </summary>
     /// <param name="type">The type to get the durable task version for.</param>
     /// <returns>The durable task version.</returns>
+    /// <remarks>
+    /// When the <see cref="DurableTaskAttribute.Version"/> declares multiple comma-separated versions, this
+    /// returns only the first declared version. Prefer <see cref="GetDurableTaskVersions"/> when all declared
+    /// versions are needed (for example, when registering a type under every version it supports).
+    /// </remarks>
     internal static TaskVersion GetDurableTaskVersion(this Type type)
     {
         // IMPORTANT: This logic needs to be kept consistent with the source generator logic.
         Check.NotNull(type);
-        return Attribute.GetCustomAttribute(type, typeof(DurableTaskAttribute)) switch
+        IReadOnlyList<TaskVersion> versions = type.GetDurableTaskVersions();
+        return versions.Count > 0 ? versions[0] : default;
+    }
+
+    /// <summary>
+    /// Gets every durable task version declared for a type via <see cref="DurableTaskAttribute.Version"/>.
+    /// </summary>
+    /// <param name="type">The type to get the durable task versions for.</param>
+    /// <returns>
+    /// The distinct (case-insensitive) set of declared versions in declaration order. An unversioned type
+    /// (no attribute, or an empty/unset <see cref="DurableTaskAttribute.Version"/>) yields a single
+    /// <see cref="TaskVersion.Unversioned"/> entry so callers can always register at least once.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when any comma-separated entry is whitespace-only. This mirrors the source generator's
+    /// <c>DURABLE3005</c> diagnostic so the reflection-based registration path fails closed for types whose
+    /// attribute the generator did not see.
+    /// </exception>
+    internal static IReadOnlyList<TaskVersion> GetDurableTaskVersions(this Type type)
+    {
+        // IMPORTANT: This logic needs to be kept consistent with the source generator logic.
+        Check.NotNull(type);
+        if (Attribute.GetCustomAttribute(type, typeof(DurableTaskAttribute)) is not DurableTaskAttribute attr
+            || string.IsNullOrEmpty(attr.Version))
         {
-            DurableTaskAttribute { Version: not null and not "" } attr => new TaskVersion(attr.Version),
-            _ => default,
-        };
+            return new[] { TaskVersion.Unversioned };
+        }
+
+        List<TaskVersion> versions = new();
+        foreach (string segment in attr.Version!.Split(','))
+        {
+            if (segment.Length == 0)
+            {
+                // Truly-empty entry (e.g. a trailing or doubled comma). Skip silently.
+                continue;
+            }
+
+            string trimmed = segment.Trim();
+            if (trimmed.Length == 0)
+            {
+                // Whitespace-only entry. Fail closed, consistent with the TaskVersion constructor and the
+                // source generator's DURABLE3005 diagnostic.
+                throw new ArgumentException(
+                    "A [DurableTask] Version entry must not be whitespace-only. Provide non-empty version " +
+                    "values or omit the Version argument to declare an unversioned task.",
+                    nameof(type));
+            }
+
+            TaskVersion version = new(trimmed);
+            if (!versions.Contains(version))
+            {
+                versions.Add(version);
+            }
+        }
+
+        return versions.Count > 0 ? versions : new[] { TaskVersion.Unversioned };
     }
 }

--- a/src/Generators/DurableTaskSourceGenerator.cs
+++ b/src/Generators/DurableTaskSourceGenerator.cs
@@ -264,31 +264,44 @@ namespace Microsoft.DurableTask.Generators
                 taskNameLocation = expression.GetLocation();
             }
 
-            string taskVersion = string.Empty;
+            List<string> taskVersions = new();
             Location? taskVersionLocation = null;
             bool hasWhitespaceVersion = false;
 
             // Read the optional named "Version = ..." argument off the [DurableTask] attribute itself.
-            // Whitespace-only values are kept as empty for downstream emission so we don't generate code
-            // that references the offending literal; DURABLE3005 will fail the build below.
+            // The value may be a single version ("v1") or a comma-separated list ("v1,v2"). Each entry is
+            // trimmed; truly-empty entries (e.g. a trailing comma) are skipped and duplicates are coalesced.
+            // Whitespace-only entries are flagged so DURABLE3005 fails the build below, and the offending
+            // value is not emitted into generated code.
             AttributeArgumentSyntax? versionArg = attribute.ArgumentList?.Arguments
                 .FirstOrDefault(arg => arg.NameEquals is { Name.Identifier.ValueText: "Version" });
             if (versionArg is not null
-                && context.SemanticModel.GetConstantValue(versionArg.Expression).Value is string version)
+                && context.SemanticModel.GetConstantValue(versionArg.Expression).Value is string version
+                && version.Length > 0)
             {
-                if (version.Length > 0 && string.IsNullOrWhiteSpace(version))
+                taskVersionLocation = versionArg.GetLocation();
+                foreach (string segment in version.Split(','))
                 {
-                    hasWhitespaceVersion = true;
-                    taskVersionLocation = versionArg.GetLocation();
-                    taskVersion = string.Empty;
-                }
-                else
-                {
-                    taskVersion = version;
+                    if (segment.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    string trimmed = segment.Trim();
+                    if (trimmed.Length == 0)
+                    {
+                        hasWhitespaceVersion = true;
+                        continue;
+                    }
+
+                    if (!taskVersions.Contains(trimmed, StringComparer.OrdinalIgnoreCase))
+                    {
+                        taskVersions.Add(trimmed);
+                    }
                 }
             }
 
-            return new DurableTaskTypeInfo(className, classNamespace, taskName, inputType, outputType, kind, taskVersion, taskNameLocation, taskVersionLocation, hasWhitespaceVersion);
+            return new DurableTaskTypeInfo(className, classNamespace, taskName, inputType, outputType, kind, taskVersions, taskNameLocation, taskVersionLocation, hasWhitespaceVersion);
         }
 
         static DurableEventTypeInfo? GetDurableEventTypeInfo(GeneratorSyntaxContext context)
@@ -424,26 +437,43 @@ namespace Microsoft.DurableTask.Generators
 
             Dictionary<string, DurableTaskTypeInfo> standaloneOrchestratorRegistrations = new(StringComparer.OrdinalIgnoreCase);
             Dictionary<string, DurableTaskTypeInfo> standaloneActivityRegistrations = new(StringComparer.OrdinalIgnoreCase);
+
+            // Reserves a standalone (name, version) registration key for each version the task declares.
+            // Returns false (after reporting DURABLE3003) when any of the task's keys is already taken,
+            // signaling the caller to skip the task. A task declaring multiple versions reserves one key
+            // per version so that two different classes cannot both claim the same name + version.
+            bool TryReserveStandaloneRegistration(Dictionary<string, DurableTaskTypeInfo> registrations, DurableTaskTypeInfo task)
+            {
+                foreach (string version in GetTaskVersionsOrUnversioned(task))
+                {
+                    string registrationKey = GetStandaloneTaskRegistrationKey(task.TaskName, version);
+                    if (registrations.ContainsKey(registrationKey))
+                    {
+                        Location location = task.TaskNameLocation ?? Location.None;
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DuplicateStandaloneOrchestratorVersionRule,
+                            location,
+                            task.TaskName,
+                            version));
+                        return false;
+                    }
+                }
+
+                foreach (string version in GetTaskVersionsOrUnversioned(task))
+                {
+                    registrations[GetStandaloneTaskRegistrationKey(task.TaskName, version)] = task;
+                }
+
+                return true;
+            }
+
             foreach (DurableTaskTypeInfo task in validTasks)
             {
                 if (task.IsActivity)
                 {
-                    if (!isDurableFunctions)
+                    if (!isDurableFunctions && !TryReserveStandaloneRegistration(standaloneActivityRegistrations, task))
                     {
-                        string registrationKey = GetStandaloneTaskRegistrationKey(task.TaskName, task.TaskVersion);
-                        if (standaloneActivityRegistrations.ContainsKey(registrationKey))
-                        {
-                            Location location = task.TaskNameLocation ?? Location.None;
-                            Diagnostic diagnostic = Diagnostic.Create(
-                                DuplicateStandaloneOrchestratorVersionRule,
-                                location,
-                                task.TaskName,
-                                task.TaskVersion);
-                            context.ReportDiagnostic(diagnostic);
-                            continue;
-                        }
-
-                        standaloneActivityRegistrations.Add(registrationKey, task);
+                        continue;
                     }
 
                     activities.Add(task);
@@ -454,22 +484,9 @@ namespace Microsoft.DurableTask.Generators
                 }
                 else
                 {
-                    if (!isDurableFunctions)
+                    if (!isDurableFunctions && !TryReserveStandaloneRegistration(standaloneOrchestratorRegistrations, task))
                     {
-                        string registrationKey = GetStandaloneTaskRegistrationKey(task.TaskName, task.TaskVersion);
-                        if (standaloneOrchestratorRegistrations.ContainsKey(registrationKey))
-                        {
-                            Location location = task.TaskNameLocation ?? Location.None;
-                            Diagnostic diagnostic = Diagnostic.Create(
-                                DuplicateStandaloneOrchestratorVersionRule,
-                                location,
-                                task.TaskName,
-                                task.TaskVersion);
-                            context.ReportDiagnostic(diagnostic);
-                            continue;
-                        }
-
-                        standaloneOrchestratorRegistrations.Add(registrationKey, task);
+                        continue;
                     }
 
                     orchestrators.Add(task);
@@ -647,9 +664,9 @@ using Microsoft.Extensions.DependencyInjection;");
                 bool hasEvents = eventsInNamespace != null && eventsInNamespace.Count > 0;
                 bool hasRegistration = isMicrosoftDurableTask && needsRegistrationMethod;
                 bool hasVersionedStandaloneOrchestratorHelpers = !isDurableFunctions
-                    && orchestratorsInNs.Any(task => !string.IsNullOrEmpty(task.TaskVersion));
+                    && orchestratorsInNs.Any(task => task.IsVersioned);
                 bool hasVersionedStandaloneActivityHelpers = !isDurableFunctions
-                    && activitiesInNs.Any(task => !string.IsNullOrEmpty(task.TaskVersion));
+                    && activitiesInNs.Any(task => task.IsVersioned);
                 bool hasVersionedStandaloneHelpers = hasVersionedStandaloneOrchestratorHelpers || hasVersionedStandaloneActivityHelpers;
 
                 if (!hasOrchestratorMethods && !hasActivityMethods && !hasEntityFunctions
@@ -682,7 +699,7 @@ namespace {targetNamespace}
                     }
 
                     string helperRoot = GetStandaloneHelperRoot(orchestrator, isDurableFunctions, standaloneOrchestratorCountsByTaskName);
-                    bool applyGeneratedVersion = !isDurableFunctions && !string.IsNullOrEmpty(orchestrator.TaskVersion);
+                    bool applyGeneratedVersion = !isDurableFunctions && orchestrator.IsVersioned;
                     AddOrchestratorCallMethod(sourceBuilder, orchestrator, targetNamespace, helperRoot, applyGeneratedVersion);
                     AddSubOrchestratorCallMethod(sourceBuilder, orchestrator, targetNamespace, helperRoot, applyGeneratedVersion);
                 }
@@ -690,7 +707,7 @@ namespace {targetNamespace}
                 foreach (DurableTaskTypeInfo activity in activitiesInNs)
                 {
                     string helperRoot = GetStandaloneHelperRoot(activity, isDurableFunctions, standaloneActivityCountsByTaskName);
-                    bool applyGeneratedVersion = !isDurableFunctions && !string.IsNullOrEmpty(activity.TaskVersion);
+                    bool applyGeneratedVersion = !isDurableFunctions && activity.IsVersioned;
                     AddActivityCallMethod(sourceBuilder, activity, targetNamespace, helperRoot, applyGeneratedVersion);
 
                     if (isDurableFunctions)
@@ -828,7 +845,7 @@ namespace {targetNamespace}
             // generated helper unique without encoding the version into the method name. Single-class and
             // Azure Functions cases continue to use the durable task name unchanged.
             if (isDurableFunctions
-                || string.IsNullOrEmpty(task.TaskVersion)
+                || !task.IsVersioned
                 || !standaloneTaskCountsByTaskName.TryGetValue(task.TaskName, out int count)
                 || count <= 1)
             {
@@ -856,7 +873,32 @@ namespace {targetNamespace}
             return string.Concat(taskName, "\0", taskVersion);
         }
 
+        // Yields each declared version for the task, or a single empty (unversioned) entry when none are
+        // declared. Lets registration/dedup logic treat versioned and unversioned tasks uniformly.
+        static IEnumerable<string> GetTaskVersionsOrUnversioned(DurableTaskTypeInfo task)
+        {
+            return task.TaskVersions.Count > 0 ? task.TaskVersions : new[] { string.Empty };
+        }
+
         static string ToCSharpStringLiteral(string value) => SymbolDisplay.FormatLiteral(value, quote: true);
+
+        // Builds a runtime guard, emitted into a multi-version call helper, that rejects a caller-supplied
+        // version not declared on the task. The condition compares against each declared version literal so
+        // the wire only ever carries a version the task advertises.
+        static string BuildDeclaredVersionGuard(DurableTaskTypeInfo task, string callKind)
+        {
+            string condition = string.Join(
+                " || ", task.TaskVersions.Select(v => $"version == {ToCSharpStringLiteral(v)}"));
+            string declaredVersions = string.Join(", ", task.TaskVersions);
+            return $@"
+            if (!({condition}))
+            {{
+                throw new ArgumentException(
+                    ""Version '"" + version + ""' is not a declared version of {callKind} '{task.TaskName}'. Declared versions: {declaredVersions}."",
+                    nameof(version));
+            }}
+";
+        }
 
         static void AddOrchestratorFunctionDeclaration(StringBuilder sourceBuilder, DurableTaskTypeInfo orchestrator, string targetNamespace)
         {
@@ -874,21 +916,39 @@ namespace {targetNamespace}
 
         static void AddOrchestratorCallMethod(StringBuilder sourceBuilder, DurableTaskTypeInfo orchestrator, string targetNamespace, string helperRoot, bool applyGeneratedVersion)
         {
+            bool multiVersion = applyGeneratedVersion && orchestrator.TaskVersions.Count > 1;
+
             string inputType = orchestrator.GetInputTypeForNamespace(targetNamespace);
             string inputParameter = inputType + " input";
-            if (inputType.EndsWith("?", StringComparison.Ordinal))
+            if (!multiVersion && inputType.EndsWith("?", StringComparison.Ordinal))
             {
                 inputParameter += " = default";
             }
 
             string simplifiedTypeName = SimplifyTypeName(orchestrator.TypeName, targetNamespace);
-            string optionsExpression = applyGeneratedVersion
-                ? $"ApplyGeneratedVersion(options, {ToCSharpStringLiteral(orchestrator.TaskVersion)})"
-                : "options";
-            string versionRemarks = applyGeneratedVersion
-                ? $@"
-        /// <remarks>Stamps version <c>{orchestrator.TaskVersion}</c> on the started instance. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>"
-                : string.Empty;
+            string versionParameter = multiVersion ? ", string version" : string.Empty;
+            string versionGuard = multiVersion ? BuildDeclaredVersionGuard(orchestrator, "orchestration") : string.Empty;
+            string optionsExpression;
+            string versionRemarks;
+            if (multiVersion)
+            {
+                string declaredVersions = string.Join(", ", orchestrator.TaskVersions);
+                optionsExpression = "ApplyGeneratedVersion(options, version)";
+                versionRemarks = $@"
+        /// <remarks>Stamps the supplied <paramref name=""version""/> on the started instance; it must be one of the declared versions: {declaredVersions}. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+        /// <param name=""version"">The declared task version to stamp on the call. Must be one of: {declaredVersions}.</param>";
+            }
+            else if (applyGeneratedVersion)
+            {
+                optionsExpression = $"ApplyGeneratedVersion(options, {ToCSharpStringLiteral(orchestrator.TaskVersions[0])})";
+                versionRemarks = $@"
+        /// <remarks>Stamps version <c>{orchestrator.TaskVersions[0]}</c> on the started instance. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>";
+            }
+            else
+            {
+                optionsExpression = "options";
+                versionRemarks = string.Empty;
+            }
 
             sourceBuilder.AppendLine($@"
         /// <summary>
@@ -896,30 +956,48 @@ namespace {targetNamespace}
         /// </summary>{versionRemarks}
         /// <inheritdoc cref=""IOrchestrationSubmitter.ScheduleNewOrchestrationInstanceAsync""/>
         public static Task<string> ScheduleNew{helperRoot}InstanceAsync(
-            this IOrchestrationSubmitter client, {inputParameter}, StartOrchestrationOptions? options = null)
-        {{
+            this IOrchestrationSubmitter client, {inputParameter}{versionParameter}, StartOrchestrationOptions? options = null)
+        {{{versionGuard}
             return client.ScheduleNewOrchestrationInstanceAsync(""{orchestrator.TaskName}"", input, {optionsExpression});
         }}");
         }
 
         static void AddSubOrchestratorCallMethod(StringBuilder sourceBuilder, DurableTaskTypeInfo orchestrator, string targetNamespace, string helperRoot, bool applyGeneratedVersion)
         {
+            bool multiVersion = applyGeneratedVersion && orchestrator.TaskVersions.Count > 1;
+
             string inputType = orchestrator.GetInputTypeForNamespace(targetNamespace);
             string outputType = orchestrator.GetOutputTypeForNamespace(targetNamespace);
             string inputParameter = inputType + " input";
-            if (inputType.EndsWith("?", StringComparison.Ordinal))
+            if (!multiVersion && inputType.EndsWith("?", StringComparison.Ordinal))
             {
                 inputParameter += " = default";
             }
 
             string simplifiedTypeName = SimplifyTypeName(orchestrator.TypeName, targetNamespace);
-            string optionsExpression = applyGeneratedVersion
-                ? $"ApplyGeneratedVersion(options, {ToCSharpStringLiteral(orchestrator.TaskVersion)})"
-                : "options";
-            string versionRemarks = applyGeneratedVersion
-                ? $@"
-        /// <remarks>Stamps version <c>{orchestrator.TaskVersion}</c> on the sub-orchestration. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>"
-                : string.Empty;
+            string versionParameter = multiVersion ? ", string version" : string.Empty;
+            string versionGuard = multiVersion ? BuildDeclaredVersionGuard(orchestrator, "orchestration") : string.Empty;
+            string optionsExpression;
+            string versionRemarks;
+            if (multiVersion)
+            {
+                string declaredVersions = string.Join(", ", orchestrator.TaskVersions);
+                optionsExpression = "ApplyGeneratedVersion(options, version)";
+                versionRemarks = $@"
+        /// <remarks>Stamps the supplied <paramref name=""version""/> on the sub-orchestration; it must be one of the declared versions: {declaredVersions}. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+        /// <param name=""version"">The declared task version to stamp on the call. Must be one of: {declaredVersions}.</param>";
+            }
+            else if (applyGeneratedVersion)
+            {
+                optionsExpression = $"ApplyGeneratedVersion(options, {ToCSharpStringLiteral(orchestrator.TaskVersions[0])})";
+                versionRemarks = $@"
+        /// <remarks>Stamps version <c>{orchestrator.TaskVersions[0]}</c> on the sub-orchestration. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>";
+            }
+            else
+            {
+                optionsExpression = "options";
+                versionRemarks = string.Empty;
+            }
 
             sourceBuilder.AppendLine($@"
         /// <summary>
@@ -927,8 +1005,8 @@ namespace {targetNamespace}
         /// </summary>{versionRemarks}
         /// <inheritdoc cref=""TaskOrchestrationContext.CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)""/>
         public static Task<{outputType}> Call{helperRoot}Async(
-            this TaskOrchestrationContext context, {inputParameter}, TaskOptions? options = null)
-        {{
+            this TaskOrchestrationContext context, {inputParameter}{versionParameter}, TaskOptions? options = null)
+        {{{versionGuard}
             return context.CallSubOrchestratorAsync<{outputType}>(""{orchestrator.TaskName}"", input, {optionsExpression});
         }}");
         }
@@ -1010,30 +1088,48 @@ namespace {targetNamespace}
 
         static void AddActivityCallMethod(StringBuilder sourceBuilder, DurableTaskTypeInfo activity, string targetNamespace, string helperRoot, bool applyGeneratedVersion)
         {
+            bool multiVersion = applyGeneratedVersion && activity.TaskVersions.Count > 1;
+
             string inputType = activity.GetInputTypeForNamespace(targetNamespace);
             string outputType = activity.GetOutputTypeForNamespace(targetNamespace);
             string inputParameter = inputType + " input";
-            if (inputType.EndsWith("?", StringComparison.Ordinal))
+            if (!multiVersion && inputType.EndsWith("?", StringComparison.Ordinal))
             {
                 inputParameter += " = default";
             }
 
             string simplifiedTypeName = SimplifyTypeName(activity.TypeName, targetNamespace);
-            string optionsExpression = applyGeneratedVersion
-                ? $"ApplyGeneratedActivityVersion(options, {ToCSharpStringLiteral(activity.TaskVersion)})"
-                : "options";
-            string versionRemarks = applyGeneratedVersion
-                ? $@"
-        /// <remarks>Stamps version <c>{activity.TaskVersion}</c> on the activity call. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>"
-                : string.Empty;
+            string versionParameter = multiVersion ? ", string version" : string.Empty;
+            string versionGuard = multiVersion ? BuildDeclaredVersionGuard(activity, "activity") : string.Empty;
+            string optionsExpression;
+            string versionRemarks;
+            if (multiVersion)
+            {
+                string declaredVersions = string.Join(", ", activity.TaskVersions);
+                optionsExpression = "ApplyGeneratedActivityVersion(options, version)";
+                versionRemarks = $@"
+        /// <remarks>Stamps the supplied <paramref name=""version""/> on the activity call; it must be one of the declared versions: {declaredVersions}. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+        /// <param name=""version"">The declared task version to stamp on the call. Must be one of: {declaredVersions}.</param>";
+            }
+            else if (applyGeneratedVersion)
+            {
+                optionsExpression = $"ApplyGeneratedActivityVersion(options, {ToCSharpStringLiteral(activity.TaskVersions[0])})";
+                versionRemarks = $@"
+        /// <remarks>Stamps version <c>{activity.TaskVersions[0]}</c> on the activity call. A non-null <paramref name=""options""/>.Version overrides this baked version.</remarks>";
+            }
+            else
+            {
+                optionsExpression = "options";
+                versionRemarks = string.Empty;
+            }
 
             sourceBuilder.AppendLine($@"
         /// <summary>
         /// Calls the <see cref=""{simplifiedTypeName}""/> activity.
         /// </summary>{versionRemarks}
         /// <inheritdoc cref=""TaskOrchestrationContext.CallActivityAsync(TaskName, object?, TaskOptions?)""/>
-        public static Task<{outputType}> Call{helperRoot}Async(this TaskOrchestrationContext ctx, {inputParameter}, TaskOptions? options = null)
-        {{
+        public static Task<{outputType}> Call{helperRoot}Async(this TaskOrchestrationContext ctx, {inputParameter}{versionParameter}, TaskOptions? options = null)
+        {{{versionGuard}
             return ctx.CallActivityAsync<{outputType}>(""{activity.TaskName}"", input, {optionsExpression});
         }}");
         }
@@ -1210,7 +1306,7 @@ namespace {targetNamespace}
                 ITypeSymbol? inputType,
                 ITypeSymbol? outputType,
                 DurableTaskKind kind,
-                string taskVersion,
+                IReadOnlyList<string> taskVersions,
                 Location? taskNameLocation = null,
                 Location? taskVersionLocation = null,
                 bool hasWhitespaceVersion = false)
@@ -1219,7 +1315,7 @@ namespace {targetNamespace}
                 this.Namespace = taskNamespace;
                 this.TaskName = taskName;
                 this.Kind = kind;
-                this.TaskVersion = taskVersion;
+                this.TaskVersions = taskVersions;
                 this.TaskNameLocation = taskNameLocation;
                 this.TaskVersionLocation = taskVersionLocation;
                 this.HasWhitespaceVersion = hasWhitespaceVersion;
@@ -1230,7 +1326,17 @@ namespace {targetNamespace}
             public string TypeName { get; }
             public string Namespace { get; }
             public string TaskName { get; }
-            public string TaskVersion { get; }
+
+            /// <summary>
+            /// Gets the distinct versions declared on the task in declaration order. Empty for an unversioned task.
+            /// </summary>
+            public IReadOnlyList<string> TaskVersions { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether the task declares one or more versions.
+            /// </summary>
+            public bool IsVersioned => this.TaskVersions.Count > 0;
+
             public DurableTaskKind Kind { get; }
             public Location? TaskNameLocation { get; }
             public Location? TaskVersionLocation { get; }

--- a/src/Worker/Core/DurableTaskWorkerWorkItemFilters.cs
+++ b/src/Worker/Core/DurableTaskWorkerWorkItemFilters.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.DurableTask.Abstractions;
+
 namespace Microsoft.DurableTask.Worker;
 
 /// <summary>
@@ -57,7 +59,9 @@ public class DurableTaskWorkerWorkItemFilters
             .GroupBy(orchestration => orchestration.Key.Name, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
             {
-                IReadOnlyList<string> versions = strictWorkerVersions ?? GetFilterVersions(group.Select(entry => entry.Key.Version));
+                IReadOnlyList<string> versions = strictWorkerVersions ?? GetFilterVersions(
+                    group.Select(entry => entry.Key.Version),
+                    workerOptions?.Versioning?.MatchStrategy == DurableTaskWorkerOptions.VersionMatchStrategy.CurrentOrOlder ? workerOptions.Versioning.Version : null);
 
                 return new OrchestrationFilter
                 {
@@ -71,7 +75,9 @@ public class DurableTaskWorkerWorkItemFilters
             .GroupBy(activity => activity.Key.Name, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
             {
-                IReadOnlyList<string> versions = strictWorkerVersions ?? GetFilterVersions(group.Select(entry => entry.Key.Version));
+                IReadOnlyList<string> versions = strictWorkerVersions ?? GetFilterVersions(
+                    group.Select(entry => entry.Key.Version),
+                    workerOptions?.Versioning?.MatchStrategy == DurableTaskWorkerOptions.VersionMatchStrategy.CurrentOrOlder ? workerOptions.Versioning.Version : null);
 
                 return new ActivityFilter
                 {
@@ -92,13 +98,14 @@ public class DurableTaskWorkerWorkItemFilters
             }).ToList(),
         };
 
-        static IReadOnlyList<string> GetFilterVersions(IEnumerable<string?> versions)
+        static IReadOnlyList<string> GetFilterVersions(IEnumerable<string?> versions, string? workerVersion)
         {
             // Normalize null to "" so an unversioned registration appears consistently.
             string[] normalized = versions
                 .Select(version => version ?? string.Empty)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(version => version, StringComparer.OrdinalIgnoreCase)
+                .Where(version => workerVersion == null || TaskOrchestrationVersioningUtils.CompareVersions(workerVersion, version) >= 0)
                 .ToArray();
 
             // Unversioned-only: emit the wildcard match-all (empty list) so the backend can deliver

--- a/test/Abstractions.Tests/DurableTaskAttributeVersionTests.cs
+++ b/test/Abstractions.Tests/DurableTaskAttributeVersionTests.cs
@@ -59,6 +59,61 @@ public class DurableTaskAttributeVersionTests
             .WithMessage("*whitespace*");
     }
 
+    [Fact]
+    public void GetDurableTaskVersions_MultipleVersions_ReturnsEachInOrder()
+    {
+        // Arrange
+        Type type = typeof(MultiVersionTestOrchestrator);
+
+        // Act
+        IReadOnlyList<TaskVersion> versions = type.GetDurableTaskVersions();
+
+        // Assert
+        versions.Select(v => v.Version).Should().Equal("v1", "v2", "v3");
+    }
+
+    [Fact]
+    public void GetDurableTaskVersions_WithWhitespaceAndDuplicateEntries_TrimsSkipsAndDedups()
+    {
+        // Arrange
+        Type type = typeof(MessyMultiVersionTestOrchestrator);
+
+        // Act
+        IReadOnlyList<TaskVersion> versions = type.GetDurableTaskVersions();
+
+        // Assert — surrounding whitespace is trimmed, the trailing-comma empty entry is dropped, and the
+        // duplicate "v1" is coalesced (case-insensitively).
+        versions.Select(v => v.Version).Should().Equal("v1", "v2");
+    }
+
+    [Fact]
+    public void GetDurableTaskVersions_Unversioned_ReturnsSingleUnversionedEntry()
+    {
+        // Arrange
+        Type type = typeof(UnversionedTestOrchestrator);
+
+        // Act
+        IReadOnlyList<TaskVersion> versions = type.GetDurableTaskVersions();
+
+        // Assert
+        versions.Should().ContainSingle().Which.Should().Be(TaskVersion.Unversioned);
+    }
+
+    [Fact]
+    public void GetDurableTaskVersions_WhitespaceOnlyEntry_ThrowsArgumentException()
+    {
+        // Arrange — a whitespace-only entry between commas must fail closed, mirroring the source
+        // generator's DURABLE3005 diagnostic.
+        Type type = typeof(WhitespaceEntryMultiVersionTestOrchestrator);
+
+        // Act
+        Action act = () => type.GetDurableTaskVersions();
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage("*whitespace*");
+    }
+
     [DurableTask(Version = "v1")]
     sealed class VersionedTestOrchestrator : TaskOrchestrator<string, string>
     {
@@ -74,6 +129,27 @@ public class DurableTaskAttributeVersionTests
 
     [DurableTask("WhitespaceVersioned", Version = "   ")]
     sealed class WhitespaceVersionedTestOrchestrator : TaskOrchestrator<string, string>
+    {
+        public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
+            => Task.FromResult(input);
+    }
+
+    [DurableTask("MultiVersion", Version = "v1,v2,v3")]
+    sealed class MultiVersionTestOrchestrator : TaskOrchestrator<string, string>
+    {
+        public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
+            => Task.FromResult(input);
+    }
+
+    [DurableTask("MessyMultiVersion", Version = " v1 , v2 ,v1,")]
+    sealed class MessyMultiVersionTestOrchestrator : TaskOrchestrator<string, string>
+    {
+        public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
+            => Task.FromResult(input);
+    }
+
+    [DurableTask("WhitespaceEntryMultiVersion", Version = "v1, ,v2")]
+    sealed class WhitespaceEntryMultiVersionTestOrchestrator : TaskOrchestrator<string, string>
     {
         public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
             => Task.FromResult(input);

--- a/test/Abstractions.Tests/DurableTaskRegistryVersioningTests.cs
+++ b/test/Abstractions.Tests/DurableTaskRegistryVersioningTests.cs
@@ -226,6 +226,54 @@ public class DurableTaskRegistryVersioningTests
         act.Should().ThrowExactly<ArgumentException>().WithParameterName("name");
     }
 
+    [Fact]
+    public void AddOrchestrator_MultiVersionAttribute_RegistersUnderEachVersion()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new();
+
+        // Act
+        registry.AddOrchestrator<MultiVersionWorkflow>();
+
+        // Assert — a single class declaring "v1,v2" is registered once per declared version.
+        registry.OrchestratorsByVersion.Keys.Should().BeEquivalentTo(new[]
+        {
+            new TaskVersionKey("MultiVersionWorkflow", "v1"),
+            new TaskVersionKey("MultiVersionWorkflow", "v2"),
+        });
+    }
+
+    [Fact]
+    public void AddActivity_MultiVersionAttribute_RegistersUnderEachVersion()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new();
+
+        // Act
+        registry.AddActivity<MultiVersionActivity>();
+
+        // Assert
+        registry.ActivitiesByVersion.Keys.Should().BeEquivalentTo(new[]
+        {
+            new TaskVersionKey("MultiVersionActivity", "v1"),
+            new TaskVersionKey("MultiVersionActivity", "v2"),
+        });
+    }
+
+    [Fact]
+    public void AddOrchestrator_MultiVersionAttribute_CollidingVersionWithExistingRegistration_Throws()
+    {
+        // Arrange — "v2" is shared between the multi-version class and the single-version class.
+        DurableTaskRegistry registry = new();
+        registry.AddOrchestrator("MultiVersionWorkflow", new TaskVersion("v2"), () => Mock.Of<ITaskOrchestrator>());
+
+        // Act
+        Action act = () => registry.AddOrchestrator<MultiVersionWorkflow>();
+
+        // Assert
+        act.Should().ThrowExactly<ArgumentException>().WithParameterName("name");
+    }
+
     [DurableTask("ShippingWorkflow", Version = "v1")]
     sealed class ShippingWorkflowV1 : TaskOrchestrator<string, string>
     {
@@ -306,5 +354,19 @@ public class DurableTaskRegistryVersioningTests
 
         public override Task<string> RunAsync(TaskActivityContext context, string input)
             => Task.FromResult(this.marker);
+    }
+
+    [DurableTask("MultiVersionWorkflow", Version = "v1,v2")]
+    sealed class MultiVersionWorkflow : TaskOrchestrator<string, string>
+    {
+        public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
+            => Task.FromResult(input);
+    }
+
+    [DurableTask("MultiVersionActivity", Version = "v1,v2")]
+    sealed class MultiVersionActivity : TaskActivity<string, string>
+    {
+        public override Task<string> RunAsync(TaskActivityContext context, string input)
+            => Task.FromResult(input);
     }
 }

--- a/test/Generators.Tests/VersionedActivityTests.cs
+++ b/test/Generators.Tests/VersionedActivityTests.cs
@@ -72,6 +72,70 @@ internal static DurableTaskRegistry AddAllGeneratedTasks(this DurableTaskRegistr
     }
 
     [Fact]
+    public Task Standalone_MultiVersionedActivity_GeneratesVersionParameterHelper()
+    {
+        string code = @"
+using System.Threading.Tasks;
+using Microsoft.DurableTask;
+
+[DurableTask(""ProcessInvoice"", Version = ""v1,v2"")]
+class ProcessInvoice : TaskActivity<int, string>
+{
+    public override Task<string> RunAsync(TaskActivityContext context, int input) => Task.FromResult(string.Empty);
+}";
+
+        string expectedOutput = TestHelpers.WrapAndFormat(
+            GeneratedClassName,
+            methodList: @"
+/// <summary>
+/// Calls the <see cref=""ProcessInvoice""/> activity.
+/// </summary>
+/// <remarks>Stamps the supplied <paramref name=""version""/> on the activity call; it must be one of the declared versions: v1, v2. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+/// <param name=""version"">The declared task version to stamp on the call. Must be one of: v1, v2.</param>
+/// <inheritdoc cref=""TaskOrchestrationContext.CallActivityAsync(TaskName, object?, TaskOptions?)""/>
+public static Task<string> CallProcessInvoiceAsync(this TaskOrchestrationContext ctx, int input, string version, TaskOptions? options = null)
+{
+    if (!(version == ""v1"" || version == ""v2""))
+    {
+        throw new ArgumentException(
+            ""Version '"" + version + ""' is not a declared version of activity 'ProcessInvoice'. Declared versions: v1, v2."",
+            nameof(version));
+    }
+
+    return ctx.CallActivityAsync<string>(""ProcessInvoice"", input, ApplyGeneratedActivityVersion(options, version));
+}
+
+static TaskOptions? ApplyGeneratedActivityVersion(TaskOptions? options, string version)
+{
+    // Caller-supplied options.Version is preserved as-is — the explicit value wins. Otherwise we
+    // stamp the version that the generated helper was emitted for.
+    if (options is null)
+    {
+        return new TaskOptions
+        {
+            Version = version,
+        };
+    }
+
+    return options.Version is not null
+        ? options
+        : new TaskOptions(options) { Version = version };
+}
+
+internal static DurableTaskRegistry AddAllGeneratedTasks(this DurableTaskRegistry builder)
+{
+    builder.AddActivity<ProcessInvoice>();
+    return builder;
+}");
+
+        return TestHelpers.RunTestAsync<DurableTaskSourceGenerator>(
+            GeneratedFileName,
+            code,
+            expectedOutput,
+            isDurableFunctions: false);
+    }
+
+    [Fact]
     public Task Standalone_MultiVersionedActivities_GenerateVersionQualifiedHelpersOnly()
     {
         string code = @"

--- a/test/Generators.Tests/VersionedOrchestratorTests.cs
+++ b/test/Generators.Tests/VersionedOrchestratorTests.cs
@@ -109,6 +109,117 @@ internal static DurableTaskRegistry AddAllGeneratedTasks(this DurableTaskRegistr
     }
 
     [Fact]
+    public Task Standalone_MultiVersionedOrchestrator_GeneratesVersionParameterHelpers()
+    {
+        string code = @"
+using System.Threading.Tasks;
+using Microsoft.DurableTask;
+
+[DurableTask(""InvoiceWorkflow"", Version = ""v1,v2"")]
+class InvoiceWorkflow : TaskOrchestrator<int, string>
+{
+    public override Task<string> RunAsync(TaskOrchestrationContext context, int input) => Task.FromResult(string.Empty);
+}";
+
+        string expectedOutput = TestHelpers.WrapAndFormat(
+            GeneratedClassName,
+            methodList: @"
+/// <summary>
+/// Schedules a new instance of the <see cref=""InvoiceWorkflow""/> orchestrator.
+/// </summary>
+/// <remarks>Stamps the supplied <paramref name=""version""/> on the started instance; it must be one of the declared versions: v1, v2. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+/// <param name=""version"">The declared task version to stamp on the call. Must be one of: v1, v2.</param>
+/// <inheritdoc cref=""IOrchestrationSubmitter.ScheduleNewOrchestrationInstanceAsync""/>
+public static Task<string> ScheduleNewInvoiceWorkflowInstanceAsync(
+    this IOrchestrationSubmitter client, int input, string version, StartOrchestrationOptions? options = null)
+{
+    if (!(version == ""v1"" || version == ""v2""))
+    {
+        throw new ArgumentException(
+            ""Version '"" + version + ""' is not a declared version of orchestration 'InvoiceWorkflow'. Declared versions: v1, v2."",
+            nameof(version));
+    }
+
+    return client.ScheduleNewOrchestrationInstanceAsync(""InvoiceWorkflow"", input, ApplyGeneratedVersion(options, version));
+}
+
+/// <summary>
+/// Calls the <see cref=""InvoiceWorkflow""/> sub-orchestrator.
+/// </summary>
+/// <remarks>Stamps the supplied <paramref name=""version""/> on the sub-orchestration; it must be one of the declared versions: v1, v2. A non-null <paramref name=""options""/>.Version overrides it.</remarks>
+/// <param name=""version"">The declared task version to stamp on the call. Must be one of: v1, v2.</param>
+/// <inheritdoc cref=""TaskOrchestrationContext.CallSubOrchestratorAsync(TaskName, object?, TaskOptions?)""/>
+public static Task<string> CallInvoiceWorkflowAsync(
+    this TaskOrchestrationContext context, int input, string version, TaskOptions? options = null)
+{
+    if (!(version == ""v1"" || version == ""v2""))
+    {
+        throw new ArgumentException(
+            ""Version '"" + version + ""' is not a declared version of orchestration 'InvoiceWorkflow'. Declared versions: v1, v2."",
+            nameof(version));
+    }
+
+    return context.CallSubOrchestratorAsync<string>(""InvoiceWorkflow"", input, ApplyGeneratedVersion(options, version));
+}
+
+static StartOrchestrationOptions? ApplyGeneratedVersion(StartOrchestrationOptions? options, string version)
+{
+    // Caller-supplied options.Version is preserved as-is — the explicit value wins. Otherwise we
+    // stamp the version that the generated helper was emitted for.
+    if (options is null)
+    {
+        return new StartOrchestrationOptions
+        {
+            Version = version,
+        };
+    }
+
+    if (options.Version is not null)
+    {
+        return options;
+    }
+
+    return options with { Version = new TaskVersion(version) };
+}
+
+static TaskOptions? ApplyGeneratedVersion(TaskOptions? options, string version)
+{
+    // Caller-supplied options.Version is preserved as-is — the explicit value wins. Otherwise we
+    // stamp the version that the generated helper was emitted for.
+    if (options is SubOrchestrationOptions subOrchestrationOptions)
+    {
+        return subOrchestrationOptions.Version is not null
+            ? subOrchestrationOptions
+            : subOrchestrationOptions with { Version = new TaskVersion(version) };
+    }
+
+    if (options is null)
+    {
+        return new SubOrchestrationOptions
+        {
+            Version = version,
+        };
+    }
+
+    return options.Version is not null
+        ? options
+        : new SubOrchestrationOptions(options) { Version = version };
+}
+
+internal static DurableTaskRegistry AddAllGeneratedTasks(this DurableTaskRegistry builder)
+{
+    builder.AddOrchestrator<InvoiceWorkflow>();
+    return builder;
+}");
+
+        return TestHelpers.RunTestAsync<DurableTaskSourceGenerator>(
+            GeneratedFileName,
+            code,
+            expectedOutput,
+            isDurableFunctions: false);
+    }
+
+    [Fact]
     public Task Standalone_VersionedOrchestratorWithImplicitName_UsesClassNameNotVersion()
     {
         // Pins the bug fix: previously [DurableTask(Version = "v1")] (no positional task name) caused the

--- a/test/Worker/Core.Tests/DependencyInjection/UseWorkItemFiltersTests.cs
+++ b/test/Worker/Core.Tests/DependencyInjection/UseWorkItemFiltersTests.cs
@@ -156,6 +156,133 @@ public class UseWorkItemFiltersTests
     }
 
     [Fact]
+    public void WorkItemFilters_CurrentOrOlder_FiltersOutNewerThanWorkerVersion()
+    {
+        // Arrange — register v1 and v2 of the same logical name. With CurrentOrOlder at worker version
+        // "v1", the backend should only be asked for versions <= v1 so it never streams v2 work items
+        // the worker would reject after the fact.
+        ServiceCollection services = new();
+        services.AddDurableTaskWorker("test", builder =>
+        {
+            builder.AddTasks(registry =>
+            {
+                registry.AddOrchestrator<VersionedFilterWorkflowV1>();
+                registry.AddOrchestrator<VersionedFilterWorkflowV2>();
+                registry.AddActivity<VersionedFilterActivityV1>();
+                registry.AddActivity<VersionedFilterActivityV2>();
+            });
+            builder.Configure(options =>
+            {
+                options.Versioning = new DurableTaskWorkerOptions.VersioningOptions
+                {
+                    Version = "v1",
+                    MatchStrategy = DurableTaskWorkerOptions.VersionMatchStrategy.CurrentOrOlder,
+                };
+            });
+            builder.UseWorkItemFilters();
+        });
+
+        // Act
+        ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsMonitor<DurableTaskWorkerWorkItemFilters> filtersMonitor =
+            provider.GetRequiredService<IOptionsMonitor<DurableTaskWorkerWorkItemFilters>>();
+        DurableTaskWorkerWorkItemFilters actual = filtersMonitor.Get("test");
+
+        // Assert — v2 is dropped because it is newer than the worker version.
+        actual.Orchestrations.Should().ContainSingle();
+        actual.Orchestrations[0].Name.Should().Be("FilterWorkflow");
+        actual.Orchestrations[0].Versions.Should().BeEquivalentTo(["v1"]);
+        actual.Activities.Should().ContainSingle();
+        actual.Activities[0].Name.Should().Be("FilterActivity");
+        actual.Activities[0].Versions.Should().BeEquivalentTo(["v1"]);
+    }
+
+    [Fact]
+    public void WorkItemFilters_CurrentOrOlder_KeepsVersionsEqualToOrOlderThanWorkerVersion()
+    {
+        // Arrange — register v1 and v2 with CurrentOrOlder at worker version "v2". Both are <= v2, so
+        // both should survive the filter.
+        ServiceCollection services = new();
+        services.AddDurableTaskWorker("test", builder =>
+        {
+            builder.AddTasks(registry =>
+            {
+                registry.AddOrchestrator<VersionedFilterWorkflowV1>();
+                registry.AddOrchestrator<VersionedFilterWorkflowV2>();
+                registry.AddActivity<VersionedFilterActivityV1>();
+                registry.AddActivity<VersionedFilterActivityV2>();
+            });
+            builder.Configure(options =>
+            {
+                options.Versioning = new DurableTaskWorkerOptions.VersioningOptions
+                {
+                    Version = "v2",
+                    MatchStrategy = DurableTaskWorkerOptions.VersionMatchStrategy.CurrentOrOlder,
+                };
+            });
+            builder.UseWorkItemFilters();
+        });
+
+        // Act
+        ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsMonitor<DurableTaskWorkerWorkItemFilters> filtersMonitor =
+            provider.GetRequiredService<IOptionsMonitor<DurableTaskWorkerWorkItemFilters>>();
+        DurableTaskWorkerWorkItemFilters actual = filtersMonitor.Get("test");
+
+        // Assert
+        actual.Orchestrations.Should().ContainSingle();
+        actual.Orchestrations[0].Name.Should().Be("FilterWorkflow");
+        actual.Orchestrations[0].Versions.Should().BeEquivalentTo(["v1", "v2"]);
+        actual.Activities.Should().ContainSingle();
+        actual.Activities[0].Name.Should().Be("FilterActivity");
+        actual.Activities[0].Versions.Should().BeEquivalentTo(["v1", "v2"]);
+    }
+
+    [Fact]
+    public void WorkItemFilters_CurrentOrOlder_RetainsUnversionedAlongsideOlderVersions()
+    {
+        // Arrange — register an unversioned, v1, and v2 registration under the same logical name with
+        // CurrentOrOlder at worker version "v1". The unversioned ("") entry is always older than any
+        // defined worker version, so it stays as a fallback; v2 is dropped as newer.
+        ServiceCollection services = new();
+        services.AddDurableTaskWorker("test", builder =>
+        {
+            builder.AddTasks(registry =>
+            {
+                registry.AddOrchestrator<UnversionedFilterWorkflow>();
+                registry.AddOrchestrator<VersionedFilterWorkflowV1>();
+                registry.AddOrchestrator<VersionedFilterWorkflowV2>();
+                registry.AddActivity<UnversionedFilterActivity>();
+                registry.AddActivity<VersionedFilterActivityV1>();
+                registry.AddActivity<VersionedFilterActivityV2>();
+            });
+            builder.Configure(options =>
+            {
+                options.Versioning = new DurableTaskWorkerOptions.VersioningOptions
+                {
+                    Version = "v1",
+                    MatchStrategy = DurableTaskWorkerOptions.VersionMatchStrategy.CurrentOrOlder,
+                };
+            });
+            builder.UseWorkItemFilters();
+        });
+
+        // Act
+        ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsMonitor<DurableTaskWorkerWorkItemFilters> filtersMonitor =
+            provider.GetRequiredService<IOptionsMonitor<DurableTaskWorkerWorkItemFilters>>();
+        DurableTaskWorkerWorkItemFilters actual = filtersMonitor.Get("test");
+
+        // Assert — "" (unversioned) and v1 are retained, v2 is filtered out.
+        actual.Orchestrations.Should().ContainSingle();
+        actual.Orchestrations[0].Name.Should().Be("FilterWorkflow");
+        actual.Orchestrations[0].Versions.Should().BeEquivalentTo([string.Empty, "v1"]);
+        actual.Activities.Should().ContainSingle();
+        actual.Activities[0].Name.Should().Be("FilterActivity");
+        actual.Activities[0].Versions.Should().BeEquivalentTo([string.Empty, "v1"]);
+    }
+
+    [Fact]
     public void WorkItemFilters_DefaultNullWithVersioningNone_WhenExplicitlyOptedIn()
     {
         // Arrange

--- a/test/Worker/Core.Tests/DurableTaskFactoryVersioningTests.cs
+++ b/test/Worker/Core.Tests/DurableTaskFactoryVersioningTests.cs
@@ -153,6 +153,45 @@ public class DurableTaskFactoryVersioningTests
         orchestrator.Should().BeOfType<UnversionedInvoiceWorkflow>();
     }
 
+    [Fact]
+    public void TryCreateActivity_UnversionedAndMultiVersionRegistrations_ServesEveryDeclaredVersion()
+    {
+        // Arrange — an "original" unversioned activity registered with a bare [DurableTask] attribute
+        // coexists with a newer class that declares multiple versions in one attribute
+        // ([DurableTask("InvoiceActivity", Version = "1.0.0,1.1.0")]). All three logical endpoints —
+        // the unversioned original plus each comma-separated version — must be independently servable.
+        DurableTaskRegistry registry = new();
+        registry.AddActivity<OriginalInvoiceActivity>();
+        registry.AddActivity<MultiVersionInvoiceActivity>();
+        IVersionedTaskFactory factory = (IVersionedTaskFactory)registry.BuildFactory();
+
+        // Act
+        bool unversionedFound = factory.TryCreateActivity(
+            new TaskName("InvoiceActivity"),
+            default,
+            Mock.Of<IServiceProvider>(),
+            out ITaskActivity? unversionedActivity);
+        bool v1Found = factory.TryCreateActivity(
+            new TaskName("InvoiceActivity"),
+            new TaskVersion("1.0.0"),
+            Mock.Of<IServiceProvider>(),
+            out ITaskActivity? v1Activity);
+        bool v11Found = factory.TryCreateActivity(
+            new TaskName("InvoiceActivity"),
+            new TaskVersion("1.1.0"),
+            Mock.Of<IServiceProvider>(),
+            out ITaskActivity? v11Activity);
+
+        // Assert — the unversioned request resolves to the original, and each declared version resolves
+        // to the multi-version class.
+        unversionedFound.Should().BeTrue();
+        unversionedActivity.Should().BeOfType<OriginalInvoiceActivity>();
+        v1Found.Should().BeTrue();
+        v1Activity.Should().BeOfType<MultiVersionInvoiceActivity>();
+        v11Found.Should().BeTrue();
+        v11Activity.Should().BeOfType<MultiVersionInvoiceActivity>();
+    }
+
     [DurableTask("InvoiceWorkflow", Version = "v1")]
     sealed class InvoiceWorkflowV1 : TaskOrchestrator<string, string>
     {
@@ -172,5 +211,19 @@ public class DurableTaskFactoryVersioningTests
     {
         public override Task<string> RunAsync(TaskOrchestrationContext context, string input)
             => Task.FromResult("unversioned");
+    }
+
+    [DurableTask("InvoiceActivity")]
+    sealed class OriginalInvoiceActivity : TaskActivity<string, string>
+    {
+        public override Task<string> RunAsync(TaskActivityContext context, string input)
+            => Task.FromResult("original");
+    }
+
+    [DurableTask("InvoiceActivity", Version = "1.0.0,1.1.0")]
+    sealed class MultiVersionInvoiceActivity : TaskActivity<string, string>
+    {
+        public override Task<string> RunAsync(TaskActivityContext context, string input)
+            => Task.FromResult(context.Version);
     }
 }


### PR DESCRIPTION
# Summary
## What changed?
The Version property now accepts a comma-separated list (e.g. "v1,v2"), registering the type under each declared version and emitting call helpers that take a required 'version' parameter validated against the declared set. Single-version and unversioned behavior is unchanged.


## Why is this change needed?
This allows customers to specify multiple versions of a single orchestration/activity without having to duplicate the code in their own codebase.

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): Copilot
- AI-assisted areas/files: Mostly tests, some of the parsing logic
- What you changed after AI output: Filtering logic

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1. App with multiple versions declared
  2. Filters had correct versions
  3. Correct app served correct versions
- Evidence (optional):

---

# Notes for reviewers
- N/A
