### PR TITLE
Prevent external-event loss after canceled waits in isolated worker

### DIFF
--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
@@ -30,7 +30,11 @@ sealed partial class TaskOrchestrationContextWrapper
         /// Tries to set the result on tcs.
         /// </summary>
         /// <param name="result">The result.</param>
-        void TrySetResult(object result);
+        /// <returns>
+        /// <c>true</c> if the result was set successfully, meaning this waiter is a live consumer of the event;
+        /// <c>false</c> if the waiter was already completed, canceled, or abandoned and cannot accept the result.
+        /// </returns>
+        bool TrySetResult(object result);
     }
 
     class EventTaskCompletionSource<T> : TaskCompletionSource<T>, IEventSource
@@ -42,7 +46,7 @@ sealed partial class TaskOrchestrationContextWrapper
         public IEventSource? Next { get; set; }
 
         /// <inheritdoc/>
-        void IEventSource.TrySetResult(object result) => this.TrySetResult((T)result);
+        bool IEventSource.TrySetResult(object result) => this.TrySetResult((T)result);
     }
 
     class NamedQueue<TValue>

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.EventSource.cs
@@ -34,10 +34,10 @@ sealed partial class TaskOrchestrationContextWrapper
         /// <c>true</c> if the result was set successfully, meaning this waiter is a live consumer of the event;
         /// <c>false</c> if the waiter was already completed, canceled, or abandoned and cannot accept the result.
         /// </returns>
-        bool TrySetResult(object result);
+        bool TrySetResult(object? result);
     }
 
-    class EventTaskCompletionSource<T> : TaskCompletionSource<T>, IEventSource
+    sealed class EventTaskCompletionSource<T> : TaskCompletionSource<T>, IEventSource
     {
         /// <inheritdoc/>
         public Type EventType => typeof(T);
@@ -46,7 +46,7 @@ sealed partial class TaskOrchestrationContextWrapper
         public IEventSource? Next { get; set; }
 
         /// <inheritdoc/>
-        bool IEventSource.TrySetResult(object result) => this.TrySetResult((T)result);
+        bool IEventSource.TrySetResult(object? result) => this.TrySetResult((T)result!);
     }
 
     class NamedQueue<TValue>

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -522,19 +522,9 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         }
         else
         {
-            if (this.preserveUnprocessedEventsOnContinueAsNew)
-            {
-                // ContinueAsNew has already been scheduled with event preservation enabled.
-                // Forward late-arriving events directly to the next execution instead of buffering
-                // them on the current wrapper instance, which is about to be discarded.
-                this.ForwardRawExternalEvent(eventName, rawEventPayload);
-            }
-            else
-            {
-                // The orchestrator isn't waiting for this event (yet?). Save it in case
-                // the orchestrator wants it later.
-                this.externalEventBuffer.Add(eventName, rawEventPayload);
-            }
+            // The orchestrator isn't waiting for this event (yet?). Save it in case
+            // the orchestrator wants it later.
+            this.externalEventBuffer.Add(eventName, rawEventPayload);
         }
     }
 

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -473,7 +473,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// <param name="rawEventPayload">The serialized event payload.</param>
     internal void CompleteExternalEvent(string eventName, string rawEventPayload)
     {
-        if (this.externalEventSources.TryGetValue(eventName, out IEventSource? waiter))
+        while (this.externalEventSources.TryGetValue(eventName, out IEventSource? waiter))
         {
             // Get the waiter at the top of the stack (most recent waiter)
             // If we're going to raise an event we should remove it from the pending collection
@@ -501,7 +501,24 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
                 value = this.DataConverter.Deserialize(rawEventPayload, waiter.EventType);
             }
 
-            waiter.TrySetResult(value);
+            if (waiter.TrySetResult(value))
+            {
+                // The event was delivered to a live waiter. We're done.
+                return;
+            }
+
+            // This waiter was already completed, canceled, or abandoned (e.g. the losing side of a
+            // Task.WhenAny) and cannot accept the event. It has already been popped off the stack above,
+            // so continue the loop to try the next waiter underneath it, if any. If there are no more
+            // waiters, fall through to the buffering/forwarding logic below as if no one was listening.
+        }
+
+        if (this.preserveUnprocessedEventsOnContinueAsNew)
+        {
+            // ContinueAsNew has already been scheduled with event preservation enabled.
+            // Forward late-arriving events directly to the next execution instead of buffering
+            // them on the current wrapper instance, which is about to be discarded.
+            this.ForwardRawExternalEvent(eventName, rawEventPayload);
         }
         else
         {

--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -473,6 +473,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
     /// <param name="rawEventPayload">The serialized event payload.</param>
     internal void CompleteExternalEvent(string eventName, string rawEventPayload)
     {
+        Dictionary<Type, object?>? deserializedValues = null;
         while (this.externalEventSources.TryGetValue(eventName, out IEventSource? waiter))
         {
             // Get the waiter at the top of the stack (most recent waiter)
@@ -489,16 +490,21 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
                 this.externalEventSources[eventName] = next;
             }
 
-            object? value;
-            if (waiter.EventType == typeof(OperationResult))
+            deserializedValues ??= new Dictionary<Type, object?>();
+            if (!deserializedValues.TryGetValue(waiter.EventType, out object? value))
             {
-                // use the framework-defined deserialization for entity responses, not the application-defined data converter,
-                // because we are just unwrapping the entity response without yet deserializing any application-defined data.
-                value = this.entityFeature!.EntityContext.DeserializeEntityResponseEvent(rawEventPayload);
-            }
-            else
-            {
-                value = this.DataConverter.Deserialize(rawEventPayload, waiter.EventType);
+                if (waiter.EventType == typeof(OperationResult))
+                {
+                    // use the framework-defined deserialization for entity responses, not the application-defined data converter,
+                    // because we are just unwrapping the entity response without yet deserializing any application-defined data.
+                    value = this.entityFeature!.EntityContext.DeserializeEntityResponseEvent(rawEventPayload);
+                }
+                else
+                {
+                    value = this.DataConverter.Deserialize(rawEventPayload, waiter.EventType);
+                }
+
+                deserializedValues[waiter.EventType] = value;
             }
 
             if (waiter.TrySetResult(value))

--- a/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
+++ b/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
@@ -391,6 +391,117 @@ public class TaskOrchestrationContextWrapperTests
         innerContext.LastSubOrchestrationVersion.Should().Be(string.Empty);
     }
 
+    [Fact]
+    public void CompleteExternalEvent_CanceledWaiter_BuffersEventForNextWaiter()
+    {
+        // Arrange: reproduces the sequence from Azure/azure-functions-durable-extension#1676.
+        // Two differently-named external event waits are registered with a shared cancellation
+        // token, similar to a Task.WhenAny loop. The waiter for "event_1" is canceled (e.g.
+        // because "event_0" won the race), but "event_1" is later raised while the canceled
+        // waiter is still the only registered listener for that name.
+        TrackingOrchestrationContext innerContext = new();
+        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
+
+        using CancellationTokenSource cts = new();
+        Task<string> canceledWait = wrapper.WaitForExternalEvent<string>("event_1", cts.Token);
+        cts.Cancel();
+
+        // Act: the event arrives after the only waiter for it has been canceled/abandoned.
+        InvokeCompleteExternalEvent(wrapper, "event_1", "\"payload\"");
+
+        // Assert: the canceled waiter must not "consume" the event. It should be buffered so
+        // that a subsequent WaitForExternalEvent call (e.g. in the next ContinueAsNew generation)
+        // can still observe it.
+        canceledWait.IsCanceled.Should().BeTrue();
+        Task<string> nextWait = wrapper.WaitForExternalEvent<string>("event_1");
+        nextWait.IsCompletedSuccessfully.Should().BeTrue();
+        nextWait.Result.Should().Be("payload");
+    }
+
+    [Fact]
+    public void CompleteExternalEvent_CanceledWaiter_WithContinueAsNewPreserved_ForwardsEventToNextExecution()
+    {
+        // Arrange: same as above, but the event arrives after ContinueAsNew(preserveUnprocessedEvents: true)
+        // has already been called (e.g. while an activity scheduled before ContinueAsNew is still
+        // completing). The event should be forwarded to the next execution, not silently dropped.
+        TrackingOrchestrationContext innerContext = new();
+        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
+
+        using CancellationTokenSource cts = new();
+        Task<string> canceledWait = wrapper.WaitForExternalEvent<string>("event_1", cts.Token);
+        cts.Cancel();
+
+        wrapper.ContinueAsNew("new-input", preserveUnprocessedEvents: true);
+
+        // Act
+        InvokeCompleteExternalEvent(wrapper, "event_1", "\"payload\"");
+
+        // Assert
+        canceledWait.IsCanceled.Should().BeTrue();
+        innerContext.SentEvents.Should().ContainSingle();
+        innerContext.SentEvents[0].InstanceId.Should().Be(wrapper.InstanceId);
+        innerContext.SentEvents[0].EventName.Should().Be("event_1");
+        innerContext.SentEvents[0].EventData.Should().BeOfType<RawInput>().Which.Value.Should().Be("\"payload\"");
+    }
+
+    [Fact]
+    public void CompleteExternalEvent_MultipleCanceledWaiters_BuffersEventAfterSkippingAll()
+    {
+        // Arrange: several waiters for the same event name are canceled/abandoned in a row
+        // (e.g. a loop that repeatedly races and abandons the same event). None of them should
+        // be able to consume the event.
+        TrackingOrchestrationContext innerContext = new();
+        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
+
+        using CancellationTokenSource cts1 = new();
+        using CancellationTokenSource cts2 = new();
+        using CancellationTokenSource cts3 = new();
+        Task<string> wait1 = wrapper.WaitForExternalEvent<string>("event_1", cts1.Token);
+        Task<string> wait2 = wrapper.WaitForExternalEvent<string>("event_1", cts2.Token);
+        Task<string> wait3 = wrapper.WaitForExternalEvent<string>("event_1", cts3.Token);
+        cts1.Cancel();
+        cts2.Cancel();
+        cts3.Cancel();
+
+        // Act
+        InvokeCompleteExternalEvent(wrapper, "event_1", "\"payload\"");
+
+        // Assert
+        wait1.IsCanceled.Should().BeTrue();
+        wait2.IsCanceled.Should().BeTrue();
+        wait3.IsCanceled.Should().BeTrue();
+        Task<string> nextWait = wrapper.WaitForExternalEvent<string>("event_1");
+        nextWait.IsCompletedSuccessfully.Should().BeTrue();
+        nextWait.Result.Should().Be("payload");
+    }
+
+    [Fact]
+    public void CompleteExternalEvent_ActiveWaiterAboveCanceledWaiter_DeliversToActiveWaiter()
+    {
+        // Arrange: the most recent (top-of-stack) waiter is still live, but an older waiter
+        // underneath it for the same event name was already canceled. The event should go to
+        // the live waiter, and the canceled one underneath should remain untouched (not consumed).
+        TrackingOrchestrationContext innerContext = new();
+        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
+
+        using CancellationTokenSource cts1 = new();
+        Task<string> canceledWait = wrapper.WaitForExternalEvent<string>("event_1", cts1.Token);
+        cts1.Cancel();
+        Task<string> activeWait = wrapper.WaitForExternalEvent<string>("event_1");
+
+        // Act
+        InvokeCompleteExternalEvent(wrapper, "event_1", "\"payload\"");
+
+        // Assert
+        canceledWait.IsCanceled.Should().BeTrue();
+        activeWait.IsCompletedSuccessfully.Should().BeTrue();
+        activeWait.Result.Should().Be("payload");
+    }
+
     static IReadOnlyDictionary<string, string> GetLastScheduledTaskTags(TrackingOrchestrationContext innerContext)
     {
         PropertyInfo tagsProperty = innerContext.LastScheduledTaskOptions!.GetType().GetProperty("Tags")!;

--- a/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
+++ b/test/Worker/Core.Tests/Shims/TaskOrchestrationContextWrapperTests.cs
@@ -453,7 +453,12 @@ public class TaskOrchestrationContextWrapperTests
         // (e.g. a loop that repeatedly races and abandons the same event). None of them should
         // be able to consume the event.
         TrackingOrchestrationContext innerContext = new();
-        OrchestrationInvocationContext invocationContext = new("Test", new(), NullLoggerFactory.Instance, null);
+        CountingDataConverter converter = new();
+        OrchestrationInvocationContext invocationContext = new(
+            "Test",
+            new DurableTaskWorkerOptions { DataConverter = converter },
+            NullLoggerFactory.Instance,
+            null);
         TaskOrchestrationContextWrapper wrapper = new(innerContext, invocationContext, "input");
 
         using CancellationTokenSource cts1 = new();
@@ -470,6 +475,7 @@ public class TaskOrchestrationContextWrapperTests
         InvokeCompleteExternalEvent(wrapper, "event_1", "\"payload\"");
 
         // Assert
+        converter.DeserializeCallCounts[typeof(string)].Should().Be(1);
         wait1.IsCanceled.Should().BeTrue();
         wait2.IsCanceled.Should().BeTrue();
         wait3.IsCanceled.Should().BeTrue();
@@ -511,6 +517,19 @@ public class TaskOrchestrationContextWrapperTests
     static void InvokeCompleteExternalEvent(TaskOrchestrationContextWrapper wrapper, string eventName, string rawEventPayload)
     {
         CompleteExternalEventMethod.Invoke(wrapper, [eventName, rawEventPayload]);
+    }
+
+    sealed class CountingDataConverter : DataConverter
+    {
+        public Dictionary<Type, int> DeserializeCallCounts { get; } = [];
+
+        public override object? Deserialize(string? data, Type targetType)
+        {
+            this.DeserializeCallCounts[targetType] = this.DeserializeCallCounts.GetValueOrDefault(targetType) + 1;
+            return targetType == typeof(string) ? "payload" : null;
+        }
+
+        public override string? Serialize(object? value) => throw new NotSupportedException();
     }
 
     sealed class TrackingOrchestrationContext : OrchestrationContext


### PR DESCRIPTION
## Summary

This fixes external-event loss in the shared portable .NET worker core, [`Microsoft.DurableTask.Worker`](https://github.com/microsoft/durabletask-dotnet/tree/main/src/Worker/Core), for the exact sequence from [Azure/azure-functions-durable-extension#1676](https://github.com/Azure/azure-functions-durable-extension/issues/1676).

Affected consumers include Azure Durable Functions .NET isolated through the gRPC worker integration, standalone portable .NET workers using `Worker.Grpc`, and hosts built on the same Worker core such as `Worker.AzureManaged` / Durable Task Scheduler. Client-only and abstractions-only use is not affected because those packages do not dispatch orchestration events. The original #1676 report is against the legacy Azure Functions in-process implementation; that implementation is separate and untouched by this PR.

## Failure sequence

- Two differently named waits, `event_0` and `event_1`, share a cancellation token source and race via `Task.WhenAny`.
- `event_0` wins, so the `event_1` waiter is canceled/abandoned.
- An activity runs, and `event_1` is raised before `ContinueAsNew(..., preserveUnprocessedEvents: true)`.
- The next generation should receive `event_1`, but the old worker dropped it.

## Root cause and fix

The failed `TrySetResult` on a canceled/abandoned waiter was treated as if the event had been consumed. The fix walks the existing LIFO stack, skips waiters that reject the event, and delivers it to the first live waiter. If none accepts it, the existing buffer/`ContinueAsNew` forwarding path handles the event.

Deserialization is now lazy and type-aware, with a per-`EventType` cache for one dispatch call. This preserves the distinct `OperationResult` entity deserializer, null results, LIFO behavior, and late-event forwarding semantics.

## Validation

- Pre-fix: 3/4 regression cases failed.
- Current head targeted `TaskOrchestrationContextWrapperTests`: 22/22; full `Worker.Tests`: 137/137.
- Live Azure E2E ran on commit `24956082fed85f8a4a9cdd30cfe6caaccc93cb6c` using an Azure-hosted Linux .NET isolated Consumption app with real Azure Storage and an explicit Blob-gated exact sequence: 10/10 unique instances completed with `Passed:true`, generation 1, and matching first/second payloads. The temporary resource group was deleted and cleanup verified.
- Current head `14b175eadd6924b6fbd26f8f7cb2707ac8da60bb` adds review follow-ups (sealing the private nested type and deserialization caching). Those follow-ups were covered by the unit and full `Worker.Tests` runs; live Azure was not rerun after these non-semantic follow-ups.

## Related work

- [#508](https://github.com/microsoft/durabletask-dotnet/issues/508) / [#509](https://github.com/microsoft/durabletask-dotnet/pull/509) changed waiter ordering.
- [#711](https://github.com/microsoft/durabletask-dotnet/pull/711) forwards late events after `ContinueAsNew` is already scheduled.

Neither covers this exact all-waiters-dead, pre-`ContinueAsNew` gap.