### PR TITLE
Set default large payload offloading threshold to 256 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Change the default large payload externalization threshold (`LargePayloadStorageOptions.ThresholdBytes`) from 900,000 bytes to 256 KiB (262,144 bytes)
 
 
 ## v1.25.0-preview.2

--- a/src/Extensions/AzureBlobPayloads/Options/LargePayloadStorageOptions.cs
+++ b/src/Extensions/AzureBlobPayloads/Options/LargePayloadStorageOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DurableTask;
 /// </summary>
 public sealed class LargePayloadStorageOptions
 {
-    int thresholdBytes = 900_000;
+    int thresholdBytes = 256 * 1024;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LargePayloadStorageOptions"/> class.
@@ -60,7 +60,7 @@ public sealed class LargePayloadStorageOptions
     }
 
     /// <summary>
-    /// Gets or sets the threshold in bytes at which payloads are externalized. Default is 900_000 bytes.
+    /// Gets or sets the threshold in bytes at which payloads are externalized. Default is 256 KiB (262,144 bytes).
     /// Value must not exceed 1 MiB (1,048,576 bytes).
     /// </summary>
     public int ThresholdBytes

--- a/test/Grpc.IntegrationTests/LargePayloadStorageOptionsTests.cs
+++ b/test/Grpc.IntegrationTests/LargePayloadStorageOptionsTests.cs
@@ -29,13 +29,13 @@ public class LargePayloadStorageOptionsTests
     }
 
     [Fact]
-    public void ThresholdBytes_DefaultValue_Is900000()
+    public void ThresholdBytes_DefaultValue_Is256KiB()
     {
         // Arrange & Act
         LargePayloadStorageOptions options = new();
 
         // Assert
-        Assert.Equal(900_000, options.ThresholdBytes);
+        Assert.Equal(256 * 1024, options.ThresholdBytes);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Changes the default large payload externalization (offloading) threshold in
`LargePayloadStorageOptions.ThresholdBytes` from **900,000 bytes** to
**256 KiB (262,144 bytes)**.

When the Azure Blob Payloads extension is enabled, payloads whose serialized
size is `>= ThresholdBytes` are stored out-of-band in Azure Blob Storage instead
of being sent inline. This lowers the default threshold so more payloads are
offloaded by default.

> **Note:** The Azure Blob Payloads (large payload offloading) extension is still
> a **preview** feature (shipping in the `1.25.0-preview.*` line), so its defaults
> and API surface may change before GA.

## Behavioral change ⚠️
This is an intentional behavioral change. Callers who enabled blob payload
offloading **without** explicitly setting `ThresholdBytes` will now externalize
payloads in the 262,144–899,999 byte range that previously stayed inline (adding
blob I/O, a storage dependency, and cost/latency for those payloads). As this is
a preview feature, the default is still subject to change pre-GA.

**Migration:** to keep the previous behavior, set `ThresholdBytes = 900_000`
explicitly.