### PR TITLE
test(InProcessTestHost): external-event + durable-timer timeout coverage (relates to #713)

### DIFF
--- a/test/InProcessTestHost.Tests/ExternalEventTests.cs
+++ b/test/InProcessTestHost.Tests/ExternalEventTests.cs
@@ -40,11 +40,12 @@ public class ExternalEventTests
 
         string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
 
-        // Give the instance a moment to start before raising the event.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+
+        // Wait for the orchestration to start before raising the event.
+        await host.Client.WaitForInstanceStartAsync(instanceId, cts.Token);
         await host.Client.RaiseEventAsync(instanceId, "MyEvent", "hello");
 
-        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
         OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
             instanceId, getInputsAndOutputs: true, cts.Token);
 
@@ -65,7 +66,8 @@ public class ExternalEventTests
             tasks.AddOrchestratorFunc<string>(orchestratorName, async ctx =>
             {
                 using CancellationTokenSource timerCts = new();
-                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent");
+                using CancellationTokenSource eventCts = new();
+                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent", eventCts.Token);
                 Task timerTask = ctx.CreateTimer(TimeSpan.FromMinutes(5), timerCts.Token);
                 Task winner = await Task.WhenAny(eventTask, timerTask);
                 if (winner == eventTask)
@@ -75,17 +77,21 @@ public class ExternalEventTests
                     return await eventTask;
                 }
 
+                // Cancel the losing external-event wait, mirroring the SDK's WaitForExternalEvent(name, timeout) helper.
+                eventCts.Cancel();
                 return "timeout";
             });
         });
 
         string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
 
-        // Raise the event shortly after start, while the 5-minute timer is still pending.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+
+        // Wait for the orchestration to start (and begin waiting on the event) before raising it,
+        // while the 5-minute timer is still pending.
+        await host.Client.WaitForInstanceStartAsync(instanceId, cts.Token);
         await host.Client.RaiseEventAsync(instanceId, "MyEvent", "event");
 
-        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
         OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
             instanceId, getInputsAndOutputs: true, cts.Token);
 
@@ -105,7 +111,8 @@ public class ExternalEventTests
             tasks.AddOrchestratorFunc<string>(orchestratorName, async ctx =>
             {
                 using CancellationTokenSource timerCts = new();
-                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent");
+                using CancellationTokenSource eventCts = new();
+                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent", eventCts.Token);
                 Task timerTask = ctx.CreateTimer(TimeSpan.FromSeconds(2), timerCts.Token);
                 Task winner = await Task.WhenAny(eventTask, timerTask);
                 if (winner == eventTask)
@@ -114,6 +121,8 @@ public class ExternalEventTests
                     return await eventTask;
                 }
 
+                // The timer won: cancel the losing external-event wait so no wait is left outstanding.
+                eventCts.Cancel();
                 return "timeout";
             });
         });

--- a/test/InProcessTestHost.Tests/ExternalEventTests.cs
+++ b/test/InProcessTestHost.Tests/ExternalEventTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Testing;
+using Microsoft.DurableTask.Worker;
+using Xunit;
+
+namespace InProcessTestHost.Tests;
+
+/// <summary>
+/// Tests for external event delivery via <see cref="TaskOrchestrationContext.WaitForExternalEvent{T}(string, CancellationToken)"/>,
+/// including the canonical "wait for an event with a timeout" pattern built on <see cref="Task.WhenAny(Task[])"/> and a
+/// durable timer.
+/// </summary>
+/// <remarks>
+/// A durable timer keeps an orchestration in the "Running" state until it expires or is cancelled. As documented on
+/// <see cref="TaskOrchestrationContext.CreateTimer(TimeSpan, System.Threading.CancellationToken)"/>, all durable timers
+/// must either expire or be cancelled via their <see cref="System.Threading.CancellationToken"/> before the orchestrator
+/// can complete. When a timer is used only as a timeout (for example, with <see cref="Task.WhenAny(Task[])"/>), cancel it
+/// once the other task wins so the orchestration completes promptly instead of waiting for the timer to fire. See
+/// https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-timers.
+/// </remarks>
+public class ExternalEventTests
+{
+    [Fact]
+    // A plain external event is delivered to a waiting orchestration and its payload is returned.
+    public async Task WaitForExternalEvent_IsDelivered()
+    {
+        const string orchestratorName = "WaitForEventOrchestrator";
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<string>(orchestratorName, async ctx =>
+            {
+                return await ctx.WaitForExternalEvent<string>("MyEvent");
+            });
+        });
+
+        string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
+
+        // Give the instance a moment to start before raising the event.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        await host.Client.RaiseEventAsync(instanceId, "MyEvent", "hello");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+        OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
+            instanceId, getInputsAndOutputs: true, cts.Token);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+        Assert.Equal("hello", metadata.ReadOutputAs<string>());
+    }
+
+    [Fact]
+    // Canonical wait-for-event-with-timeout: when the event wins the Task.WhenAny, cancelling the durable timer lets the
+    // orchestration complete promptly, well before the 5-minute timer would fire.
+    public async Task WaitForExternalEvent_WithTimeout_EventWins()
+    {
+        const string orchestratorName = "EventWithTimeoutOrchestrator";
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<string>(orchestratorName, async ctx =>
+            {
+                using CancellationTokenSource timerCts = new();
+                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent");
+                Task timerTask = ctx.CreateTimer(TimeSpan.FromMinutes(5), timerCts.Token);
+                Task winner = await Task.WhenAny(eventTask, timerTask);
+                if (winner == eventTask)
+                {
+                    // Cancel the still-pending durable timer so the orchestration can complete now.
+                    timerCts.Cancel();
+                    return await eventTask;
+                }
+
+                return "timeout";
+            });
+        });
+
+        string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
+
+        // Raise the event shortly after start, while the 5-minute timer is still pending.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        await host.Client.RaiseEventAsync(instanceId, "MyEvent", "event");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+        OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
+            instanceId, getInputsAndOutputs: true, cts.Token);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+        Assert.Equal("event", metadata.ReadOutputAs<string>());
+    }
+
+    [Fact]
+    // Same pattern with a short timer and no event raised: the timer wins and the orchestration returns "timeout".
+    public async Task WaitForExternalEvent_WithTimeout_TimerWins()
+    {
+        const string orchestratorName = "TimeoutWinsOrchestrator";
+
+        await using DurableTaskTestHost host = await DurableTaskTestHost.StartAsync(tasks =>
+        {
+            tasks.AddOrchestratorFunc<string>(orchestratorName, async ctx =>
+            {
+                using CancellationTokenSource timerCts = new();
+                Task<string> eventTask = ctx.WaitForExternalEvent<string>("MyEvent");
+                Task timerTask = ctx.CreateTimer(TimeSpan.FromSeconds(2), timerCts.Token);
+                Task winner = await Task.WhenAny(eventTask, timerTask);
+                if (winner == eventTask)
+                {
+                    timerCts.Cancel();
+                    return await eventTask;
+                }
+
+                return "timeout";
+            });
+        });
+
+        string instanceId = await host.Client.ScheduleNewOrchestrationInstanceAsync(orchestratorName);
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+        OrchestrationMetadata metadata = await host.Client.WaitForInstanceCompletionAsync(
+            instanceId, getInputsAndOutputs: true, cts.Token);
+
+        Assert.NotNull(metadata);
+        Assert.Equal(OrchestrationRuntimeStatus.Completed, metadata.RuntimeStatus);
+        Assert.Equal("timeout", metadata.ReadOutputAs<string>());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `InProcessTestHost.Tests` coverage for external events (`TaskOrchestrationContext.WaitForExternalEvent<T>`), including the canonical `Task.WhenAny(eventTask, timerTask)` "wait for an event with a timeout" pattern. This fills a gap in external-event test coverage and documents the correct durable-timer cancellation semantics.

Relates to #713.

## Background — #713 is expected behavior

#713 reports that an orchestration awaiting `Task.WhenAny(externalEventTask, timerTask)` appears to "hang" after the external event is raised, while the durable timer is still pending.

A verification-only investigation shows the external event **is** delivered and wins the `WhenAny`. The orchestration does not complete because a **durable timer that was created but never cancelled remains outstanding**. This is standard Durable Task Framework behavior, already documented on `TaskOrchestrationContext.CreateTimer`:

> All durable timers created using this method must either expire or be cancelled using the `cancellationToken` before the orchestrator can complete. If unexpired timers exist when the orchestration completes, it will remain in the "Running" state until the scheduled expiration time.

and on [Microsoft Learn (durable-functions-timers)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-timers): the framework doesn't change an orchestration's status to *Completed* until all outstanding tasks, including durable timer tasks, are either completed or canceled.

The issue's repro uses a 5-minute timer and never cancels it, so the instance stays `Running` until the timer would fire (~5 min) — which looks like a hang inside a short test. This is **not** a lost/dropped event and **not** an InProcessTestHost-specific defect: the worker forwards the `CancellationToken` straight into `DurableTask.Core` (`TaskOrchestrationContextWrapper.CreateTimer`), the same path all backends use.

## What this PR adds

`test/InProcessTestHost.Tests/ExternalEventTests.cs` with three fast, deterministic tests:

1. **`WaitForExternalEvent_IsDelivered`** — a plain external event is delivered to a waiting orchestration and its payload is returned (fills the missing plain external-event coverage).
2. **`WaitForExternalEvent_WithTimeout_EventWins`** — the canonical pattern: a 5-minute timer under `Task.WhenAny`; when the event wins, the timer's `CancellationTokenSource` is cancelled so the orchestration completes promptly (well under the timer) with the event payload.
3. **`WaitForExternalEvent_WithTimeout_TimerWins`** — same shape with a short 2 s timer and no event raised; the timer wins and the orchestration returns `"timeout"`.

Each test uses a 30 s completion `CancellationTokenSource` purely as a safety guard; all complete in a few seconds.

## Notes

- **No runtime/product code changes.** The `CreateTimer` cancellation/completion semantics are already documented on the public API, so this PR only adds tests (with a summary comment in the test file pointing at those docs). It does not change observable behavior.
- Does **not** close #713 — filed as *Relates to*, since the reported behavior is by design; these tests document the correct usage pattern.

## Validation

`dotnet test test/InProcessTestHost.Tests/InProcessTestHost.Tests.csproj -c Debug -f net10.0` → **22 passed, 0 failed** (3 new tests + 19 existing).