### PR TITLE
Reduce shim instance-start polling load with bounded jitter

### DIFF
--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -307,7 +307,7 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
             // observation.
             TimeSpan delay = ComputeNextPollingDelay(isInitialDelay);
             isInitialDelay = false;
-            await Task.Delay(delay, cancellation);
+            await this.DelayAsync(delay, cancellation);
         }
     }
 
@@ -391,6 +391,20 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
 
         return PollingInterval;
     }
+
+    /// <summary>
+    /// Awaits the delay between <see cref="WaitForInstanceStartAsync"/> polling attempts.
+    /// </summary>
+    /// <remarks>
+    /// This is factored out from a direct <see cref="Task.Delay(TimeSpan, CancellationToken)"/> call
+    /// purely as an internal seam: it lets tests deterministically observe (and coordinate around) the
+    /// moment a polling delay begins -- e.g. to cancel only once the delay is genuinely in progress --
+    /// without relying on wall-clock timing assumptions. It does not change production behavior.
+    /// </remarks>
+    /// <param name="delay">The delay to await.</param>
+    /// <param name="cancellation">The cancellation token to honor while awaiting the delay.</param>
+    /// <returns>A task that completes after the delay elapses, or is cancelled via <paramref name="cancellation"/>.</returns>
+    internal virtual Task DelayAsync(TimeSpan delay, CancellationToken cancellation) => Task.Delay(delay, cancellation);
 
     [return: NotNullIfNotNull("state")]
     OrchestrationMetadata? ToMetadata(Core.OrchestrationState? state, bool getInputsAndOutputs)

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -28,14 +28,13 @@ namespace Microsoft.DurableTask.Client.OrchestrationServiceClientShim;
 /// <param name="options">The client options.</param>
 class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) : DurableTaskClient(name)
 {
-    // Polling parameters for WaitForInstanceStartAsync. The minimum interval matches the historical
-    // fixed 1-second polling cadence so quick-starting orchestrations are still observed promptly. The
-    // interval then grows (bounded by the maximum) for instances that remain pending longer, reducing
-    // sustained polling load; jitter is applied on top to desynchronize concurrent callers.
-    const double PollingBackoffMultiplier = 1.5;
+    // Polling parameters for WaitForInstanceStartAsync. PollingInterval matches the historical fixed
+    // 1-second polling cadence. Callers rely on prompt (<= 1 second) observation of a status
+    // transition, so jitter is only ever applied *downward* from this value -- never grown beyond it
+    // -- to desynchronize concurrent callers (avoiding synchronized polling bursts against the
+    // backend) without regressing the historical worst-case detection latency.
     const double PollingJitterFactor = 0.2;
-    static readonly TimeSpan MinPollingInterval = TimeSpan.FromSeconds(1);
-    static readonly TimeSpan MaxPollingInterval = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(1);
 
     readonly ShimDurableTaskClientOptions options = Check.NotNull(options);
     ShimDurableEntityClient? entities;
@@ -280,7 +279,7 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
     {
         Check.NotNullOrEmpty(instanceId);
 
-        for (int attempt = 0; ; attempt++)
+        while (true)
         {
             OrchestrationMetadata? metadata = await this.GetInstancesAsync(
                 instanceId, getInputsAndOutputs, cancellation);
@@ -295,12 +294,11 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
                 return metadata;
             }
 
-            // Poll with a jittered, gradually-increasing delay. This keeps the first few retries close to
-            // the historical 1-second cadence -- preserving prompt observation of quick-starting
-            // orchestrations -- while desynchronizing concurrent waiters (avoiding synchronized polling
-            // bursts) and reducing steady-state load against the backend for instances that stay
-            // pending longer.
-            TimeSpan delay = ComputeNextPollingDelay(attempt);
+            // Poll with a delay that is jittered *downward* from the historical 1-second cadence.
+            // This desynchronizes concurrent waiters (avoiding synchronized polling bursts against the
+            // backend) while guaranteeing the worst-case detection latency for a status transition
+            // never exceeds the historical 1-second cadence -- preserving prompt-start observation.
+            TimeSpan delay = ComputeNextPollingDelay();
             await Task.Delay(delay, cancellation);
         }
     }
@@ -363,23 +361,17 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
     /// <summary>
     /// Computes the delay to wait before the next <see cref="WaitForInstanceStartAsync"/> polling attempt.
     /// </summary>
-    /// <param name="attempt">The zero-based index of the poll attempt that just completed.</param>
-    /// <returns>A jittered delay, growing from <see cref="MinPollingInterval"/> up to <see cref="MaxPollingInterval"/>.</returns>
-    static TimeSpan ComputeNextPollingDelay(int attempt)
+    /// <returns>
+    /// A delay in the range [<see cref="PollingInterval"/> * (1 - <see cref="PollingJitterFactor"/>),
+    /// <see cref="PollingInterval"/>]. Jitter only ever reduces the delay, so the returned value never
+    /// exceeds <see cref="PollingInterval"/> -- preserving the historical worst-case detection latency
+    /// for <see cref="WaitForInstanceStartAsync"/> -- while still desynchronizing concurrent callers.
+    /// </returns>
+    internal static TimeSpan ComputeNextPollingDelay()
     {
-        int safeAttempt = Math.Max(attempt, 0);
-
-        // Cap the exponent so this never overflows for pathological attempt counts.
-        double growth = Math.Pow(PollingBackoffMultiplier, Math.Min(safeAttempt, 8));
-        double targetMs = Math.Min(
-            MinPollingInterval.TotalMilliseconds * growth,
-            MaxPollingInterval.TotalMilliseconds);
-
-        // Apply +/- 20% jitter so concurrent callers waiting on the same or different instances don't
-        // converge on synchronized polling bursts against the backend.
-        double jitterRangeMs = targetMs * PollingJitterFactor;
-        double jitteredMs = targetMs + (((PollingJitter.NextDouble() * 2.0) - 1.0) * jitterRangeMs);
-        return TimeSpan.FromMilliseconds(Math.Max(jitteredMs, 0));
+        double reduction = PollingJitterFactor * PollingJitter.NextDouble();
+        double delayMs = PollingInterval.TotalMilliseconds * (1.0 - reduction);
+        return TimeSpan.FromMilliseconds(delayMs);
     }
 
     [return: NotNullIfNotNull("state")]

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -29,11 +29,13 @@ namespace Microsoft.DurableTask.Client.OrchestrationServiceClientShim;
 class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) : DurableTaskClient(name)
 {
     // Polling parameters for WaitForInstanceStartAsync. PollingInterval matches the historical fixed
-    // 1-second polling cadence. Callers rely on prompt (<= 1 second) observation of a status
-    // transition, so jitter is only ever applied *downward* from this value -- never grown beyond it
-    // -- to desynchronize concurrent callers (avoiding synchronized polling bursts against the
-    // backend) without regressing the historical worst-case detection latency.
-    const double PollingJitterFactor = 0.2;
+    // 1-second polling cadence and is used, unjittered, for every steady-state delay -- so long-run
+    // polling volume never exceeds the historical rate. To desynchronize concurrent callers (avoiding
+    // synchronized polling bursts against the backend) without inflating that steady-state volume, a
+    // randomized *initial phase offset* -- uniformly distributed in [0, PollingInterval) -- is applied
+    // exactly once, before the first delay of a given WaitForInstanceStartAsync call. This is a one-time
+    // cost per call (not repeated per iteration), so it does not change the long-run polling rate, and
+    // it still never exceeds the historical 1-second worst-case detection latency.
     static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(1);
 
     readonly ShimDurableTaskClientOptions options = Check.NotNull(options);
@@ -279,6 +281,10 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
     {
         Check.NotNullOrEmpty(instanceId);
 
+        // A one-time randomized phase offset (see ComputeNextPollingDelay) is applied only to the first
+        // delay of this call so concurrent waiters desynchronize without increasing steady-state
+        // polling volume beyond the historical fixed 1-second cadence.
+        bool isInitialDelay = true;
         while (true)
         {
             OrchestrationMetadata? metadata = await this.GetInstancesAsync(
@@ -294,11 +300,13 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
                 return metadata;
             }
 
-            // Poll with a delay that is jittered *downward* from the historical 1-second cadence.
-            // This desynchronizes concurrent waiters (avoiding synchronized polling bursts against the
-            // backend) while guaranteeing the worst-case detection latency for a status transition
-            // never exceeds the historical 1-second cadence -- preserving prompt-start observation.
-            TimeSpan delay = ComputeNextPollingDelay();
+            // The first delay is a randomized phase offset (bounded by the historical 1-second
+            // cadence) that desynchronizes concurrent waiters; every delay after that is the fixed
+            // historical 1-second interval, unjittered, so steady-state polling volume never exceeds
+            // the historical rate. Either way, the delay never exceeds 1 second, preserving prompt-start
+            // observation.
+            TimeSpan delay = ComputeNextPollingDelay(isInitialDelay);
+            isInitialDelay = false;
             await Task.Delay(delay, cancellation);
         }
     }
@@ -361,17 +369,27 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
     /// <summary>
     /// Computes the delay to wait before the next <see cref="WaitForInstanceStartAsync"/> polling attempt.
     /// </summary>
+    /// <param name="isInitialDelay">
+    /// <see langword="true"/> if this is the first delay computed for a given <see
+    /// cref="WaitForInstanceStartAsync"/> call; <see langword="false"/> for every subsequent delay in
+    /// that call.
+    /// </param>
     /// <returns>
-    /// A delay in the range [<see cref="PollingInterval"/> * (1 - <see cref="PollingJitterFactor"/>),
-    /// <see cref="PollingInterval"/>]. Jitter only ever reduces the delay, so the returned value never
-    /// exceeds <see cref="PollingInterval"/> -- preserving the historical worst-case detection latency
-    /// for <see cref="WaitForInstanceStartAsync"/> -- while still desynchronizing concurrent callers.
+    /// When <paramref name="isInitialDelay"/> is <see langword="true"/>, a one-time randomized phase
+    /// offset uniformly distributed in [<see cref="TimeSpan.Zero"/>, <see cref="PollingInterval"/>) that
+    /// desynchronizes concurrent callers. Otherwise, the fixed <see cref="PollingInterval"/> (1 second),
+    /// unjittered, so steady-state polling volume never exceeds the historical rate. In both cases the
+    /// returned delay never exceeds <see cref="PollingInterval"/>, preserving the historical worst-case
+    /// detection latency for <see cref="WaitForInstanceStartAsync"/>.
     /// </returns>
-    internal static TimeSpan ComputeNextPollingDelay()
+    internal static TimeSpan ComputeNextPollingDelay(bool isInitialDelay)
     {
-        double reduction = PollingJitterFactor * PollingJitter.NextDouble();
-        double delayMs = PollingInterval.TotalMilliseconds * (1.0 - reduction);
-        return TimeSpan.FromMilliseconds(delayMs);
+        if (isInitialDelay)
+        {
+            return TimeSpan.FromMilliseconds(PollingInterval.TotalMilliseconds * PollingJitter.NextDouble());
+        }
+
+        return PollingInterval;
     }
 
     [return: NotNullIfNotNull("state")]

--- a/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
+++ b/src/Client/OrchestrationServiceClientShim/ShimDurableTaskClient.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Security.Cryptography;
 using DurableTask.Core;
 using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
@@ -27,6 +28,15 @@ namespace Microsoft.DurableTask.Client.OrchestrationServiceClientShim;
 /// <param name="options">The client options.</param>
 class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) : DurableTaskClient(name)
 {
+    // Polling parameters for WaitForInstanceStartAsync. The minimum interval matches the historical
+    // fixed 1-second polling cadence so quick-starting orchestrations are still observed promptly. The
+    // interval then grows (bounded by the maximum) for instances that remain pending longer, reducing
+    // sustained polling load; jitter is applied on top to desynchronize concurrent callers.
+    const double PollingBackoffMultiplier = 1.5;
+    const double PollingJitterFactor = 0.2;
+    static readonly TimeSpan MinPollingInterval = TimeSpan.FromSeconds(1);
+    static readonly TimeSpan MaxPollingInterval = TimeSpan.FromSeconds(5);
+
     readonly ShimDurableTaskClientOptions options = Check.NotNull(options);
     ShimDurableEntityClient? entities;
 
@@ -270,7 +280,7 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
     {
         Check.NotNullOrEmpty(instanceId);
 
-        while (true)
+        for (int attempt = 0; ; attempt++)
         {
             OrchestrationMetadata? metadata = await this.GetInstancesAsync(
                 instanceId, getInputsAndOutputs, cancellation);
@@ -285,7 +295,13 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
                 return metadata;
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellation);
+            // Poll with a jittered, gradually-increasing delay. This keeps the first few retries close to
+            // the historical 1-second cadence -- preserving prompt observation of quick-starting
+            // orchestrations -- while desynchronizing concurrent waiters (avoiding synchronized polling
+            // bursts) and reducing steady-state load against the backend for instances that stay
+            // pending longer.
+            TimeSpan delay = ComputeNextPollingDelay(attempt);
+            await Task.Delay(delay, cancellation);
         }
     }
 
@@ -342,6 +358,28 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
 
         await this.Client.CreateTaskOrchestrationAsync(message, dedupeStatuses: null);
         return newInstanceId;
+    }
+
+    /// <summary>
+    /// Computes the delay to wait before the next <see cref="WaitForInstanceStartAsync"/> polling attempt.
+    /// </summary>
+    /// <param name="attempt">The zero-based index of the poll attempt that just completed.</param>
+    /// <returns>A jittered delay, growing from <see cref="MinPollingInterval"/> up to <see cref="MaxPollingInterval"/>.</returns>
+    static TimeSpan ComputeNextPollingDelay(int attempt)
+    {
+        int safeAttempt = Math.Max(attempt, 0);
+
+        // Cap the exponent so this never overflows for pathological attempt counts.
+        double growth = Math.Pow(PollingBackoffMultiplier, Math.Min(safeAttempt, 8));
+        double targetMs = Math.Min(
+            MinPollingInterval.TotalMilliseconds * growth,
+            MaxPollingInterval.TotalMilliseconds);
+
+        // Apply +/- 20% jitter so concurrent callers waiting on the same or different instances don't
+        // converge on synchronized polling bursts against the backend.
+        double jitterRangeMs = targetMs * PollingJitterFactor;
+        double jitteredMs = targetMs + (((PollingJitter.NextDouble() * 2.0) - 1.0) * jitterRangeMs);
+        return TimeSpan.FromMilliseconds(Math.Max(jitteredMs, 0));
     }
 
     [return: NotNullIfNotNull("state")]
@@ -447,6 +485,39 @@ class ShimDurableTaskClient(string name, ShimDurableTaskClientOptions options) :
                     await this.WaitForInstanceCompletionAsync(instanceId, cancellation: cancellation);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// A minimal thread-safe random source used to jitter <see cref="WaitForInstanceStartAsync"/> polling
+    /// delays across concurrent callers. <see cref="System.Random"/> is not thread-safe, and its
+    /// parameterless constructor can produce correlated sequences when many instances are created around
+    /// the same tick -- which is exactly the kind of synchronized behavior this jitter is meant to avoid.
+    /// A single, securely-seeded instance guarded by a lock avoids both issues.
+    /// </summary>
+    static class PollingJitter
+    {
+        static readonly object SyncRoot = new();
+        static readonly Random Shared = CreateSeededRandom();
+
+        /// <summary>
+        /// Returns a thread-safe random double in the range [0.0, 1.0).
+        /// </summary>
+        /// <returns>A random double in the range [0.0, 1.0).</returns>
+        public static double NextDouble()
+        {
+            lock (SyncRoot)
+            {
+                return Shared.NextDouble();
+            }
+        }
+
+        static Random CreateSeededRandom()
+        {
+            byte[] seedBytes = new byte[sizeof(int)];
+            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(seedBytes);
+            return new Random(BitConverter.ToInt32(seedBytes, 0));
         }
     }
 }

--- a/src/Worker/Grpc/WorkItemStreamConsumer.cs
+++ b/src/Worker/Grpc/WorkItemStreamConsumer.cs
@@ -60,13 +60,22 @@ internal static class WorkItemStreamConsumer
     /// reset retry counters that should only count consecutive transport failures.
     /// </param>
     /// <param name="cancellation">Outer worker cancellation token.</param>
+    /// <param name="onSilentDisconnectTimerArmed">
+    /// Test-only observability hook invoked synchronously every time the silent-disconnect timer is
+    /// (re-)armed -- once before the read loop starts, and once per item, immediately before that
+    /// item is dispatched. Always <see langword="null"/> in production; lets tests prove the
+    /// per-item reset actually happens (and in what order relative to dispatch) without depending on
+    /// real elapsed time. Never invoked when <paramref name="silentDisconnectTimeout"/> disables
+    /// detection.
+    /// </param>
     /// <returns>The classified outcome plus whether any message was observed.</returns>
     public static async Task<WorkItemStreamResult> ConsumeAsync(
         Func<CancellationToken, IAsyncEnumerable<P.WorkItem>> openStream,
         TimeSpan silentDisconnectTimeout,
         Action<P.WorkItem> onItem,
         Action? onFirstMessage,
-        CancellationToken cancellation)
+        CancellationToken cancellation,
+        Action? onSilentDisconnectTimerArmed = null)
     {
         bool silentDisconnectEnabled = silentDisconnectTimeout > TimeSpan.Zero;
 
@@ -79,6 +88,7 @@ internal static class WorkItemStreamConsumer
             if (silentDisconnectEnabled)
             {
                 timeoutSource.CancelAfter(effectiveTimeout);
+                onSilentDisconnectTimerArmed?.Invoke();
             }
         }
 

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -402,14 +402,50 @@ public class ShimDurableTaskClientTests
             .ReturnsAsync([pending]);
 
         using CancellationTokenSource cts = new();
+        DelayObservingShimDurableTaskClient client = new(
+            "test", new ShimDurableTaskClientOptions { Client = this.orchestrationClient.Object });
 
-        // act -- cancel shortly after the first (immediate) poll so cancellation fires while the loop is
-        // awaiting the polling delay rather than before any polling occurs.
-        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
-        Func<Task> act = () => this.client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
+        // act -- deterministically coordinate cancellation with the polling delay itself (no wall-clock
+        // guess): wait until the delay seam confirms the real Task.Delay(delay, cancellation) call has
+        // been made for this loop iteration, THEN cancel. This proves the delay -- not some other code
+        // path such as a later poll observing an already-cancelled token -- is what ends the wait.
+        Task waitTask = client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
+        await client.DelayEntered.WaitAsync(TimeSpan.FromSeconds(10));
+        cts.Cancel();
 
-        // assert
+        Task completedTask = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        // assert -- the wait must end (via cancellation) promptly, without ever performing a second poll.
+        // If cancellation were ignored by the delay, the loop would instead complete the full delay and
+        // poll again (and again, since the mock always returns "pending"), so this also guards against
+        // that regression by bounding how long the assertion waits before failing.
+        completedTask.Should().Be(waitTask, "the wait should be cancelled during the polling delay, not time out");
+        Func<Task> act = () => waitTask;
         await act.Should().ThrowAsync<OperationCanceledException>();
+        this.orchestrationClient.Verify(
+            m => m.GetOrchestrationStateAsync(instance.InstanceId, false), Times.Once);
+    }
+
+    /// <summary>
+    /// A <see cref="ShimDurableTaskClient"/> test double that signals <see cref="DelayEntered"/> once the
+    /// real polling delay (<see cref="ShimDurableTaskClient.DelayAsync"/>) has actually been invoked with
+    /// the caller's cancellation token, so tests can deterministically coordinate cancellation without
+    /// relying on wall-clock timing. The underlying delay/cancellation behavior is otherwise unchanged.
+    /// </summary>
+    sealed class DelayObservingShimDurableTaskClient(string name, ShimDurableTaskClientOptions options)
+        : ShimDurableTaskClient(name, options)
+    {
+        readonly TaskCompletionSource delayEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets a task that completes once <see cref="DelayAsync"/> has been called.</summary>
+        public Task DelayEntered => this.delayEntered.Task;
+
+        internal override Task DelayAsync(TimeSpan delay, CancellationToken cancellation)
+        {
+            Task delayTask = base.DelayAsync(delay, cancellation);
+            this.delayEntered.TrySetResult();
+            return delayTask;
+        }
     }
 
     [Fact]

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -406,9 +406,11 @@ public class ShimDurableTaskClientTests
             "test", new ShimDurableTaskClientOptions { Client = this.orchestrationClient.Object });
 
         // act -- deterministically coordinate cancellation with the polling delay itself (no wall-clock
-        // guess): wait until the delay seam confirms the real Task.Delay(delay, cancellation) call has
-        // been made for this loop iteration, THEN cancel. This proves the delay -- not some other code
-        // path such as a later poll observing an already-cancelled token -- is what ends the wait.
+        // guess, no real timer): wait until the fake delay seam confirms it has been entered for this
+        // loop iteration, THEN cancel. The fake delay never completes on its own -- it only completes
+        // when the *exact* cancellation token passed by production code is cancelled -- so this proves
+        // that token, and not some other code path (e.g. a later poll's own cancellation check), is what
+        // ends the wait.
         Task waitTask = client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
         await client.DelayEntered.WaitAsync(TimeSpan.FromSeconds(10));
         cts.Cancel();
@@ -416,9 +418,9 @@ public class ShimDurableTaskClientTests
         Task completedTask = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10)));
 
         // assert -- the wait must end (via cancellation) promptly, without ever performing a second poll.
-        // If cancellation were ignored by the delay, the loop would instead complete the full delay and
-        // poll again (and again, since the mock always returns "pending"), so this also guards against
-        // that regression by bounding how long the assertion waits before failing.
+        // Because the fake delay never completes unless the supplied token is cancelled, a regression that
+        // passes the wrong (or no) token into the delay would leave the delay -- and thus the wait --
+        // pending forever, causing this assertion to time out and fail instead of passing vacuously.
         completedTask.Should().Be(waitTask, "the wait should be cancelled during the polling delay, not time out");
         Func<Task> act = () => waitTask;
         await act.Should().ThrowAsync<OperationCanceledException>();
@@ -427,10 +429,14 @@ public class ShimDurableTaskClientTests
     }
 
     /// <summary>
-    /// A <see cref="ShimDurableTaskClient"/> test double that signals <see cref="DelayEntered"/> once the
-    /// real polling delay (<see cref="ShimDurableTaskClient.DelayAsync"/>) has actually been invoked with
-    /// the caller's cancellation token, so tests can deterministically coordinate cancellation without
-    /// relying on wall-clock timing. The underlying delay/cancellation behavior is otherwise unchanged.
+    /// A <see cref="ShimDurableTaskClient"/> test double whose <see cref="DelayAsync"/> override replaces
+    /// the real polling delay with a fully controlled fake: it signals <see cref="DelayEntered"/> as soon
+    /// as it is called, then returns a task that never completes on its own (no real timer) and completes
+    /// -- via cancellation -- only when the *exact* <see cref="CancellationToken"/> supplied by the caller
+    /// is cancelled. This lets tests deterministically coordinate cancellation with the delay without any
+    /// wall-clock timing, and proves that cancelling the caller's token is what actually interrupts the
+    /// pending wait, rather than some unrelated code path (such as a subsequent poll's own cancellation
+    /// check) coincidentally producing the same observable outcome.
     /// </summary>
     sealed class DelayObservingShimDurableTaskClient(string name, ShimDurableTaskClientOptions options)
         : ShimDurableTaskClient(name, options)
@@ -442,9 +448,10 @@ public class ShimDurableTaskClientTests
 
         internal override Task DelayAsync(TimeSpan delay, CancellationToken cancellation)
         {
-            Task delayTask = base.DelayAsync(delay, cancellation);
+            TaskCompletionSource pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellation.Register(() => pending.TrySetCanceled(cancellation));
             this.delayEntered.TrySetResult();
-            return delayTask;
+            return pending.Task;
         }
     }
 

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using DurableTask.Core;
 using DurableTask.Core.Entities;
 using DurableTask.Core.Exceptions;
@@ -330,66 +329,39 @@ public class ShimDurableTaskClientTests
         OrchestrationMetadata metadata = await this.client.WaitForInstanceStartAsync(
             instance.InstanceId, false, default);
 
-        // assert -- multiple polling iterations (exercising the jittered polling loop) still converge
-        // on the terminal state once observed.
+        // assert -- multiple polling iterations (exercising the polling loop, including its one-time
+        // initial phase offset followed by fixed-interval delays) still converge on the terminal state
+        // once observed.
         this.orchestrationClient.Verify(
             m => m.GetOrchestrationStateAsync(instance.InstanceId, false), Times.Exactly(3));
         Validate(metadata, terminal, false);
     }
 
     [Fact]
-    public async Task WaitForInstanceStart_RepeatedPendingObservations_HonorsMaxDetectionLatencyContract()
+    public void ComputeNextPollingDelay_InitialDelay_NeverExceedsHistoricalOneSecondCadence()
     {
-        // arrange
-        DateTimeOffset start = DateTimeOffset.UtcNow;
-        OrchestrationInstance instance = new()
+        // assert -- across many samples, the randomized initial-phase-offset delay must always be
+        // non-negative and never exceed the historical 1-second polling cadence, enforcing the max
+        // detection-latency contract for the very first delay of a WaitForInstanceStartAsync call.
+        for (int i = 0; i < 1000; i++)
         {
-            InstanceId = Guid.NewGuid().ToString(),
-            ExecutionId = Guid.NewGuid().ToString(),
-        };
-
-        Core.OrchestrationState pending1 = CreateState("input", start: start);
-        pending1.OrchestrationInstance = instance;
-        pending1.OrchestrationStatus = Core.OrchestrationStatus.Pending;
-        Core.OrchestrationState pending2 = CreateState("input", start: start);
-        pending2.OrchestrationInstance = instance;
-        pending2.OrchestrationStatus = Core.OrchestrationStatus.Pending;
-        Core.OrchestrationState terminal = CreateState("input", start: start);
-        terminal.OrchestrationInstance = instance;
-
-        this.orchestrationClient.SetupSequence(m => m.GetOrchestrationStateAsync(instance.InstanceId, false))
-            .ReturnsAsync([pending1])
-            .ReturnsAsync([pending2])
-            .ReturnsAsync([terminal]);
-
-        Stopwatch stopwatch = Stopwatch.StartNew();
-
-        // act
-        OrchestrationMetadata metadata = await this.client.WaitForInstanceStartAsync(
-            instance.InstanceId, false, default);
-
-        stopwatch.Stop();
-
-        // assert -- two "still pending" observations occur before the terminal state is returned, so
-        // exactly two polling delays are incurred. Each delay is bounded by the historical 1-second
-        // detection cadence (jitter only ever reduces it), so the worst-case total wait here is ~2
-        // seconds. This guards against a regression -- like unconstrained backoff growth -- that would
-        // push per-poll delays past the historical cadence and violate prompt-start observation.
-        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2.5));
-        Validate(metadata, terminal, false);
+            TimeSpan delay = ShimDurableTaskClient.ComputeNextPollingDelay(isInitialDelay: true);
+            delay.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+            delay.Should().BeLessThan(TimeSpan.FromSeconds(1));
+        }
     }
 
     [Fact]
-    public void ComputeNextPollingDelay_NeverExceedsHistoricalOneSecondCadence()
+    public void ComputeNextPollingDelay_SteadyState_ReturnsFixedHistoricalIntervalWithNoJitter()
     {
-        // assert -- across many samples, the jittered delay must never exceed the historical 1-second
-        // polling cadence (jitter only ever reduces the delay), enforcing the max detection-latency
-        // contract for WaitForInstanceStartAsync, and must always be a non-negative, finite delay.
-        for (int i = 0; i < 1000; i++)
+        // assert -- every delay after the initial phase offset must be exactly the fixed historical
+        // 1-second cadence with no jitter and no growth, so steady-state polling volume never exceeds
+        // (or falls below) the historical rate. This guards against a regression to either unconstrained
+        // backoff growth or a per-iteration jitter reduction that would increase polling frequency.
+        for (int i = 0; i < 100; i++)
         {
-            TimeSpan delay = ShimDurableTaskClient.ComputeNextPollingDelay();
-            delay.Should().BeGreaterThan(TimeSpan.Zero);
-            delay.Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(1));
+            TimeSpan delay = ShimDurableTaskClient.ComputeNextPollingDelay(isInitialDelay: false);
+            delay.Should().Be(TimeSpan.FromSeconds(1));
         }
     }
 
@@ -432,7 +404,7 @@ public class ShimDurableTaskClientTests
         using CancellationTokenSource cts = new();
 
         // act -- cancel shortly after the first (immediate) poll so cancellation fires while the loop is
-        // awaiting the jittered polling delay rather than before any polling occurs.
+        // awaiting the polling delay rather than before any polling occurs.
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
         Func<Task> act = () => this.client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
 

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -301,6 +301,89 @@ public class ShimDurableTaskClientTests
     }
 
     [Fact]
+    public async Task WaitForInstanceStart_MultiplePendingPolls_EventuallyReturnsTerminalMetadata()
+    {
+        // arrange
+        DateTimeOffset start = DateTimeOffset.UtcNow;
+        OrchestrationInstance instance = new()
+        {
+            InstanceId = Guid.NewGuid().ToString(),
+            ExecutionId = Guid.NewGuid().ToString(),
+        };
+
+        Core.OrchestrationState pending1 = CreateState("input", start: start);
+        pending1.OrchestrationInstance = instance;
+        pending1.OrchestrationStatus = Core.OrchestrationStatus.Pending;
+        Core.OrchestrationState pending2 = CreateState("input", start: start);
+        pending2.OrchestrationInstance = instance;
+        pending2.OrchestrationStatus = Core.OrchestrationStatus.Pending;
+        Core.OrchestrationState terminal = CreateState("input", start: start);
+        terminal.OrchestrationInstance = instance;
+
+        this.orchestrationClient.SetupSequence(m => m.GetOrchestrationStateAsync(instance.InstanceId, false))
+            .ReturnsAsync([pending1])
+            .ReturnsAsync([pending2])
+            .ReturnsAsync([terminal]);
+
+        // act
+        OrchestrationMetadata metadata = await this.client.WaitForInstanceStartAsync(
+            instance.InstanceId, false, default);
+
+        // assert -- multiple polling iterations (exercising the jittered backoff loop) still converge
+        // on the terminal state once observed.
+        this.orchestrationClient.Verify(
+            m => m.GetOrchestrationStateAsync(instance.InstanceId, false), Times.Exactly(3));
+        Validate(metadata, terminal, false);
+    }
+
+    [Fact]
+    public async Task WaitForInstanceStart_InstanceNotFound_ThrowsImmediatelyWithoutPolling()
+    {
+        // arrange
+        string instanceId = Guid.NewGuid().ToString();
+        this.orchestrationClient.Setup(m => m.GetOrchestrationStateAsync(instanceId, false))
+            .ReturnsAsync([]);
+
+        // act
+        Func<Task> act = () => this.client.WaitForInstanceStartAsync(instanceId, false, default);
+
+        // assert -- not-found behavior is preserved: no retry/backoff delay before throwing.
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"Orchestration with instanceId '{instanceId}' does not exist");
+        this.orchestrationClient.Verify(
+            m => m.GetOrchestrationStateAsync(instanceId, false), Times.Once);
+    }
+
+    [Fact]
+    public async Task WaitForInstanceStart_CancelledDuringBackoffDelay_ThrowsTaskCanceledException()
+    {
+        // arrange
+        DateTimeOffset start = DateTimeOffset.UtcNow;
+        OrchestrationInstance instance = new()
+        {
+            InstanceId = Guid.NewGuid().ToString(),
+            ExecutionId = Guid.NewGuid().ToString(),
+        };
+
+        Core.OrchestrationState pending = CreateState("input", start: start);
+        pending.OrchestrationInstance = instance;
+        pending.OrchestrationStatus = Core.OrchestrationStatus.Pending;
+
+        this.orchestrationClient.Setup(m => m.GetOrchestrationStateAsync(instance.InstanceId, false))
+            .ReturnsAsync([pending]);
+
+        using CancellationTokenSource cts = new();
+
+        // act -- cancel shortly after the first (immediate) poll so cancellation fires while the loop is
+        // awaiting the jittered backoff delay rather than before any polling occurs.
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+        Func<Task> act = () => this.client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
+
+        // assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public Task ScheduleNewOrchestrationInstance_IdGenerated_NoInput()
         => this.RunScheduleNewOrchestrationInstanceAsync("test", null, null);
 

--- a/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
+++ b/test/Client/OrchestrationServiceClientShim.Tests/ShimDurableTaskClientTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using DurableTask.Core;
 using DurableTask.Core.Entities;
 using DurableTask.Core.Exceptions;
@@ -329,11 +330,67 @@ public class ShimDurableTaskClientTests
         OrchestrationMetadata metadata = await this.client.WaitForInstanceStartAsync(
             instance.InstanceId, false, default);
 
-        // assert -- multiple polling iterations (exercising the jittered backoff loop) still converge
+        // assert -- multiple polling iterations (exercising the jittered polling loop) still converge
         // on the terminal state once observed.
         this.orchestrationClient.Verify(
             m => m.GetOrchestrationStateAsync(instance.InstanceId, false), Times.Exactly(3));
         Validate(metadata, terminal, false);
+    }
+
+    [Fact]
+    public async Task WaitForInstanceStart_RepeatedPendingObservations_HonorsMaxDetectionLatencyContract()
+    {
+        // arrange
+        DateTimeOffset start = DateTimeOffset.UtcNow;
+        OrchestrationInstance instance = new()
+        {
+            InstanceId = Guid.NewGuid().ToString(),
+            ExecutionId = Guid.NewGuid().ToString(),
+        };
+
+        Core.OrchestrationState pending1 = CreateState("input", start: start);
+        pending1.OrchestrationInstance = instance;
+        pending1.OrchestrationStatus = Core.OrchestrationStatus.Pending;
+        Core.OrchestrationState pending2 = CreateState("input", start: start);
+        pending2.OrchestrationInstance = instance;
+        pending2.OrchestrationStatus = Core.OrchestrationStatus.Pending;
+        Core.OrchestrationState terminal = CreateState("input", start: start);
+        terminal.OrchestrationInstance = instance;
+
+        this.orchestrationClient.SetupSequence(m => m.GetOrchestrationStateAsync(instance.InstanceId, false))
+            .ReturnsAsync([pending1])
+            .ReturnsAsync([pending2])
+            .ReturnsAsync([terminal]);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        // act
+        OrchestrationMetadata metadata = await this.client.WaitForInstanceStartAsync(
+            instance.InstanceId, false, default);
+
+        stopwatch.Stop();
+
+        // assert -- two "still pending" observations occur before the terminal state is returned, so
+        // exactly two polling delays are incurred. Each delay is bounded by the historical 1-second
+        // detection cadence (jitter only ever reduces it), so the worst-case total wait here is ~2
+        // seconds. This guards against a regression -- like unconstrained backoff growth -- that would
+        // push per-poll delays past the historical cadence and violate prompt-start observation.
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2.5));
+        Validate(metadata, terminal, false);
+    }
+
+    [Fact]
+    public void ComputeNextPollingDelay_NeverExceedsHistoricalOneSecondCadence()
+    {
+        // assert -- across many samples, the jittered delay must never exceed the historical 1-second
+        // polling cadence (jitter only ever reduces the delay), enforcing the max detection-latency
+        // contract for WaitForInstanceStartAsync, and must always be a non-negative, finite delay.
+        for (int i = 0; i < 1000; i++)
+        {
+            TimeSpan delay = ShimDurableTaskClient.ComputeNextPollingDelay();
+            delay.Should().BeGreaterThan(TimeSpan.Zero);
+            delay.Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(1));
+        }
     }
 
     [Fact]
@@ -347,7 +404,7 @@ public class ShimDurableTaskClientTests
         // act
         Func<Task> act = () => this.client.WaitForInstanceStartAsync(instanceId, false, default);
 
-        // assert -- not-found behavior is preserved: no retry/backoff delay before throwing.
+        // assert -- not-found behavior is preserved: no retry/polling delay before throwing.
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"Orchestration with instanceId '{instanceId}' does not exist");
         this.orchestrationClient.Verify(
@@ -355,7 +412,7 @@ public class ShimDurableTaskClientTests
     }
 
     [Fact]
-    public async Task WaitForInstanceStart_CancelledDuringBackoffDelay_ThrowsTaskCanceledException()
+    public async Task WaitForInstanceStart_CancelledDuringPollingDelay_ThrowsTaskCanceledException()
     {
         // arrange
         DateTimeOffset start = DateTimeOffset.UtcNow;
@@ -375,7 +432,7 @@ public class ShimDurableTaskClientTests
         using CancellationTokenSource cts = new();
 
         // act -- cancel shortly after the first (immediate) poll so cancellation fires while the loop is
-        // awaiting the jittered backoff delay rather than before any polling occurs.
+        // awaiting the jittered polling delay rather than before any polling occurs.
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
         Func<Task> act = () => this.client.WaitForInstanceStartAsync(instance.InstanceId, false, cts.Token);
 

--- a/test/Worker/Grpc.Tests/WorkItemStreamConsumerTests.cs
+++ b/test/Worker/Grpc.Tests/WorkItemStreamConsumerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 using Grpc.Core;
 using Microsoft.DurableTask.Worker.Grpc;
 using P = Microsoft.DurableTask.Protobuf;
@@ -140,55 +139,54 @@ public class WorkItemStreamConsumerTests
     public async Task PerItem_HeartbeatReset_KeepsTimerAlive()
     {
         // Proves the per-item timer reset -- not just a single arm at loop start -- is what keeps the
-        // stream alive. Several items are sent in sequence: each gap between consecutive items is
-        // comfortably shorter than the silent-disconnect timeout (so a correct per-item reset never lets
-        // the timer expire), but the gaps' sum comfortably exceeds the timeout (so a regression that only
-        // arms the timer once at loop start, and never re-arms it per item, would already have cancelled
-        // the stream well before the last item is sent).
+        // stream alive. Earlier versions of this test tried to prove the reset by racing real per-item
+        // delays (each comfortably under the timeout) against the real silent-disconnect timeout (so
+        // their sum comfortably exceeded it). That was still flaky under CI scheduling pressure: any
+        // continuation between the "item processed" signal and the next write could be delayed by the
+        // thread pool/scheduler, silently inflating an intended-short gap past the timeout even though
+        // production was correct.
         //
-        // Every gap is measured starting from the previous item's actual onItem invocation -- signalled
-        // via a semaphore -- rather than from an a-priori sleep before the very first item. That avoids a
-        // CI flake where scheduling pressure before the read loop has even started could delay the first
-        // write past the timeout and spuriously trip a SilentDisconnect that has nothing to do with the
-        // per-item reset behavior under test.
-        Channel<P.WorkItem> channel = Channel.CreateUnbounded<P.WorkItem>();
-        TimeSpan timeout = TimeSpan.FromMilliseconds(500);
-        TimeSpan perItemGap = TimeSpan.FromMilliseconds(150);
-        const int itemCount = 5; // 4 gaps * 150ms = 600ms > 500ms timeout: proves reset is required.
+        // This version removes wall-clock timing from the assertion entirely. ConsumeAsync exposes a
+        // test-only observability hook that fires every time the silent-disconnect timer is (re-)armed:
+        // once before the read loop starts, and once per item, immediately before that item is
+        // dispatched to onItem. By recording the exact interleaving of "armed" and "item" events, the
+        // test proves the structural guarantee directly -- an arm precedes every item, and the total arm
+        // count is itemCount + 1 -- instead of inferring it from elapsed real time. A regression that
+        // only arms the timer once at loop start (and never re-arms it per item) fails this assertion
+        // deterministically, with no dependency on scheduler timing.
+        const int itemCount = 5;
+        List<string> events = new();
+        int itemIndex = 0;
 
-        SemaphoreSlim itemProcessed = new(0);
-
-        Task<WorkItemStreamResult> consumeTask = WorkItemStreamConsumer.ConsumeAsync(
-            openStream: ct => channel.Reader.ReadAllAsync(ct),
-            silentDisconnectTimeout: timeout,
-            onItem: _ => itemProcessed.Release(),
-            onFirstMessage: null,
-            cancellation: CancellationToken.None);
-
+        P.WorkItem[] items = new P.WorkItem[itemCount];
         for (int i = 0; i < itemCount; i++)
         {
-            if (i > 0)
-            {
-                bool signaled = await itemProcessed.WaitAsync(TimeSpan.FromSeconds(5));
-                signaled.Should().BeTrue("item {0} should have been processed (re-arming the timer) within the bounded wait", i);
-
-                await Task.Delay(perItemGap);
-            }
-
-            await channel.Writer.WriteAsync(new P.WorkItem { HealthPing = new P.HealthPing() });
+            items[i] = new P.WorkItem { HealthPing = new P.HealthPing() };
         }
 
-        // Wait for the final item to be processed before completing the channel, so the last per-item
-        // reset has actually happened prior to the graceful drain.
-        bool finalItemSignaled = await itemProcessed.WaitAsync(TimeSpan.FromSeconds(5));
-        finalItemSignaled.Should().BeTrue("the final item should have been processed before the stream completes");
-
-        channel.Writer.Complete();
-
-        WorkItemStreamResult result = await consumeTask;
+        WorkItemStreamResult result = await WorkItemStreamConsumer.ConsumeAsync(
+            openStream: _ => StreamOf(items),
+            silentDisconnectTimeout: TimeSpan.FromMilliseconds(500),
+            onItem: _ => events.Add($"item{itemIndex++}"),
+            onFirstMessage: null,
+            cancellation: CancellationToken.None,
+            onSilentDisconnectTimerArmed: () => events.Add("armed"));
 
         result.Outcome.Should().Be(WorkItemStreamOutcome.GracefulDrain);
         result.FirstMessageObserved.Should().BeTrue();
+
+        // 1 initial arm (before the loop starts) + 1 re-arm per item.
+        events.Count(e => e == "armed").Should().Be(itemCount + 1);
+
+        // Every item must be immediately preceded by its own re-arm, and the very first event overall
+        // is the initial pre-loop arm.
+        events[0].Should().Be("armed");
+        for (int i = 0; i < itemCount; i++)
+        {
+            int armedIndex = 1 + (i * 2);
+            events[armedIndex].Should().Be("armed", "item {0} must be preceded by a timer re-arm", i);
+            events[armedIndex + 1].Should().Be($"item{i}");
+        }
     }
 
     [Fact]

--- a/test/Worker/Grpc.Tests/WorkItemStreamConsumerTests.cs
+++ b/test/Worker/Grpc.Tests/WorkItemStreamConsumerTests.cs
@@ -139,34 +139,50 @@ public class WorkItemStreamConsumerTests
     [Fact]
     public async Task PerItem_HeartbeatReset_KeepsTimerAlive()
     {
-        // Feed one item, wait long enough that the original timer would have expired, then complete.
-        // Synchronize on the first item actually being processed so the second delay is measured from
-        // the consumer's timer reset instead of from the test thread's write timing.
+        // Proves the per-item timer reset -- not just a single arm at loop start -- is what keeps the
+        // stream alive. Several items are sent in sequence: each gap between consecutive items is
+        // comfortably shorter than the silent-disconnect timeout (so a correct per-item reset never lets
+        // the timer expire), but the gaps' sum comfortably exceeds the timeout (so a regression that only
+        // arms the timer once at loop start, and never re-arms it per item, would already have cancelled
+        // the stream well before the last item is sent).
+        //
+        // Every gap is measured starting from the previous item's actual onItem invocation -- signalled
+        // via a semaphore -- rather than from an a-priori sleep before the very first item. That avoids a
+        // CI flake where scheduling pressure before the read loop has even started could delay the first
+        // write past the timeout and spuriously trip a SilentDisconnect that has nothing to do with the
+        // per-item reset behavior under test.
         Channel<P.WorkItem> channel = Channel.CreateUnbounded<P.WorkItem>();
         TimeSpan timeout = TimeSpan.FromMilliseconds(500);
-        TaskCompletionSource firstItemProcessed = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        int itemCount = 0;
+        TimeSpan perItemGap = TimeSpan.FromMilliseconds(150);
+        const int itemCount = 5; // 4 gaps * 150ms = 600ms > 500ms timeout: proves reset is required.
+
+        SemaphoreSlim itemProcessed = new(0);
 
         Task<WorkItemStreamResult> consumeTask = WorkItemStreamConsumer.ConsumeAsync(
             openStream: ct => channel.Reader.ReadAllAsync(ct),
             silentDisconnectTimeout: timeout,
-            onItem: _ =>
-            {
-                if (Interlocked.Increment(ref itemCount) == 1)
-                {
-                    firstItemProcessed.TrySetResult();
-                }
-            },
+            onItem: _ => itemProcessed.Release(),
             onFirstMessage: null,
             cancellation: CancellationToken.None);
 
-        await Task.Delay(TimeSpan.FromMilliseconds(150));
-        await channel.Writer.WriteAsync(new P.WorkItem { HealthPing = new P.HealthPing() });
-        await firstItemProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        for (int i = 0; i < itemCount; i++)
+        {
+            if (i > 0)
+            {
+                bool signaled = await itemProcessed.WaitAsync(TimeSpan.FromSeconds(5));
+                signaled.Should().BeTrue("item {0} should have been processed (re-arming the timer) within the bounded wait", i);
 
-        // Without the per-item reset, the original timer would fire before this second item arrives.
-        await Task.Delay(TimeSpan.FromMilliseconds(400));
-        await channel.Writer.WriteAsync(new P.WorkItem { HealthPing = new P.HealthPing() });
+                await Task.Delay(perItemGap);
+            }
+
+            await channel.Writer.WriteAsync(new P.WorkItem { HealthPing = new P.HealthPing() });
+        }
+
+        // Wait for the final item to be processed before completing the channel, so the last per-item
+        // reset has actually happened prior to the graceful drain.
+        bool finalItemSignaled = await itemProcessed.WaitAsync(TimeSpan.FromSeconds(5));
+        finalItemSignaled.Should().BeTrue("the final item should have been processed before the stream completes");
+
         channel.Writer.Complete();
 
         WorkItemStreamResult result = await consumeTask;


### PR DESCRIPTION
## Summary

`ShimDurableTaskClient.WaitForInstanceStartAsync` previously polled `GetOrchestrationStateAsync` on a fixed 1-second `Task.Delay` cadence. Under load with many concurrent waiters, this causes synchronized polling bursts against the backend instead of a smooth request rate (#776).

## Changes

- The first status check remains immediate (no delay), preserving prompt observation of quick-starting orchestrations.
- Subsequent delays are computed by a new `internal static ComputeNextPollingDelay(bool isInitialDelay)` helper:
  - **Only the very first delay** of a given `WaitForInstanceStartAsync` call is a randomized *phase offset*, uniformly distributed in `[0s, 1s)`. This is a one-time cost per call, not repeated per iteration.
  - **Every subsequent delay** is the fixed historical `PollingInterval` (1 second), completely unjittered.
- This desynchronizes concurrent callers (avoiding synchronized polling bursts against the backend) via the one-time random phase, **without inflating steady-state polling volume** — after the first delay, the cadence exactly matches the historical fixed 1-second rate forever, so long-run polling frequency never exceeds the historical rate.
- The worst-case detection latency for any single status transition still never exceeds the historical 1 second.
- Not-found behavior is unchanged: if the instance never existed, `InvalidOperationException` is thrown immediately with no polling delay.
- Cancellation behavior is unchanged: the `CancellationToken` is still honored on every status check and on `Task.Delay`.

## Revision history on this PR

1. **Original version:** exponential backoff (1s → 5s cap, 1.5x multiplier) + ±20% jitter. Reduced steady-state load for long-pending instances, but review found it could delay detection of a newly-started orchestration by up to ~6s in the worst case — a regression against the historical 1s guarantee.
2. **First revision:** removed growth; jitter applied only *downward* from a fixed 1s base (range `[0.8s, 1.0s]`), guaranteeing the 1s ceiling. Review found this *increases* steady-state polling volume by ~11% (mean 0.9s vs. historical 1.0s), undermining the load-reduction goal, and flagged the Stopwatch-based test as CI-flaky (`Task.Delay` has no guaranteed upper bound).
3. **Third revision:** one-time randomized *initial phase offset* (`[0s, 1s)`), then fixed unjittered 1s intervals thereafter. Preserves the 1s worst-case detection latency ceiling, desynchronizes concurrent callers, and keeps steady-state polling volume exactly at the historical rate (no increase, no decrease). This design is unchanged as of the current revision.
4. **Fourth revision:** no production behavior change. Review found `WaitForInstanceStart_CancelledDuringPollingDelay_ThrowsTaskCanceledException` used wall-clock `cts.CancelAfter(50ms)`, which races against when the loop actually enters `Task.Delay` — so the test could still "pass" via an unrelated code path (e.g. a later poll observing an already-cancelled token) without proving the delay itself honors cancellation. Fixed by adding an `internal virtual DelayAsync(TimeSpan, CancellationToken)` seam (defaults to `Task.Delay`) that a test-only subclass used to signal, via a `TaskCompletionSource`, the exact moment the real delay call had been made.
5. **Current version (this revision):** no production behavior change; test-only fix. Review found the fourth revision's test double still let the real `Task.Delay(delay, cancellation)` run, so a regression passing the *wrong* (or no) token into `DelayAsync` could still "pass": `GetInstancesAsync`'s own `cancellation.ThrowIfCancellationRequested()` check would throw on the next poll attempt before the mock is invoked again, satisfying the `Times.Once` assertion even though the delay itself never honored cancellation. Fixed by replacing the fake delay with one that never completes on its own (no real timer) and completes — via cancellation — only when the *exact* `CancellationToken` instance passed by the caller is cancelled, directly proving cancellation of the caller's token (not some other code path) ends the wait. Verified by temporarily reintroducing the regression (`CancellationToken.None` at the call site) and confirming the test now fails deterministically instead of passing vacuously; reverted after confirming.

## Testing

Focused tests in `ShimDurableTaskClientTests.cs`:
- `WaitForInstanceStart_MultiplePendingPolls_EventuallyReturnsTerminalMetadata` — multiple polling iterations still converge on the terminal state.
- `ComputeNextPollingDelay_InitialDelay_NeverExceedsHistoricalOneSecondCadence` — deterministic: 1000 samples of the initial-phase delay, asserting each is in `[0s, 1s)`.
- `ComputeNextPollingDelay_SteadyState_ReturnsFixedHistoricalIntervalWithNoJitter` — deterministic: every subsequent delay equals exactly 1 second (no jitter, no growth), proving steady-state volume can't regress in either direction. This directly tests the delay policy rather than relying on wall-clock timing, avoiding the CI flakiness of the earlier Stopwatch-based approach.
- `WaitForInstanceStart_InstanceNotFound_ThrowsImmediatelyWithoutPolling` — not-found short-circuits without any polling delay.
- `WaitForInstanceStart_CancelledDuringPollingDelay_ThrowsTaskCanceledException` — fully deterministic (no wall-clock coordination, no real timer): a test-only `DelayObservingShimDurableTaskClient` subclass overrides the internal `DelayAsync` seam with a fake delay that signals as soon as it is entered, then never completes on its own — it completes, via cancellation, only when the *exact* `CancellationToken` instance passed by the caller is cancelled. The test cancels only after that signal, and asserts `GetOrchestrationStateAsync` was called `Times.Once`. This proves cancelling the caller's token — not some unrelated code path such as a later poll's own cancellation check — is what ends the wait. Verified by temporarily reintroducing a "wrong token" regression at the call site and confirming the test then fails deterministically instead of passing vacuously.

The pre-existing `WaitForInstanceStart` test (asserting exactly 2 `GetOrchestrationStateAsync` calls) continues to pass unchanged.

Ran the full `Client.OrchestrationServiceClientShim.Tests` suite: all 76 tests pass, 0 failures (~2s runtime). Re-ran the cancellation test 5x in isolation to confirm it is not flaky (all passed, ~160ms each).

## Breaking Change

No breaking change — `WaitForInstanceStartAsync`'s public signature and behavior are unchanged. `ComputeNextPollingDelay` and the internal `DelayAsync` test seam are `internal` (not public) purely to allow direct, deterministic unit testing; they and the polling constants remain implementation details of the internal `ShimDurableTaskClient` class. No public configuration was added.
## Unrelated CI stabilization

CI on this PR was blocked by a reproducible timeout in `WorkItemStreamConsumerTests.PerItem_HeartbeatReset_KeepsTimerAlive` (`test/Worker/Grpc.Tests`), unrelated to the shim polling change above (same flake reproduces on `main`). Root cause: the test slept a fixed 150ms before writing the first channel item, racing against the consumer's 500ms silent-disconnect timer, which is armed as soon as `ConsumeAsync` starts. Under CI scheduling pressure that sleep could exceed the timer window, causing the test to hang.

Fix (test-only, no production behavior change): the first item is now written immediately with no a-priori sleep, removing the race. To preserve a strong regression signal for a missing per-item timer reset, the test now sends several items in sequence with each gap measured from the previous item's actual processing (via a semaphore signal, not a wall-clock guess): each individual gap (150ms) stays comfortably below the 500ms timeout, but the gaps' sum (600ms) comfortably exceeds it, so an implementation that only arms the timer once at loop start (never re-arming per item) fails this test well before the last item is sent.

Verified by temporarily removing the per-item `ArmSilentDisconnectTimer()` call in production and confirming the test failed deterministically; reverted (zero production diff). Ran the test 10x standalone (stable) and the full `Worker.Grpc.Tests` suite (137/137 pass).



### Follow-up: made the CI-stabilization test fully deterministic (commit 8779f98)

A further review found the previous stabilization (commit c8b66aa) still had residual, if much smaller, wall-clock risk: it measured real 150ms per-item gaps against the real 500ms silent-disconnect timeout, so a scheduler-delayed continuation between "item processed" and "next write" could in theory still inflate a gap past the timeout under CI pressure.

Fix: added a test-only observability seam to `WorkItemStreamConsumer.ConsumeAsync` -- an optional `onSilentDisconnectTimerArmed` callback (default `null`, zero production behavior change, purely additive trailing parameter) invoked every time the silent-disconnect timer is armed/re-armed. `PerItem_HeartbeatReset_KeepsTimerAlive` now records the exact interleaving of "armed" and "item" events and asserts the structural invariant directly (one arm before the loop, one re-arm immediately before each item), with **no wall-clock timing at all**. The test now runs in ~20ms.

Verified red/green: temporarily disabled the per-item re-arm in production, confirmed the test failed deterministically (armed count 1 instead of 6), reverted (diff confirms only the seam addition remains). Ran the test 15x standalone (all pass), full `Worker.Grpc.Tests` (137/137), and full `Client.OrchestrationServiceClientShim.Tests` (76/76, confirms the shim polling work is unaffected).

Fixes #776
