### PR TITLE
Report non-secret external payload store URI on worker handshake

### DIFF
--- a/src/Extensions/AzureBlobPayloads/DependencyInjection/DurableTaskWorkerBuilderExtensions.AzureBlobPayloads.cs
+++ b/src/Extensions/AzureBlobPayloads/DependencyInjection/DurableTaskWorkerBuilderExtensions.AzureBlobPayloads.cs
@@ -80,6 +80,7 @@ public static class DurableTaskWorkerBuilderExtensionsAzureBlobPayloads
                 }
 
                 opt.Capabilities.Add(P.WorkerCapability.LargePayloads);
+                opt.ExternalPayloadStoreUri = store.ExternalPayloadStoreBaseUri?.ToString();
             });
 
         return builder;

--- a/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
+++ b/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
@@ -68,6 +68,15 @@ public sealed class BlobPayloadStore : PayloadStore
     }
 
     /// <inheritdoc/>
+    public override Uri? ExternalPayloadStoreBaseUri => new BlobUriBuilder(this.containerClient.Uri)
+    {
+        BlobContainerName = string.Empty,
+        BlobName = string.Empty,
+        Sas = null,
+        Query = string.Empty,
+    }.ToUri();
+
+    /// <inheritdoc/>
     public override async Task<string> UploadAsync(string payLoad, CancellationToken cancellationToken)
     {
         // One blob per payload using GUID-based name for uniqueness (stable across retries)

--- a/src/Extensions/AzureBlobPayloads/PayloadStore/PayloadStore.cs
+++ b/src/Extensions/AzureBlobPayloads/PayloadStore/PayloadStore.cs
@@ -9,6 +9,12 @@ namespace Microsoft.DurableTask;
 public abstract class PayloadStore
 {
     /// <summary>
+    /// Gets the non-secret base URI (scheme+host[+account path for emulator]) of the external payload store, or
+    /// <c>null</c> if not applicable. Never contains a secret/SAS/key.
+    /// </summary>
+    public virtual Uri? ExternalPayloadStoreBaseUri => null;
+
+    /// <summary>
     /// Uploads a payload and returns an opaque reference token that can be embedded in orchestration messages.
     /// </summary>
     /// <param name="payLoad">The payload.</param>

--- a/src/Grpc/orchestrator_service.proto
+++ b/src/Grpc/orchestrator_service.proto
@@ -832,6 +832,10 @@ message GetWorkItemsRequest {
 
     repeated WorkerCapability capabilities = 10;
     WorkItemFilters workItemFilters = 11;
+
+    // Non-secret base URI of the external payload store (e.g. "https://<account>.blob.core.windows.net/") where this
+    // worker externalizes large payloads. Empty when no external payload store is configured. Never contains a secret.
+    string external_payload_store_uri = 12 [json_name = "externalPayloadStoreUri"];
 }
 
 enum WorkerCapability {

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -333,6 +333,7 @@ sealed partial class GrpcDurableTaskWorker
                         workerOptions.Concurrency.MaximumConcurrentEntityWorkItems,
                     Capabilities = { this.worker.grpcOptions.Capabilities },
                     WorkItemFilters = this.worker.workItemFilters?.ToGrpcWorkItemFilters(),
+                    ExternalPayloadStoreUri = this.worker.grpcOptions.ExternalPayloadStoreUri ?? string.Empty,
                 },
                 cancellationToken: cancellation);
         }

--- a/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs
@@ -45,6 +45,12 @@ public sealed class GrpcDurableTaskWorkerOptions : DurableTaskWorkerOptions
     public HashSet<P.WorkerCapability> Capabilities { get; } = new() { P.WorkerCapability.HistoryStreaming };
 
     /// <summary>
+    /// Gets or sets the non-secret external payload store base URI reported to the backend on the work-item
+    /// handshake. Empty/null when not using externalized payloads.
+    /// </summary>
+    public string? ExternalPayloadStoreUri { get; set; }
+
+    /// <summary>
     /// Gets or sets the maximum size of all actions in a complete orchestration work item chunk.
     /// The default value is 3.9MB. We leave some headroom to account for request size overhead.
     /// </summary>

--- a/test/Worker/Grpc.Tests/ExternalPayloadStoreUriTests.cs
+++ b/test/Worker/Grpc.Tests/ExternalPayloadStoreUriTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DurableTask.Worker.Grpc.Tests;
+
+/// <summary>
+/// Tests for the non-secret external payload store base URI that the worker reports on the work-item handshake.
+/// </summary>
+public class ExternalPayloadStoreUriTests
+{
+    // Well-known Azurite development storage account key. Used here only to prove it is never leaked into the base URI.
+    const string DevelopmentAccountKey =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    [Fact]
+    public void ExternalPayloadStoreBaseUri_EmulatorConnectionString_ReturnsAccountBaseUriWithoutContainerOrSas()
+    {
+        // Arrange
+        LargePayloadStorageOptions options = new("UseDevelopmentStorage=true")
+        {
+            ContainerName = "my-payloads",
+        };
+        BlobPayloadStore store = new(options);
+
+        // Act
+        Uri? baseUri = store.ExternalPayloadStoreBaseUri;
+
+        // Assert
+        baseUri.Should().NotBeNull();
+        baseUri!.AbsoluteUri.TrimEnd('/').Should().Be("http://127.0.0.1:10000/devstoreaccount1");
+        baseUri.Query.Should().BeEmpty();
+        baseUri.AbsoluteUri.Should().NotContain("my-payloads");
+    }
+
+    [Fact]
+    public void ExternalPayloadStoreBaseUri_ConnectionStringWithAccountKey_ReturnsAccountBaseUriAndNeverLeaksKey()
+    {
+        // Arrange
+        LargePayloadStorageOptions options = new(
+            $"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey={DevelopmentAccountKey};EndpointSuffix=core.windows.net")
+        {
+            ContainerName = "my-payloads",
+        };
+        BlobPayloadStore store = new(options);
+
+        // Act
+        Uri? baseUri = store.ExternalPayloadStoreBaseUri;
+
+        // Assert
+        baseUri.Should().Be(new Uri("https://myaccount.blob.core.windows.net/"));
+        baseUri!.Query.Should().BeEmpty();
+        baseUri.AbsoluteUri.Should().NotContain(DevelopmentAccountKey);
+        baseUri.AbsoluteUri.Should().NotContain("my-payloads");
+    }
+
+    [Fact]
+    public void ExternalPayloadStoreBaseUri_AccountUriAndCredential_ReturnsAccountBaseUriWithoutContainerOrSas()
+    {
+        // Arrange
+        LargePayloadStorageOptions options = new(
+            new Uri("https://myaccount.blob.core.windows.net"),
+            new FakeTokenCredential())
+        {
+            ContainerName = "my-payloads",
+        };
+        BlobPayloadStore store = new(options);
+
+        // Act
+        Uri? baseUri = store.ExternalPayloadStoreBaseUri;
+
+        // Assert
+        baseUri.Should().Be(new Uri("https://myaccount.blob.core.windows.net/"));
+        baseUri!.Query.Should().BeEmpty();
+        baseUri.AbsoluteUri.Should().NotContain("my-payloads");
+    }
+
+    [Fact]
+    public void UseExternalizedPayloads_SetsExternalPayloadStoreUriFromStore()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        DefaultDurableTaskWorkerBuilder builder = new(null, services);
+        builder.UseGrpc(GrpcChannel.ForAddress("http://localhost:9001"));
+        builder.UseExternalizedPayloads(opt =>
+        {
+            opt.ContainerName = "my-payloads";
+            opt.ConnectionString = "UseDevelopmentStorage=true";
+        });
+
+        // Act
+        IServiceProvider provider = services.BuildServiceProvider();
+        GrpcDurableTaskWorkerOptions options = provider.GetOptions<GrpcDurableTaskWorkerOptions>();
+
+        // Assert
+        options.ExternalPayloadStoreUri.Should().NotBeNullOrEmpty();
+        options.ExternalPayloadStoreUri!.TrimEnd('/').Should().Be("http://127.0.0.1:10000/devstoreaccount1");
+    }
+
+    sealed class FakeTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new("fake-token", DateTimeOffset.MaxValue);
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(this.GetToken(requestContext, cancellationToken));
+    }
+}


### PR DESCRIPTION
## Summary

DTS externalizes large orchestration payloads to Azure Blob Storage, persisting only an opaque token `blob:v1:<container>:<blobName>` (no storage account) in the backend DB. To let the DTS dashboard render those payloads by reading the blob directly with the signed-in user's own AAD token, the backend needs the worker's **non-secret** storage account base URI.

The worker already configures the storage account (`LargePayloadStorageOptions`) and advertises `WorkerCapability.LargePayloads` on its `GetWorkItems` handshake. This PR makes the worker also report its non-secret account base URI on that handshake, via a new proto field `external_payload_store_uri` (field number 12) on `GetWorkItemsRequest`.

> This is an **independent** feature and is **not** related to the auto-purge PR #758 — it branches from `main` and does not contain any auto-purge code.

## Changes

1. **Proto** (`src/Grpc/orchestrator_service.proto`): add `string external_payload_store_uri = 12` to `GetWorkItemsRequest`. C# stubs are generated at build time by `Grpc.Tools` (no checked-in stubs), yielding a `GetWorkItemsRequest.ExternalPayloadStoreUri` property.
2. **`PayloadStore`** (abstract base): add `virtual Uri? ExternalPayloadStoreBaseUri => null`.
3. **`BlobPayloadStore`**: override it to return the storage **account** base URI derived from `this.containerClient.Uri` using `BlobUriBuilder`, stripping the container, blob, SAS and query. This never contains a secret/SAS/key — even when configured from a connection string (e.g. `https://acct.blob.core.windows.net/`, or `http://127.0.0.1:10000/devstoreaccount1` for Azurite).
4. **`GrpcDurableTaskWorkerOptions`**: add `string? ExternalPayloadStoreUri` next to `Capabilities`.
5. **AzureBlobPayloads worker registration**: in the same `PostConfigure` that adds `WorkerCapability.LargePayloads`, set `opt.ExternalPayloadStoreUri = store.ExternalPayloadStoreBaseUri?.ToString()`.
6. **`GrpcDurableTaskWorker.Processor`**: send `ExternalPayloadStoreUri` on the `GetWorkItemsRequest` handshake.

## Tests

Added `test/Worker/Grpc.Tests/ExternalPayloadStoreUriTests.cs` (that project already references `AzureBlobPayloads`, keeping the change minimal — no new test project/solution wiring):

- `BlobPayloadStore.ExternalPayloadStoreBaseUri` returns the account base URI with **no** query/SAS for a connection-string store (`UseDevelopmentStorage=true`), a connection-string store with an account key (asserts the key is never leaked), and an `AccountUri` + credential store.
- The worker-options plumbing sets `GrpcDurableTaskWorkerOptions.ExternalPayloadStoreUri` from the store.

## Validation

- `dotnet build Microsoft.DurableTask.sln` → **0 errors**.
- `Worker.Grpc.Tests` → **141 passed, 0 failed** (137 existing + 4 new).

## Compatibility

Adding a new optional proto field is backward-compatible; all existing field numbers are preserved.