### PR TITLE
Make externalized large-payload token self-describing (token v2)

### DIFF
--- a/samples/LargePayloadConsoleApp/Program.cs
+++ b/samples/LargePayloadConsoleApp/Program.cs
@@ -129,7 +129,8 @@ builder.Services.AddDurableTaskWorker(b =>
                 return string.Empty;
             }
 
-            if (value.StartsWith("blob:v1:", StringComparison.Ordinal))
+            if (value.StartsWith("blob:v1:", StringComparison.Ordinal)
+                || value.StartsWith("blob:v2:", StringComparison.Ordinal))
             {
                 throw new InvalidOperationException("Activity received a payload token instead of raw input.");
             }

--- a/src/Extensions/AzureBlobPayloads/AzureBlobPayloads.csproj
+++ b/src/Extensions/AzureBlobPayloads/AzureBlobPayloads.csproj
@@ -26,4 +26,8 @@
   <ItemGroup>
     <SharedSection Include="Core" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DurableTask.Grpc.IntegrationTests" Key="$(StrongNamePublicKey)" />
+  </ItemGroup>
 </Project>

--- a/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
+++ b/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
@@ -13,11 +13,14 @@ namespace Microsoft.DurableTask;
 
 /// <summary>
 /// Azure Blob Storage implementation of <see cref="PayloadStore"/>.
-/// Stores payloads as blobs and returns opaque tokens in the form "blob:v1:&lt;container&gt;:&lt;blobName&gt;".
+/// Stores payloads as blobs and returns self-describing opaque tokens in the form
+/// "blob:v2:&lt;fullBlobUrl&gt;", where the URL is the blob's absolute URI including the storage account.
+/// Legacy "blob:v1:&lt;container&gt;:&lt;blobName&gt;" tokens are still recognized for read back-compatibility.
 /// </summary>
 public sealed class BlobPayloadStore : PayloadStore
 {
-    const string TokenPrefix = "blob:v1:";
+    const string TokenPrefixV1 = "blob:v1:";
+    const string TokenPrefixV2 = "blob:v2:";
     const string ContentEncodingGzip = "gzip";
     const int MaxRetryAttempts = 8;
     const int BaseDelayMs = 250;
@@ -25,6 +28,7 @@ public sealed class BlobPayloadStore : PayloadStore
     const int NetworkTimeoutMinutes = 2;
     readonly BlobContainerClient containerClient;
     readonly LargePayloadStorageOptions options;
+    readonly BlobClientOptions clientOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BlobPayloadStore"/> class.
@@ -48,7 +52,7 @@ public sealed class BlobPayloadStore : PayloadStore
                 nameof(options));
         }
 
-        BlobClientOptions clientOptions = new()
+        this.clientOptions = new BlobClientOptions
         {
             Retry =
             {
@@ -61,8 +65,8 @@ public sealed class BlobPayloadStore : PayloadStore
         };
 
         BlobServiceClient serviceClient = hasIdentityAuth
-            ? new BlobServiceClient(options.AccountUri, options.Credential, clientOptions)
-            : new BlobServiceClient(options.ConnectionString, clientOptions);
+            ? new BlobServiceClient(options.AccountUri, options.Credential, this.clientOptions)
+            : new BlobServiceClient(options.ConnectionString, this.clientOptions);
 
         this.containerClient = serviceClient.GetBlobContainerClient(options.ContainerName);
     }
@@ -105,44 +109,48 @@ public sealed class BlobPayloadStore : PayloadStore
             await blobStream.FlushAsync(cancellationToken);
         }
 
-        return EncodeToken(this.containerClient.Name, blobName);
+        return EncodeToken(blob.Uri);
     }
 
     /// <inheritdoc/>
     public override async Task<string> DownloadAsync(string token, CancellationToken cancellationToken)
     {
-        (string container, string name) = DecodeToken(token);
-        if (!string.Equals(container, this.containerClient.Name, StringComparison.Ordinal))
+        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) = DecodeToken(token);
+
+        if (!isV2)
         {
-            throw new ArgumentException("Token container does not match configured container.", nameof(token));
-        }
-
-        BlobClient blob = this.containerClient.GetBlobClient(name);
-
-        try
-        {
-            using BlobDownloadStreamingResult result = await blob.DownloadStreamingAsync(cancellationToken: cancellationToken);
-            Stream contentStream = result.Content;
-            bool isGzip = string.Equals(
-                result.Details.ContentEncoding, ContentEncodingGzip, StringComparison.OrdinalIgnoreCase);
-
-            if (isGzip)
+            // v1 tokens do not carry the account, so the payload is assumed to live in the configured container.
+            if (!string.Equals(container, this.containerClient.Name, StringComparison.Ordinal))
             {
-                using GZipStream decompressed = new(contentStream, CompressionMode.Decompress);
-                using StreamReader reader = new(decompressed, Encoding.UTF8);
-                return await ReadToEndAsync(reader, cancellationToken);
+                throw new ArgumentException("Token container does not match configured container.", nameof(token));
             }
 
-            using StreamReader uncompressedReader = new(contentStream, Encoding.UTF8);
-            return await ReadToEndAsync(uncompressedReader, cancellationToken);
+            return await DownloadFromBlobAsync(this.containerClient.GetBlobClient(name), cancellationToken);
         }
-        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+
+        // v2 tokens are self-describing: honor the account and container encoded in the token.
+        BlobClient blob;
+        if (this.IsConfiguredContainer(containerUri!))
+        {
+            // Same account and container as the configured store: reuse it (works with any auth mode).
+            blob = this.containerClient.GetBlobClient(name);
+        }
+        else if (this.options.Credential != null)
+        {
+            // The payload lives in a different account (e.g. the store was repointed). Identity auth can still
+            // read it as long as the credential has RBAC access to that account.
+            blob = new BlobClient(blobUri, this.options.Credential, this.clientOptions);
+        }
+        else
         {
             throw new PayloadStorageException(
-                $"The blob '{name}' was not found in container '{container}'. " +
-                "The payload may have been deleted or the container was never created.",
-                ex);
+                $"The externalized payload lives in a different storage account ('{containerUri}') than the " +
+                $"currently-configured payload store ('{this.containerClient.Uri}'). Cross-account payload reads " +
+                "require identity (AAD) authentication with access to both accounts; connection-string / " +
+                "account-key credentials are account-specific and cannot read another account.");
         }
+
+        return await DownloadFromBlobAsync(blob, cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -153,7 +161,60 @@ public sealed class BlobPayloadStore : PayloadStore
             return false;
         }
 
-        return value.StartsWith(TokenPrefix, StringComparison.Ordinal);
+        return value.StartsWith(TokenPrefixV1, StringComparison.Ordinal)
+            || value.StartsWith(TokenPrefixV2, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Encodes a self-describing v2 payload token from the blob's absolute URI. The token carries the full blob
+    /// URL (including the storage account) so readers can locate the payload without relying on the currently
+    /// configured store. <c>BlobClient.Uri</c> contains no SAS or account key and is safe to persist.
+    /// </summary>
+    /// <param name="blobUri">The absolute URI of the blob holding the payload.</param>
+    /// <returns>An opaque payload token in the form "blob:v2:&lt;fullBlobUrl&gt;".</returns>
+    internal static string EncodeToken(Uri blobUri) => $"{TokenPrefixV2}{blobUri}";
+
+    /// <summary>
+    /// Decodes a payload token. Supports self-describing v2 tokens ("blob:v2:&lt;fullBlobUrl&gt;") and legacy v1
+    /// tokens ("blob:v1:&lt;container&gt;:&lt;blobName&gt;"), the latter for read back-compatibility.
+    /// </summary>
+    /// <param name="token">The payload token to decode.</param>
+    /// <returns>
+    /// A tuple describing the token: whether it is v2, the container and blob names, and (for v2 only) the
+    /// absolute blob URI and its container-level URI.
+    /// </returns>
+    internal static (bool IsV2, string Container, string Name, Uri? BlobUri, Uri? ContainerUri) DecodeToken(
+        string token)
+    {
+        if (token.StartsWith(TokenPrefixV2, StringComparison.Ordinal))
+        {
+            string rest = token.Substring(TokenPrefixV2.Length);
+            if (!Uri.TryCreate(rest, UriKind.Absolute, out Uri? blobUri))
+            {
+                throw new ArgumentException("Invalid external payload token format.", nameof(token));
+            }
+
+            BlobUriBuilder builder = new(blobUri);
+            string container = builder.BlobContainerName;
+            string name = builder.BlobName;
+            builder.BlobName = string.Empty;
+            Uri containerUri = builder.ToUri();
+            return (true, container, name, blobUri, containerUri);
+        }
+
+        if (token.StartsWith(TokenPrefixV1, StringComparison.Ordinal))
+        {
+            string rest = token.Substring(TokenPrefixV1.Length);
+            int sep = rest.IndexOf(':');
+            if (sep <= 0 || sep >= rest.Length - 1)
+            {
+                throw new ArgumentException("Invalid external payload token format.", nameof(token));
+            }
+
+            return (false, rest.Substring(0, sep), rest.Substring(sep + 1), null, null);
+        }
+
+        throw new ArgumentException("Invalid external payload token.", nameof(token));
     }
 
     static async Task WritePayloadAsync(byte[] payloadBuffer, Stream target, CancellationToken cancellationToken)
@@ -177,22 +238,43 @@ public sealed class BlobPayloadStore : PayloadStore
 #endif
     }
 
-    static string EncodeToken(string container, string name) => $"blob:v1:{container}:{name}";
-
-    static (string Container, string Name) DecodeToken(string token)
+    static async Task<string> DownloadFromBlobAsync(BlobClient blob, CancellationToken cancellationToken)
     {
-        if (!token.StartsWith(TokenPrefix, StringComparison.Ordinal))
+        try
         {
-            throw new ArgumentException("Invalid external payload token.", nameof(token));
-        }
+            using BlobDownloadStreamingResult result = await blob.DownloadStreamingAsync(cancellationToken: cancellationToken);
+            Stream contentStream = result.Content;
+            bool isGzip = string.Equals(
+                result.Details.ContentEncoding, ContentEncodingGzip, StringComparison.OrdinalIgnoreCase);
 
-        string rest = token.Substring(TokenPrefix.Length);
-        int sep = rest.IndexOf(':');
-        if (sep <= 0 || sep >= rest.Length - 1)
+            if (isGzip)
+            {
+                using GZipStream decompressed = new(contentStream, CompressionMode.Decompress);
+                using StreamReader reader = new(decompressed, Encoding.UTF8);
+                return await ReadToEndAsync(reader, cancellationToken);
+            }
+
+            using StreamReader uncompressedReader = new(contentStream, Encoding.UTF8);
+            return await ReadToEndAsync(uncompressedReader, cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
         {
-            throw new ArgumentException("Invalid external payload token format.", nameof(token));
+            throw new PayloadStorageException(
+                $"The blob '{blob.Name}' was not found in container '{blob.BlobContainerName}'. " +
+                "The payload may have been deleted or the container was never created.",
+                ex);
         }
+    }
 
-        return (rest.Substring(0, sep), rest.Substring(sep + 1));
+    bool IsConfiguredContainer(Uri tokenContainerUri)
+    {
+        Uri configured = this.containerClient.Uri;
+        return string.Equals(tokenContainerUri.Scheme, configured.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(tokenContainerUri.Host, configured.Host, StringComparison.OrdinalIgnoreCase)
+            && tokenContainerUri.Port == configured.Port
+            && string.Equals(
+                tokenContainerUri.AbsolutePath.TrimEnd('/'),
+                configured.AbsolutePath.TrimEnd('/'),
+                StringComparison.Ordinal);
     }
 }

--- a/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
+++ b/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
@@ -115,36 +115,36 @@ public sealed class BlobPayloadStore : PayloadStore
     /// <inheritdoc/>
     public override async Task<string> DownloadAsync(string token, CancellationToken cancellationToken)
     {
-        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) = DecodeToken(token);
+        DecodeTokenResult decoded = DecodeToken(token);
 
-        if (!isV2)
+        if (!decoded.IsV2)
         {
             // v1 tokens do not carry the account, so the payload is assumed to live in the configured container.
-            if (!string.Equals(container, this.containerClient.Name, StringComparison.Ordinal))
+            if (!string.Equals(decoded.Container, this.containerClient.Name, StringComparison.Ordinal))
             {
                 throw new ArgumentException("Token container does not match configured container.", nameof(token));
             }
 
-            return await DownloadFromBlobAsync(this.containerClient.GetBlobClient(name), cancellationToken);
+            return await DownloadFromBlobAsync(this.containerClient.GetBlobClient(decoded.Name), cancellationToken);
         }
 
         // v2 tokens are self-describing: honor the account and container encoded in the token.
         BlobClient blob;
-        if (this.IsConfiguredContainer(containerUri!))
+        if (this.IsConfiguredContainer(decoded.ContainerUri!))
         {
             // Same account and container as the configured store: reuse it (works with any auth mode).
-            blob = this.containerClient.GetBlobClient(name);
+            blob = this.containerClient.GetBlobClient(decoded.Name);
         }
         else if (this.options.Credential != null)
         {
             // The payload lives in a different account (e.g. the store was repointed). Identity auth can still
             // read it as long as the credential has RBAC access to that account.
-            blob = new BlobClient(blobUri, this.options.Credential, this.clientOptions);
+            blob = new BlobClient(decoded.BlobUri, this.options.Credential, this.clientOptions);
         }
         else
         {
             throw new PayloadStorageException(
-                $"The externalized payload lives in a different storage account ('{containerUri}') than the " +
+                $"The externalized payload lives in a different storage account ('{decoded.ContainerUri}') than the " +
                 $"currently-configured payload store ('{this.containerClient.Uri}'). Cross-account payload reads " +
                 "require identity (AAD) authentication with access to both accounts; connection-string / " +
                 "account-key credentials are account-specific and cannot read another account.");

--- a/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
+++ b/src/Extensions/AzureBlobPayloads/PayloadStore/BlobPayloadStore.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DurableTask;
 /// <summary>
 /// Azure Blob Storage implementation of <see cref="PayloadStore"/>.
 /// Stores payloads as blobs and returns self-describing opaque tokens in the form
-/// "blob:v2:&lt;fullBlobUrl&gt;", where the URL is the blob's absolute URI including the storage account.
-/// Legacy "blob:v1:&lt;container&gt;:&lt;blobName&gt;" tokens are still recognized for read back-compatibility.
+/// <c>blob:v2:{fullBlobUrl}</c>, where the URL is the blob's absolute URI including the storage account.
+/// Legacy <c>blob:v1:{container}:{blobName}</c> tokens are still recognized for read back-compatibility.
 /// </summary>
 public sealed class BlobPayloadStore : PayloadStore
 {
@@ -171,20 +171,19 @@ public sealed class BlobPayloadStore : PayloadStore
     /// configured store. <c>BlobClient.Uri</c> contains no SAS or account key and is safe to persist.
     /// </summary>
     /// <param name="blobUri">The absolute URI of the blob holding the payload.</param>
-    /// <returns>An opaque payload token in the form "blob:v2:&lt;fullBlobUrl&gt;".</returns>
+    /// <returns>An opaque payload token in the form <c>blob:v2:{fullBlobUrl}</c>.</returns>
     internal static string EncodeToken(Uri blobUri) => $"{TokenPrefixV2}{blobUri}";
 
     /// <summary>
-    /// Decodes a payload token. Supports self-describing v2 tokens ("blob:v2:&lt;fullBlobUrl&gt;") and legacy v1
-    /// tokens ("blob:v1:&lt;container&gt;:&lt;blobName&gt;"), the latter for read back-compatibility.
+    /// Decodes a payload token. Supports self-describing v2 tokens (<c>blob:v2:{fullBlobUrl}</c>) and legacy v1
+    /// tokens (<c>blob:v1:{container}:{blobName}</c>), the latter for read back-compatibility.
     /// </summary>
     /// <param name="token">The payload token to decode.</param>
     /// <returns>
-    /// A tuple describing the token: whether it is v2, the container and blob names, and (for v2 only) the
-    /// absolute blob URI and its container-level URI.
+    /// A <see cref="DecodeTokenResult"/> describing the token: whether it is v2, the container and blob names,
+    /// and (for v2 only) the absolute blob URI and its container-level URI.
     /// </returns>
-    internal static (bool IsV2, string Container, string Name, Uri? BlobUri, Uri? ContainerUri) DecodeToken(
-        string token)
+    internal static DecodeTokenResult DecodeToken(string token)
     {
         if (token.StartsWith(TokenPrefixV2, StringComparison.Ordinal))
         {
@@ -199,7 +198,7 @@ public sealed class BlobPayloadStore : PayloadStore
             string name = builder.BlobName;
             builder.BlobName = string.Empty;
             Uri containerUri = builder.ToUri();
-            return (true, container, name, blobUri, containerUri);
+            return new(true, container, name, blobUri, containerUri);
         }
 
         if (token.StartsWith(TokenPrefixV1, StringComparison.Ordinal))
@@ -211,7 +210,7 @@ public sealed class BlobPayloadStore : PayloadStore
                 throw new ArgumentException("Invalid external payload token format.", nameof(token));
             }
 
-            return (false, rest.Substring(0, sep), rest.Substring(sep + 1), null, null);
+            return new(false, rest.Substring(0, sep), rest.Substring(sep + 1), null, null);
         }
 
         throw new ArgumentException("Invalid external payload token.", nameof(token));
@@ -277,4 +276,20 @@ public sealed class BlobPayloadStore : PayloadStore
                 configured.AbsolutePath.TrimEnd('/'),
                 StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// The result of decoding an externalized payload token.
+    /// </summary>
+    /// <param name="IsV2">Whether the token is a self-describing v2 token.</param>
+    /// <param name="Container">The name of the container holding the payload.</param>
+    /// <param name="Name">The name of the blob holding the payload.</param>
+    /// <param name="BlobUri">
+    /// The absolute URI of the blob holding the payload, or <see langword="null"/> for v1 tokens, which do not
+    /// carry the storage account.
+    /// </param>
+    /// <param name="ContainerUri">
+    /// The container-level URI of <paramref name="BlobUri"/>, or <see langword="null"/> for v1 tokens.
+    /// </param>
+    internal readonly record struct DecodeTokenResult(
+        bool IsV2, string Container, string Name, Uri? BlobUri, Uri? ContainerUri);
 }

--- a/test/Grpc.IntegrationTests/BlobPayloadStoreTests.cs
+++ b/test/Grpc.IntegrationTests/BlobPayloadStoreTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DurableTask.Grpc.Tests;
+
+public class BlobPayloadStoreTests
+{
+    [Fact]
+    public void EncodeToken_FromBlobUri_ProducesSelfDescribingV2Token()
+    {
+        // Arrange
+        Uri blobUri = new("https://myaccount.blob.core.windows.net/mycontainer/abc123def456");
+
+        // Act
+        string token = BlobPayloadStore.EncodeToken(blobUri);
+
+        // Assert
+        Assert.StartsWith("blob:v2:", token);
+        Assert.Contains("mycontainer", token);
+        Assert.Contains("abc123def456", token);
+
+        // Round-trip: decoding the encoded token yields the original container and blob name.
+        (bool isV2, string container, string name, _, _) = BlobPayloadStore.DecodeToken(token);
+        Assert.True(isV2);
+        Assert.Equal("mycontainer", container);
+        Assert.Equal("abc123def456", name);
+    }
+
+    [Theory]
+    [InlineData("https://myaccount.blob.core.windows.net/mycontainer/abc123def456", "mycontainer", "abc123def456")]
+    [InlineData("http://127.0.0.1:10000/devstoreaccount1/mycontainer/abc123def456", "mycontainer", "abc123def456")]
+    public void DecodeToken_V2Url_ParsesContainerAndBlob(string blobUrl, string expectedContainer, string expectedBlob)
+    {
+        // Arrange
+        string token = "blob:v2:" + blobUrl;
+
+        // Act
+        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) =
+            BlobPayloadStore.DecodeToken(token);
+
+        // Assert
+        Assert.True(isV2);
+        Assert.Equal(expectedContainer, container);
+        Assert.Equal(expectedBlob, name);
+        Assert.Equal(new Uri(blobUrl), blobUri);
+        Assert.NotNull(containerUri);
+        Assert.EndsWith(expectedContainer, containerUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public void DecodeToken_LegacyV1Token_ParsesContainerAndBlob()
+    {
+        // Arrange
+        string token = "blob:v1:mycontainer:abc123def456";
+
+        // Act
+        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) =
+            BlobPayloadStore.DecodeToken(token);
+
+        // Assert
+        Assert.False(isV2);
+        Assert.Equal("mycontainer", container);
+        Assert.Equal("abc123def456", name);
+        Assert.Null(blobUri);
+        Assert.Null(containerUri);
+    }
+
+    [Fact]
+    public void IsKnownPayloadToken_RecognizesV1AndV2_RejectsOtherValues()
+    {
+        // Arrange
+        BlobPayloadStore store = CreateStore();
+
+        // Act & Assert
+        Assert.True(store.IsKnownPayloadToken("blob:v1:mycontainer:abc123"));
+        Assert.True(store.IsKnownPayloadToken("blob:v2:https://acct.blob.core.windows.net/mycontainer/abc123"));
+        Assert.False(store.IsKnownPayloadToken("just a normal payload"));
+        Assert.False(store.IsKnownPayloadToken(string.Empty));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_V2TokenForDifferentAccountWithoutIdentity_ThrowsBeforeNetworkCall()
+    {
+        // Arrange: the configured store uses a connection string (account-key auth, no TokenCredential), while
+        // the token points at a different storage account. Account keys are account-specific, so cross-account
+        // reads are impossible and must fail fast (before any network call) with a clear error.
+        BlobPayloadStore store = CreateStore();
+        string token =
+            "blob:v2:https://otheraccount.blob.core.windows.net/othercontainer/" + Guid.NewGuid().ToString("N");
+
+        // Act
+        PayloadStorageException ex = await Assert.ThrowsAsync<PayloadStorageException>(
+            () => store.DownloadAsync(token, CancellationToken.None));
+
+        // Assert
+        Assert.Contains("different storage account", ex.Message);
+    }
+
+    static BlobPayloadStore CreateStore() =>
+        new(new LargePayloadStorageOptions("UseDevelopmentStorage=true") { ContainerName = "test" });
+}

--- a/test/Grpc.IntegrationTests/BlobPayloadStoreTests.cs
+++ b/test/Grpc.IntegrationTests/BlobPayloadStoreTests.cs
@@ -20,10 +20,10 @@ public class BlobPayloadStoreTests
         Assert.Contains("abc123def456", token);
 
         // Round-trip: decoding the encoded token yields the original container and blob name.
-        (bool isV2, string container, string name, _, _) = BlobPayloadStore.DecodeToken(token);
-        Assert.True(isV2);
-        Assert.Equal("mycontainer", container);
-        Assert.Equal("abc123def456", name);
+        BlobPayloadStore.DecodeTokenResult decoded = BlobPayloadStore.DecodeToken(token);
+        Assert.True(decoded.IsV2);
+        Assert.Equal("mycontainer", decoded.Container);
+        Assert.Equal("abc123def456", decoded.Name);
     }
 
     [Theory]
@@ -35,16 +35,15 @@ public class BlobPayloadStoreTests
         string token = "blob:v2:" + blobUrl;
 
         // Act
-        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) =
-            BlobPayloadStore.DecodeToken(token);
+        BlobPayloadStore.DecodeTokenResult decoded = BlobPayloadStore.DecodeToken(token);
 
         // Assert
-        Assert.True(isV2);
-        Assert.Equal(expectedContainer, container);
-        Assert.Equal(expectedBlob, name);
-        Assert.Equal(new Uri(blobUrl), blobUri);
-        Assert.NotNull(containerUri);
-        Assert.EndsWith(expectedContainer, containerUri!.AbsolutePath);
+        Assert.True(decoded.IsV2);
+        Assert.Equal(expectedContainer, decoded.Container);
+        Assert.Equal(expectedBlob, decoded.Name);
+        Assert.Equal(new Uri(blobUrl), decoded.BlobUri);
+        Assert.NotNull(decoded.ContainerUri);
+        Assert.EndsWith(expectedContainer, decoded.ContainerUri!.AbsolutePath);
     }
 
     [Fact]
@@ -54,15 +53,14 @@ public class BlobPayloadStoreTests
         string token = "blob:v1:mycontainer:abc123def456";
 
         // Act
-        (bool isV2, string container, string name, Uri? blobUri, Uri? containerUri) =
-            BlobPayloadStore.DecodeToken(token);
+        BlobPayloadStore.DecodeTokenResult decoded = BlobPayloadStore.DecodeToken(token);
 
         // Assert
-        Assert.False(isV2);
-        Assert.Equal("mycontainer", container);
-        Assert.Equal("abc123def456", name);
-        Assert.Null(blobUri);
-        Assert.Null(containerUri);
+        Assert.False(decoded.IsV2);
+        Assert.Equal("mycontainer", decoded.Container);
+        Assert.Equal("abc123def456", decoded.Name);
+        Assert.Null(decoded.BlobUri);
+        Assert.Null(decoded.ContainerUri);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes the externalized large-payload token **self-describing** by embedding the storage account in it (token format **v2**). This is "Option A" for the dashboard-payload-access feature.

Today the token is `blob:v1:<container>:<blobName>` and does **not** carry the storage account — the account is implicit (whatever the worker's `PayloadStore` is currently configured with). That breaks two scenarios:

1. The DTS dashboard reads blobs **directly** from Storage using the signed-in user's own AAD token, so it needs the full blob URL — but the v1 token lacks the account.
2. If the customer repoints the store to a different account, old blobs (in the old account) become unresolvable because nothing records where each payload actually lives.

Fix: write the account into each token at upload time.

## Token format

- **v2 (new, written):** `blob:v2:<fullBlobUrl>` — everything after `blob:v2:` is one complete absolute blob URI, e.g.
  - `blob:v2:https://acct.blob.core.windows.net/mycontainer/<guid>` (DNS style)
  - `blob:v2:http://127.0.0.1:10000/devstoreaccount1/mycontainer/<guid>` (Azurite path style)
  - `BlobClient.Uri` carries no SAS/key, so the token is non-secret and safe to persist.
- **v1 (legacy, still read):** `blob:v1:<container>:<blobName>` — account implicit = configured store.

## Changes

- `BlobPayloadStore.EncodeToken(Uri)` emits v2 from the blob's absolute URI (`blob.Uri`) at upload time.
- `DecodeToken` parses both v2 (via `BlobUriBuilder`, handling DNS- and Azurite path-style URLs) and legacy v1.
- `IsKnownPayloadToken` recognizes both `blob:v1:` and `blob:v2:` so v2 tokens rehydrate.
- `DownloadAsync` honors the token's account:
  - **Same account/container** as the configured store → fast path via the existing container client (works with any auth).
  - **Different account** (post-repoint) → if identity auth (`TokenCredential`) is configured, read cross-account via a new `BlobClient` using the same retry options; otherwise throw a clear `PayloadStorageException` **before any network call**.
  - The download + gzip-decompress body is factored into a shared `DownloadFromBlobAsync` helper.
- Sample `LargePayloadConsoleApp` token check updated to also recognize `blob:v2:`.

## Back-compat

Preview product; breaking existing `blob:v1:` payloads would be acceptable, but v1 **read** back-compat is kept anyway (cheap, avoids breaking in-flight orchestrations).

## Caveat (by design)

Worker cross-account read only works with identity/managed-identity auth that has RBAC on both accounts. With connection-string/account-key auth the key is account-specific, so cross-account is impossible — the clear throw is the correct behavior. The dashboard (out of scope, different repo) is unaffected: it uses the user's own AAD token.

## Tests

Added `test/Grpc.IntegrationTests/BlobPayloadStoreTests.cs` (no live Azure required):
- EncodeToken → v2 token contains container + blob; round-trips through DecodeToken.
- DecodeToken parses v2 DNS-style **and** Azurite path-style URLs.
- DecodeToken still parses legacy v1.
- IsKnownPayloadToken true for v1 + v2, false for a plain string.
- Cross-account guard: v2 token for a different account with no identity credential throws `PayloadStorageException` before any network call.

Full solution builds with 0 errors and no new analyzer warnings; the 6 new tests pass.

## Coordination note — draft PR #758 (auto-purge)

> Read-only inspection; **not** modified here.

PR #758 (`yunchuwang-wangbill-blob-payload-autopurge-sdk`) adds `PayloadStore.DeleteAsync` + `BlobPayloadStore.DeleteAsync`, which still use the **v1-only** `DecodeToken`/`TokenPrefix` and a v1-only `IsKnownPayloadToken`. `DeleteExternalBlobActivity` classifies the `ArgumentException` that the v1 decoder throws on an unrecognized prefix as a **poison token → `Discarded`** (acked so the backend clears the tombstone row).

If #758 merges on top of this change without reconciliation, every **v2** token handed to `DeleteAsync` would fail the `blob:v1:` prefix check, throw `ArgumentException`, and be silently **discarded without deleting the blob** (payload leak) — and v2 tokens wouldn't be recognized as known. Whoever merges second should port #758's `DeleteAsync`/`DecodeToken`/`IsKnownPayloadToken` to the v2-aware versions (account-aware blob resolution, same fast-path/cross-account logic as `DownloadAsync`). There's also a mechanical merge conflict in `BlobPayloadStore.cs` since both branches edit the same token region.

---
Superseded/related (closed separately, **not touched here**): protobuf #77, this repo's #765, and a backend ADO PR.