### PR TITLE
Optimize orchestration history scans for tracing performance

### DIFF
--- a/src/Shared/Grpc/Tracing/TraceHelper.cs
+++ b/src/Shared/Grpc/Tracing/TraceHelper.cs
@@ -21,6 +21,12 @@ static class TraceHelper
     static readonly ActivitySource ActivityTraceSource = new ActivitySource(Source);
 
     /// <summary>
+    /// Gets whether any listener is subscribed to Durable Task tracing activities.
+    /// </summary>
+    /// <returns><see langword="true"/> when tracing work can produce activities; otherwise, <see langword="false"/>.</returns>
+    public static bool HasListeners() => ActivityTraceSource.HasListeners();
+
+    /// <summary>
     /// Starts a new trace activity for scheduling an orchestration from the client.
     /// </summary>
     /// <param name="createInstanceRequest">The orchestration's creation request.</param>

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
@@ -602,105 +602,89 @@ sealed partial class GrpcDurableTaskWorker
             string completionToken,
             CancellationToken cancellationToken)
         {
-            var executionStartedEvent =
-                request
-                    .NewEvents
-                    .Concat(request.PastEvents)
-                    .Where(e => e.EventTypeCase == P.HistoryEvent.EventTypeOneofCase.ExecutionStarted)
-                    .Select(e => e.ExecutionStarted)
-                    .FirstOrDefault();
-
-            Activity? traceActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(
-                executionStartedEvent,
-                request.OrchestrationTraceContext);
-
-            if (executionStartedEvent is not null)
+            Activity? traceActivity = null;
+            if (TraceHelper.HasListeners())
             {
-                P.HistoryEvent? GetSuborchestrationInstanceCreatedEvent(int eventId)
+                var executionStartedEvent =
+                    request
+                        .NewEvents
+                        .Concat(request.PastEvents)
+                        .Where(e => e.EventTypeCase == P.HistoryEvent.EventTypeOneofCase.ExecutionStarted)
+                        .Select(e => e.ExecutionStarted)
+                        .FirstOrDefault();
+
+                traceActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(
+                    executionStartedEvent,
+                    request.OrchestrationTraceContext);
+
+                if (executionStartedEvent is not null)
                 {
-                    var subOrchestrationEvent =
-                        request
-                            .PastEvents
-                            .Where(x => x.EventTypeCase == P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceCreated)
-                            .FirstOrDefault(x => x.EventId == eventId);
+                    TracingHistoryEventIndex historyEventIndex = new(request.PastEvents);
 
-                    return subOrchestrationEvent;
-                }
-
-                P.HistoryEvent? GetTaskScheduledEvent(int eventId)
-                {
-                    var taskScheduledEvent =
-                        request
-                            .PastEvents
-                            .Where(x => x.EventTypeCase == P.HistoryEvent.EventTypeOneofCase.TaskScheduled)
-                            .LastOrDefault(x => x.EventId == eventId);
-
-                    return taskScheduledEvent;
-                }
-
-                foreach (var newEvent in request.NewEvents)
-                {
-                    switch (newEvent.EventTypeCase)
+                    foreach (var newEvent in request.NewEvents)
                     {
-                        case P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceCompleted:
-                            {
-                                P.HistoryEvent? subOrchestrationInstanceCreatedEvent =
-                                    GetSuborchestrationInstanceCreatedEvent(
-                                        newEvent.SubOrchestrationInstanceCompleted.TaskScheduledId);
+                        switch (newEvent.EventTypeCase)
+                        {
+                            case P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceCompleted:
+                                {
+                                    P.HistoryEvent? subOrchestrationInstanceCreatedEvent =
+                                        historyEventIndex.GetSubOrchestrationInstanceCreatedEvent(
+                                            newEvent.SubOrchestrationInstanceCompleted.TaskScheduledId);
 
-                                TraceHelper.EmitTraceActivityForSubOrchestrationCompleted(
+                                    TraceHelper.EmitTraceActivityForSubOrchestrationCompleted(
+                                        request.InstanceId,
+                                        subOrchestrationInstanceCreatedEvent,
+                                        subOrchestrationInstanceCreatedEvent?.SubOrchestrationInstanceCreated);
+                                    break;
+                                }
+
+                            case P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceFailed:
+                                {
+                                    P.HistoryEvent? subOrchestrationInstanceCreatedEvent =
+                                        historyEventIndex.GetSubOrchestrationInstanceCreatedEvent(
+                                            newEvent.SubOrchestrationInstanceFailed.TaskScheduledId);
+
+                                    TraceHelper.EmitTraceActivityForSubOrchestrationFailed(
+                                        request.InstanceId,
+                                        subOrchestrationInstanceCreatedEvent,
+                                        subOrchestrationInstanceCreatedEvent?.SubOrchestrationInstanceCreated,
+                                        newEvent.SubOrchestrationInstanceFailed);
+                                    break;
+                                }
+
+                            case P.HistoryEvent.EventTypeOneofCase.TaskCompleted:
+                                {
+                                    P.HistoryEvent? taskScheduledEvent =
+                                        historyEventIndex.GetTaskScheduledEvent(newEvent.TaskCompleted.TaskScheduledId);
+
+                                    TraceHelper.EmitTraceActivityForTaskCompleted(
+                                        request.InstanceId,
+                                        taskScheduledEvent,
+                                        taskScheduledEvent?.TaskScheduled);
+                                    break;
+                                }
+
+                            case P.HistoryEvent.EventTypeOneofCase.TaskFailed:
+                                {
+                                    P.HistoryEvent? taskScheduledEvent =
+                                        historyEventIndex.GetTaskScheduledEvent(newEvent.TaskFailed.TaskScheduledId);
+
+                                    TraceHelper.EmitTraceActivityForTaskFailed(
+                                        request.InstanceId,
+                                        taskScheduledEvent,
+                                        taskScheduledEvent?.TaskScheduled,
+                                        newEvent.TaskFailed);
+                                    break;
+                                }
+
+                            case P.HistoryEvent.EventTypeOneofCase.TimerFired:
+                                TraceHelper.EmitTraceActivityForTimer(
                                     request.InstanceId,
-                                    subOrchestrationInstanceCreatedEvent,
-                                    subOrchestrationInstanceCreatedEvent?.SubOrchestrationInstanceCreated);
+                                    executionStartedEvent.Name,
+                                    newEvent.Timestamp.ToDateTime(),
+                                    newEvent.TimerFired);
                                 break;
-                            }
-
-                        case P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceFailed:
-                            {
-                                P.HistoryEvent? subOrchestrationInstanceCreatedEvent =
-                                    GetSuborchestrationInstanceCreatedEvent(
-                                        newEvent.SubOrchestrationInstanceFailed.TaskScheduledId);
-
-                                TraceHelper.EmitTraceActivityForSubOrchestrationFailed(
-                                    request.InstanceId,
-                                    subOrchestrationInstanceCreatedEvent,
-                                    subOrchestrationInstanceCreatedEvent?.SubOrchestrationInstanceCreated,
-                                    newEvent.SubOrchestrationInstanceFailed);
-                                break;
-                            }
-
-                        case P.HistoryEvent.EventTypeOneofCase.TaskCompleted:
-                            {
-                                P.HistoryEvent? taskScheduledEvent =
-                                    GetTaskScheduledEvent(newEvent.TaskCompleted.TaskScheduledId);
-
-                                TraceHelper.EmitTraceActivityForTaskCompleted(
-                                    request.InstanceId,
-                                    taskScheduledEvent,
-                                    taskScheduledEvent?.TaskScheduled);
-                                break;
-                            }
-
-                        case P.HistoryEvent.EventTypeOneofCase.TaskFailed:
-                            {
-                                P.HistoryEvent? taskScheduledEvent =
-                                    GetTaskScheduledEvent(newEvent.TaskFailed.TaskScheduledId);
-
-                                TraceHelper.EmitTraceActivityForTaskFailed(
-                                    request.InstanceId,
-                                    taskScheduledEvent,
-                                    taskScheduledEvent?.TaskScheduled,
-                                    newEvent.TaskFailed);
-                                break;
-                            }
-
-                        case P.HistoryEvent.EventTypeOneofCase.TimerFired:
-                            TraceHelper.EmitTraceActivityForTimer(
-                                request.InstanceId,
-                                executionStartedEvent.Name,
-                                newEvent.Timestamp.ToDateTime(),
-                                newEvent.TimerFired);
-                            break;
+                        }
                     }
                 }
             }

--- a/src/Worker/Grpc/TracingHistoryEventIndex.cs
+++ b/src/Worker/Grpc/TracingHistoryEventIndex.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using P = Microsoft.DurableTask.Protobuf;
+
+namespace Microsoft.DurableTask.Worker.Grpc;
+
+/// <summary>
+/// Indexes the orchestration history events used to reconstruct tracing spans.
+/// </summary>
+sealed class TracingHistoryEventIndex
+{
+    readonly Dictionary<int, P.HistoryEvent> subOrchestrationCreatedEvents = new();
+    readonly Dictionary<int, P.HistoryEvent> taskScheduledEvents = new();
+
+    public TracingHistoryEventIndex(IEnumerable<P.HistoryEvent> pastEvents)
+    {
+        foreach (P.HistoryEvent historyEvent in pastEvents)
+        {
+            switch (historyEvent.EventTypeCase)
+            {
+                case P.HistoryEvent.EventTypeOneofCase.SubOrchestrationInstanceCreated:
+                    // Preserve the previous FirstOrDefault semantics for duplicate IDs.
+                    if (!this.subOrchestrationCreatedEvents.ContainsKey(historyEvent.EventId))
+                    {
+                        this.subOrchestrationCreatedEvents.Add(historyEvent.EventId, historyEvent);
+                    }
+
+                    break;
+
+                case P.HistoryEvent.EventTypeOneofCase.TaskScheduled:
+                    // Preserve the previous LastOrDefault semantics for duplicate IDs.
+                    this.taskScheduledEvents[historyEvent.EventId] = historyEvent;
+                    break;
+            }
+        }
+    }
+
+    public P.HistoryEvent? GetSubOrchestrationInstanceCreatedEvent(int eventId)
+        => this.subOrchestrationCreatedEvents.TryGetValue(eventId, out P.HistoryEvent? historyEvent)
+            ? historyEvent
+            : null;
+
+    public P.HistoryEvent? GetTaskScheduledEvent(int eventId)
+        => this.taskScheduledEvents.TryGetValue(eventId, out P.HistoryEvent? historyEvent)
+            ? historyEvent
+            : null;
+}

--- a/test/Worker/Grpc.Tests/TraceHelperTests.cs
+++ b/test/Worker/Grpc.Tests/TraceHelperTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Microsoft.DurableTask.Tracing;
+
+namespace Microsoft.DurableTask.Worker.Grpc.Tests;
+
+public class TraceHelperTests
+{
+    [Fact]
+    public void HasListeners_TracksMatchingActivityListener()
+    {
+        bool initialHasListeners = TraceHelper.HasListeners();
+        ActivityListener listener = new()
+        {
+            ShouldListenTo = source => source.Name == "Microsoft.DurableTask",
+        };
+
+        try
+        {
+            ActivitySource.AddActivityListener(listener);
+
+            TraceHelper.HasListeners().Should().BeTrue();
+        }
+        finally
+        {
+            listener.Dispose();
+        }
+
+        TraceHelper.HasListeners().Should().Be(initialHasListeners);
+    }
+}

--- a/test/Worker/Grpc.Tests/TracingHistoryEventIndexTests.cs
+++ b/test/Worker/Grpc.Tests/TracingHistoryEventIndexTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using P = Microsoft.DurableTask.Protobuf;
+
+namespace Microsoft.DurableTask.Worker.Grpc.Tests;
+
+public class TracingHistoryEventIndexTests
+{
+    [Fact]
+    public void GetSubOrchestrationInstanceCreatedEvent_DuplicateIds_ReturnsFirstEvent()
+    {
+        P.HistoryEvent first = new()
+        {
+            EventId = 7,
+            SubOrchestrationInstanceCreated = new P.SubOrchestrationInstanceCreatedEvent { Name = "first" },
+        };
+        P.HistoryEvent second = new()
+        {
+            EventId = 7,
+            SubOrchestrationInstanceCreated = new P.SubOrchestrationInstanceCreatedEvent { Name = "second" },
+        };
+
+        TracingHistoryEventIndex index = new([first, second]);
+
+        index.GetSubOrchestrationInstanceCreatedEvent(7).Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void GetTaskScheduledEvent_DuplicateIds_ReturnsLastEvent()
+    {
+        P.HistoryEvent first = new()
+        {
+            EventId = 11,
+            TaskScheduled = new P.TaskScheduledEvent { Name = "first" },
+        };
+        P.HistoryEvent second = new()
+        {
+            EventId = 11,
+            TaskScheduled = new P.TaskScheduledEvent { Name = "second" },
+        };
+
+        TracingHistoryEventIndex index = new([first, second]);
+
+        index.GetTaskScheduledEvent(11).Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void Lookups_MissingIds_ReturnNull()
+    {
+        P.HistoryEvent unrelated = new()
+        {
+            EventId = 3,
+            TimerCreated = new P.TimerCreatedEvent(),
+        };
+
+        TracingHistoryEventIndex index = new([unrelated]);
+
+        index.GetSubOrchestrationInstanceCreatedEvent(3).Should().BeNull();
+        index.GetTaskScheduledEvent(3).Should().BeNull();
+    }
+}


### PR DESCRIPTION
Summary

What changed?

* Avoid repeated orchestration history scans performed only for tracing.
* Skip orchestration tracing lookup/indexing work entirely when the Durable Task ActivitySource has no listeners.
* Build a one-pass index over relevant PastEvents when tracing is enabled, allowing completion events to use O(1) lookups.
* Preserve the existing lookup semantics:
    * SubOrchestrationInstanceCreated: first matching event wins.
    * TaskScheduled: last matching event wins.
* Add unit tests covering duplicate event IDs, missing IDs, and ActivitySource listener detection.

Why is this change needed?

* The tracing path previously rescanned PastEvents for each completed/failed task or sub-orchestration event.
* For orchestration histories with many events, this can result in repeated O(N) scans and significant unnecessary CPU overhead.
* The lookup work was also performed even when no tracing listener was registered.
* This change reduces tracing-history processing to a single pass when tracing is active and avoids the work entirely when tracing is inactive, without intentionally changing tracing behavior.

Issues / work items

* Resolves #769

⸻

Project checklist

* [x]	Release notes are not required for the next release
    * [ ]	Otherwise: Notes added to release_notes.md
* [x]	Backport is not required
    * [ ]	Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x]	All required tests have been added/updated (unit tests, E2E tests)
* [x]	Breaking change? No
    * [ ]	If yes:
        * Impact:
        * Migration guidance:

⸻

AI-assisted code disclosure (required)

Was an AI tool used? (select one)

* [ ]	No
* [ ]	Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
* [x]	Yes, an AI agent generated most of this PR

If AI was used:

* Tool(s): ChatGPT
* AI-assisted areas/files:
    * src/Shared/Grpc/Tracing/TraceHelper.cs
    * src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs
    * src/Worker/Grpc/TracingHistoryEventIndex.cs
    * test/Worker/Grpc.Tests/TraceHelperTests.cs
    * test/Worker/Grpc.Tests/TracingHistoryEventIndexTests.cs
* What you changed after AI output: I reviewed the generated implementation and tests against the existing tracing code and issue requirements. I verified that the optimization preserves the existing first/last lookup behavior, that the listener gate does not intentionally change tracing semantics, and that the final diff contains only the intended implementation and test changes.

AI verification (required if AI was used):

* [x]	I understand the code and can explain it
* [x]	I verified referenced APIs/types exist and are correct
* [x]	I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
* [x]	I reviewed concurrency/async behavior
* [x]	I checked for unintended breaking or behavior changes

⸻

Testing

Automated tests

* Result: Passed
* dotnet test test/Worker/Grpc.Tests/Worker.Grpc.Tests.csproj --configuration Release
* Added coverage verifies:
    * first-match semantics for duplicate SubOrchestrationInstanceCreated IDs;
    * last-match semantics for duplicate TaskScheduled IDs;
    * missing event IDs return no match;
    * TraceHelper.HasListeners() detects a matching Durable Task ActivityListener and returns to its previous state after the listener is disposed.

Manual validation (only if runtime/behavior changed)

* Environment: N/A
* Steps + observed results:
    1. No separate manual runtime validation was performed because this is an internal tracing performance optimization with no intended externally observable behavior change.
    2. Existing behavior was compared directly against the previous implementation, and the significant lookup semantics were preserved explicitly and covered by automated tests.
* Evidence (optional): Automated test coverage above.

⸻

Notes for reviewers

* The history index intentionally has different duplicate-ID semantics for its two event types. This preserves the previous implementation exactly: sub-orchestration lookup used FirstOrDefault, while task-scheduled lookup used LastOrDefault.
* The index is only created when the Durable Task tracing ActivitySource has listeners, so the normal no-listener path avoids both the previous scans and the new index allocation.