### PR TITLE
Enforce maximum length in entity instance ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Change the default large payload externalization threshold (`LargePayloadStorageOptions.ThresholdBytes`) from 900,000 bytes to 256 KiB (262,144 bytes)
+- **BREAKING**: `EntityInstanceId` now throws if its string form exceeds 100 characters (backend limit). Migration: shorten entity name/key; if entities already exist with overlong IDs, use the truncated 100-character value when addressing them.
 
 
 ## v1.25.0-preview.2

--- a/src/Abstractions/Entities/EntityInstanceId.cs
+++ b/src/Abstractions/Entities/EntityInstanceId.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DurableTask.Entities;
 [JsonConverter(typeof(EntityInstanceId.JsonConverter))]
 public readonly record struct EntityInstanceId
 {
+    const int MaxInstanceIdLength = 100;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityInstanceId"/> struct.
     /// </summary>
@@ -28,6 +30,12 @@ public readonly record struct EntityInstanceId
         Check.NotNull(key);
         this.Name = name.ToLowerInvariant();
         this.Key = key;
+
+        int length = this.ToString().Length;
+        if (length > MaxInstanceIdLength)
+        {
+            throw new ArgumentException($"entity instance ids may not exceed 100 characters in length, actual length {length}.");
+        }
     }
 
     /// <summary>

--- a/test/Abstractions.Tests/Entities/EntityInstanceIdTests.cs
+++ b/test/Abstractions.Tests/Entities/EntityInstanceIdTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.DurableTask.Abstractions.Tests.Entities;
+
+public class EntityInstanceIdTests
+{
+    [Fact]
+    public void TestValidEntityInstanceId()
+    {
+        var entityId = new EntityInstanceId("entity", "key1");
+        Assert.Equal("@entity@key1", entityId.ToString());
+    }
+
+    [Fact]
+    public void TestEntityNameLowercased()
+    {
+        var entityId = new EntityInstanceId("Entity", "key1");
+        Assert.Equal("entity", entityId.Name);
+        Assert.Equal("@entity@key1", entityId.ToString());
+    }
+
+    [Fact]
+    public void TestEntityNameWithAtSymbolThrows()
+    {
+        Assert.Throws<ArgumentException>(() => new EntityInstanceId("entity@name", "key1"));
+    }
+
+    [Fact]
+    public void TestEntityInstanceIdExceedsMaxLengthThrows()
+    {
+        string longName = new string('a', 50);
+        string longKey = new string('b', 51);
+        Assert.Throws<ArgumentException>(() => new EntityInstanceId(longName, longKey));
+    }
+
+    [Fact]
+    public void TestEntityInstanceIdEqualsMaxLength()
+    {
+        string longName = new string('a', 49);
+        string longKey = new string('b', 49);
+        var entityId = new EntityInstanceId(longName, longKey);
+        Assert.Equal($"@{longName}@{longKey}", entityId.ToString());
+    }
+
+    [Fact]
+    public void TestFromStringValid()
+    {
+        var entityId = EntityInstanceId.FromString("@entity@key1");
+        Assert.Equal("entity", entityId.Name);
+        Assert.Equal("key1", entityId.Key);
+    }
+
+    [Fact]
+    public void TestFromStringInvalidThrows()
+    {
+        Assert.Throws<ArgumentException>(() => EntityInstanceId.FromString("invalid"));
+        Assert.Throws<ArgumentException>(() => EntityInstanceId.FromString("@entitykey1"));
+        Assert.Throws<ArgumentException>(() => EntityInstanceId.FromString("@@key1"));
+        Assert.Throws<ArgumentException>(() => EntityInstanceId.FromString($"@entity@{new string('a', 100)}"));
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
- Enforce maximum length of entity instances

## Why is this change needed?
- The backend expects a maximum length of 100 characters for an Entity's ID. This change enforces that at the SDK level, allowing for an opt-in breaking change to eliminate bad behavior on the backend.

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [x] Breaking change?
    - Impact: Users will no longer be able to specify Entity Instance Ids (combination of name and key) longer than 100 characters
    - Migration guidance: Use smaller name/key combos for Entities. If entities already exist with IDs that are too long, you must use the truncated value to access them: `entityInstanceId.ToString().Take(100)`
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [x] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed

---

# Notes for reviewers
- N/A
